### PR TITLE
Fix all compiler warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use log::error;
 use notify::EventHandler;
-use objc2_core_foundation::{CFData, CFDataGetBytePtr, CFStringCreateWithCharacters};
+use objc2_core_foundation::{CFData, CFString};
 use serde::{Deserialize, Deserializer, de};
 use std::{
     collections::HashMap,
@@ -452,7 +452,7 @@ fn generate_virtual_keymap() -> Vec<(String, u8)> {
                 )
             })
         })
-        .and_then(|uchr| NonNull::new(unsafe { CFDataGetBytePtr(uchr.as_ref()) as *mut u8 }));
+        .and_then(|uchr| NonNull::new(unsafe { CFData::byte_ptr(uchr.as_ref()) as *mut u8 }));
     let Some(keyboard_layout) = keyboard_layout else {
         error!(
             "{}: problem fetching current virtual keyboard layout.",
@@ -479,7 +479,7 @@ fn generate_virtual_keymap() -> Vec<(String, u8)> {
                 chars.as_mut_ptr(),
             ))
             .then(|| {
-                let name = CFStringCreateWithCharacters(None, chars.as_ptr(), got)
+                let name = CFString::with_characters(None, chars.as_ptr(), got)
                     .map(|chars| chars.to_string());
                 name.zip(Some(*keycode))
             })

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use log::{debug, error, info, trace, warn};
 use objc2::rc::Retained;
-use objc2_core_foundation::{CFNumberGetValue, CFNumberType, CFRetained, CGPoint, CGRect};
+use objc2_core_foundation::{CFNumber, CFNumberType, CFRetained, CGPoint, CGRect};
 use objc2_core_graphics::{CGDirectDisplayID, CGEventFlags};
 use std::io::{Error, ErrorKind, Result};
 use std::ops::Deref;
@@ -778,7 +778,7 @@ impl EventHandler {
                 for item in get_array_values(window_list.deref()) {
                     let mut child_wid: WinID = 0;
                     unsafe {
-                        if !CFNumberGetValue(
+                        if !CFNumber::value(
                             item.as_ref(),
                             CFNumberType::SInt32Type,
                             NonNull::from(&mut child_wid).as_ptr().cast(),

--- a/src/process.rs
+++ b/src/process.rs
@@ -119,7 +119,7 @@ impl Process {
             .unwrap_or_default();
 
         // [[NSRunningApplication runningApplicationWithProcessIdentifier:process->pid] retain];
-        let apps = unsafe { NSRunningApplication::runningApplicationWithProcessIdentifier(pid) };
+        let apps = NSRunningApplication::runningApplicationWithProcessIdentifier(pid);
 
         Box::pin(Process {
             app: None,
@@ -154,7 +154,7 @@ impl Process {
     /// `true` if the application is observable, `false` otherwise.
     pub fn is_observable(&mut self) -> bool {
         if let Some(app) = &self.application {
-            self.policy = unsafe { app.activationPolicy() };
+            self.policy = app.activationPolicy();
             self.policy == NSApplicationActivationPolicy::Regular
         } else {
             self.policy = NSApplicationActivationPolicy::Prohibited;
@@ -170,7 +170,7 @@ impl Process {
     pub fn finished_launching(&self) -> bool {
         self.application
             .as_ref()
-            .is_some_and(|app| unsafe { app.isFinishedLaunching() })
+            .is_some_and(|app| app.isFinishedLaunching())
     }
 
     /// Subscribes to "finishedLaunching" key-value observations for the associated `NSRunningApplication`.


### PR DESCRIPTION
The objc bindings deprecated official symbol names for Rust-ified equivalents. In the process, many formerly unsafe functions are now safe.