### PR TITLE
Fix cargo build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Paneru is currently in a basic, working state.
 Paneru is built using Rust's `cargo`.
 
 ```shell
-$ cargo build --target release
+$ cargo build --release
 $ cp target/release/paneru ~/bin/
 ```
 


### PR DESCRIPTION
The instructions suggest `cargo build --target release` which fails. I think you meant `cargo build --release`