### PR TITLE
Set the Rust toolchain version to stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+profile = "default"


### PR DESCRIPTION
Related to #8. This causes `rustup` managed binaries (`cargo`, …) to automatically use the latest stable version of Rust when ran in this repository.