### PR TITLE
chore: Allow config to disable swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ starting point:
 [options]
 # Enables focus follows mouse
 focus_follows_mouse = true
+swipe_enabled = true
 
 [bindings]
 # Moves the focus between windows.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -653,6 +653,9 @@ impl InputHandler {
     }
 
     fn handle_swipe(&mut self, event: &CGEvent) -> Result<bool> {
+        if !self.config.options().is_swipe_enabled() {
+            return Ok(false);
+        }
         const SWIPE_THRESHOLD: f64 = 0.01;
         let Some(ns_event) = NSEvent::eventWithCGEvent(event) else {
             return Err(Error::new(


### PR DESCRIPTION
Since the configuration will automatically fail if a key is missing, I'm forced to add the key as optional, otherwise this would break it for a lot of users. 

My suggestion is that the configuration should load defaults if keys are missing, hell the entire configuration should load a default if missing, but that should be a different PR. 

I use Swipes for historical navigation, like in Safari or Finder, so I need it disabled. 