### PR TITLE
fix: Make Nix build independent of local macOS SDK directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,15 @@
         pname = "paneru";
         version = "0.2.0";
         src = pkgs.lib.cleanSource ./.;
+        postPatch = ''
+          substituteInPlace build.rs --replace-fail \
+            'let sdk_dir = "/Library/Developer/CommandLineTools/SDKs";' \
+            'let sdk_dir = "${pkgs.apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs";'
+        '';
         cargoLock.lockFile = ./Cargo.lock;
+        buildInputs = [
+          pkgs.apple-sdk.privateFrameworksHook
+        ];
       };
     in
     {


### PR DESCRIPTION
Thank you for creating this project. I found paneru today and I'm happy to have a niri-like tiling experience on macOS. I've been using PaperWM.spoon and looking forward to paneru as an alternative.

## Problem

When building with Nix on systems without Command Line Tools installed, the build fails with the following error:

```
error: failed to run custom build command for `paneru v0.2.0 (/nix/var/nix/builds/nix-36366-727777097/source)`

Caused by:
  process didn't exit successfully: `/nix/var/nix/builds/nix-36366-727777097/source/target/release/build/paneru-ff220856ed954091/build-script-build` (exit status: 101)
  --- stderr

  thread 'main' panicked at build.rs:13:18:
  Failed to read SDK directory: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

## Root Cause

The issue stems from `build.rs:8` which hardcodes a system path:

```rust
let sdk_dir = "/Library/Developer/CommandLineTools/SDKs";
```

This creates an environment-dependent build that:
- Succeeds when Command Line Tools are installed locally
- Fails when Command Line Tools are not installed
- Violates Nix's reproducibility principles

The problem was hidden because macOS's loose sandbox allows Nix builds to access system paths like `/Library/Developer/CommandLineTools/SDKs`. This made the build appear to work on some machines while failing on others.

## Solution

This PR fixes the issue by modifying `flake.nix` with two key changes:

### 1. Path Substitution
```nix
postPatch = ''
  substituteInPlace build.rs --replace-fail \
    'let sdk_dir = "/Library/Developer/CommandLineTools/SDKs";' \
    'let sdk_dir = "${pkgs.apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs";'
'';
```

This replaces the hardcoded system path with Nix's hermetic SDK path before building.

### 2. Framework Hook
```nix
buildInputs = [
  pkgs.apple-sdk.privateFrameworksHook
];
```

This ensures proper framework search paths are set up, allowing the SDK discovery in `build.rs` (which finds macOS frameworks like SkyLight) to work consistently in Nix's build environment.