### PR TITLE
feat: add binding to toggle focused window to full display width

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Paneru provides a home manager module to install and configure paneru.
         window_swap_last = "alt + shift - l";
         window_center = "alt - c";
         window_resize = "alt - r";
+        window_fullwidth = "alt - f";
         window_manage = "ctrl + alt - t";
         window_stack = "alt - ]";
         window_unstack = "alt + shift - ]";
@@ -224,6 +225,9 @@ window_center = "alt - c"
 
 # Cycles between the window sizes defined in the `preset_column_widths` option.
 window_resize = "alt - r"
+
+# Toggle full width for the current focused window.
+window_fullwidth = "alt - f";
 
 # Toggles the window for management. If unmanaged, the window will be "floating".
 window_manage = "ctrl + alt - t"

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "swap" => Operation::Swap(parse_direction(argv.get(1).ok_or(err)?)?),
         "center" => Operation::Center,
         "resize" => Operation::Resize,
+        "fullwidth" => Operation::FullWidth,
         "manage" => Operation::Manage,
         "stack" => Operation::Stack(true),
         "unstack" => Operation::Stack(false),


### PR DESCRIPTION
Introduce a binding that toggles the focused window to full width. This provides a faster workflow on laptop screens, where full-width use is common, without interfering with ratio-based presets typically configured for large external displays.