### PR TITLE
Move home-manager config file to xdg.configHome

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,8 +112,13 @@
               };
             };
 
-            xdg.configFile."paneru/paneru.toml".source =
-              tomlFormat.generate "paneru.toml" config.services.paneru.settings;
+            xdg.configFile."paneru/paneru.toml" = lib.mkIf (config.xdg.enable) {
+              source = tomlFormat.generate "paneru.toml" config.services.paneru.settings;
+            };
+
+            home.file.".paneru.toml" = lib.mkIf (!config.xdg.enable) {
+              source = tomlFormat.generate ".paneru.toml" config.services.paneru.settings;
+            };
           };
         };
     };


### PR DESCRIPTION
Updated `flake.nix` with xdg.configHome and bumped version number.