### PR TITLE
fix: fix incorrect AX permissions check

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -39,7 +39,7 @@ use crate::errors::{Error, Result};
 use crate::events::{Event, EventSender};
 use crate::process::Process;
 use crate::skylight::OSStatus;
-use crate::util::{AXUIWrapper, Cleanuper, add_run_loop, remove_run_loop};
+use crate::util::{AXUIWrapper, Cleanuper, add_run_loop, check_ax_privilege, remove_run_loop};
 
 pub type Pid = i32;
 pub type CFStringRef = *const CFString;
@@ -1485,6 +1485,16 @@ impl PlatformCallbacks {
                 ErrorKind::Unsupported,
                 format!(
                     "{}: Can not startup Cocoa runloop from Carbon code.",
+                    function_name!()
+                ),
+            ));
+        }
+
+        if !check_ax_privilege() {
+            return Err(Error::new(
+                ErrorKind::PermissionDenied,
+                format!(
+                    "{}: Accessibility permissions are required. Please enable them in System Preferences -> Security & Privacy -> Privacy -> Accessibility.",
                     function_name!()
                 ),
             ));

--- a/src/util.rs
+++ b/src/util.rs
@@ -363,22 +363,14 @@ pub fn exe_path() -> Option<PathBuf> {
 /// # Returns
 ///
 /// `true` if Accessibility privileges are granted, `false` otherwise.
-#[allow(dead_code)]
 pub fn check_ax_privilege() -> bool {
     unsafe {
-        let mut keys = vec![kAXTrustedCheckOptionPrompt.cast::<c_void>()];
-        let mut values = vec![NonNull::from(kCFBooleanTrue.unwrap()).as_ptr() as *const c_void];
-
-        CFDictionary::new(
-            None,
-            keys.as_mut_ptr(),
-            values.as_mut_ptr(),
-            isize::try_from(keys.len()).unwrap(),
-            &raw const kCFCopyStringDictionaryKeyCallBacks,
-            &raw const kCFTypeDictionaryValueCallBacks,
-        )
-        .map(|options| NonNull::from_ref(&*options).as_ptr())
-        .map(|options| AXIsProcessTrustedWithOptions(options.cast()))
-        .is_some_and(|supported| supported)
+        let keys = [kAXTrustedCheckOptionPrompt
+            .cast::<CFString>()
+            .as_ref()
+            .unwrap()];
+        let values = [kCFBooleanTrue.unwrap()];
+        let opts = CFDictionary::from_slices(&keys, &values);
+        AXIsProcessTrustedWithOptions((&raw const *opts).cast())
     }
 }


### PR DESCRIPTION
My code uses another set of libraries so the function cannot be copy-pasted. However, I managed to fix your code for you without adding extra dependencies.

Unfortunately this doesn't solve my immediate problem, but a fix is a fix, and you are free to decide where to actually put the check, or not at all :)