### PR TITLE
nix: Bump package version from 0.3.0 to 0.3.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       pkgs = import nixpkgs { system = "aarch64-darwin"; };
       package = pkgs.rustPlatform.buildRustPackage {
         pname = "paneru";
-        version = "0.3.0";
+        version = "0.3.1";
         src = pkgs.lib.cleanSource ./.;
         postPatch = ''
           substituteInPlace build.rs --replace-fail \


### PR DESCRIPTION
In the future it should be done automatically, but right now I only have time for a quick fix.