### PR TITLE
chore(nix): make HM settings optional

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,8 @@
             };
 
             settings = lib.mkOption {
-              type = lib.types.attrs;
-              default = { };
+              type = lib.types.nullOr lib.types.attrs;
+              default = null;
               description = "Configuration to put in `~/.paneru.toml`.";
               example = {
                 options = {
@@ -112,12 +112,12 @@
               };
             };
 
-            xdg.configFile."paneru/paneru.toml" = lib.mkIf (config.xdg.enable) {
-              source = tomlFormat.generate "paneru.toml" config.services.paneru.settings;
+            xdg.configFile."paneru/paneru.toml" = lib.mkIf (config.xdg.enable && cfg.settings != null) {
+              source = tomlFormat.generate "paneru.toml" cfg.settings;
             };
 
-            home.file.".paneru.toml" = lib.mkIf (!config.xdg.enable) {
-              source = tomlFormat.generate ".paneru.toml" config.services.paneru.settings;
+            home.file.".paneru.toml" = lib.mkIf (!config.xdg.enable && cfg.settings != null) {
+              source = tomlFormat.generate ".paneru.toml" cfg.settings;
             };
           };
         };


### PR DESCRIPTION
Default settings to null and only write the config file when provided.

Why: currently the default for settings is `{}` and the only check on whether to write the config is whether the service is enabled. This doesn't let a user enable the service and *not* create a config via the module.