### PR TITLE
feat: Add dim overlay, active window border, and configurable menubar height

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,43 @@ animation_speed = 50
 # padding_left = 0
 # padding_right = 0
 
-# When disabled, swiping of windows is clamped so you cannot scroll
-# past the first or last window.
-# When enabled (default) the strip slides freely, exposing the desktop behind.
-# free_slide = true
+# Swiping keeps sliding windows until the first or last window.
+# Set to false to clamp so edge windows stay on-screen. Enabled by default.
+# continuous_swipe = true
+
+# Override the system-reported menubar height (in pixels).
+# Useful when auto-hiding the menubar or when the detected value is wrong.
+# When unset, the height reported by macOS is used.
+# menubar_height = 25
+
+# Opacity of the dim overlay drawn on inactive windows (0.0–1.0).
+# 0.0 disables the overlay entirely. Higher values make inactive windows darker.
+# Default: 0.0 (disabled).
+# dim_inactive_windows = 0.3
+
+# Hex color for the dim overlay on inactive windows.
+# Default: "#000000" (black).
+# dim_inactive_color = "#000000"
+
+# Draw a border around the active (focused) window.
+# Default: false.
+# border_active_window = true
+
+# Hex color for the active window border.
+# Default: "#FFFFFF" (white).
+# border_color = "#89b4fa"
+
+# Opacity of the active window border (0.0–1.0).
+# Default: 1.0.
+# border_opacity = 1.0
+
+# Width of the active window border in pixels.
+# Default: 2.0.
+# border_width = 2.0
+
+# Corner radius of the active window border in pixels.
+# Default: 10.0.
+# border_radius = 10.0
 
 [bindings]
 # Moves the focus between windows. If there are no windows when moving up or
@@ -333,6 +366,14 @@ width = 0.5
 title = "Passwords.*"
 floating = true
 grid = "6:6:1:1:4:4"
+
+[windows.terminal]
+# Per-window border radius override. Some windows have different corner
+# rounding than the default. This overrides the global border_radius setting.
+# Dynamically updated on config reload (no restart needed).
+title = ".*"
+bundle_id = "com.apple.Terminal"
+border_radius = 12.0
 
 [windows.all]
 # Matches all windows and adds a few pixels of spacing to their borders.

--- a/src/config.rs
+++ b/src/config.rs
@@ -315,6 +315,65 @@ impl Config {
     pub fn continuous_swipe(&self) -> bool {
         self.options().continuous_swipe.unwrap_or(true)
     }
+
+    pub fn dim_inactive_opacity(&self) -> f64 {
+        self.options()
+            .dim_inactive_windows
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0)
+    }
+
+    pub fn dim_inactive_color(&self) -> (f64, f64, f64) {
+        self.options()
+            .dim_inactive_color
+            .as_deref()
+            .map_or((0.0, 0.0, 0.0), parse_hex_color)
+    }
+
+    pub fn border_active_window(&self) -> bool {
+        self.options().border_active_window.unwrap_or(false)
+    }
+
+    pub fn border_color(&self) -> (f64, f64, f64) {
+        self.options()
+            .border_color
+            .as_deref()
+            .map_or((1.0, 1.0, 1.0), parse_hex_color)
+    }
+
+    pub fn border_opacity(&self) -> f64 {
+        self.options()
+            .border_opacity
+            .unwrap_or(1.0)
+            .clamp(0.0, 1.0)
+    }
+
+    pub fn border_width(&self) -> f64 {
+        self.options().border_width.unwrap_or(2.0).max(0.0)
+    }
+
+    pub fn border_radius(&self) -> f64 {
+        self.options().border_radius.unwrap_or(10.0).max(0.0)
+    }
+
+    pub fn menubar_height(&self) -> Option<i32> {
+        self.options().menubar_height.map(i32::from)
+    }
+}
+
+fn parse_hex_color(hex: &str) -> (f64, f64, f64) {
+    let hex = hex.strip_prefix('#').unwrap_or(hex);
+    if hex.len() != 6 {
+        return (1.0, 1.0, 1.0);
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255);
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255);
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255);
+    (
+        f64::from(r) / 255.0,
+        f64::from(g) / 255.0,
+        f64::from(b) / 255.0,
+    )
 }
 
 impl Default for Config {
@@ -452,6 +511,30 @@ pub struct MainOptions {
     pub padding_bottom: Option<u16>,
     pub padding_left: Option<u16>,
     pub padding_right: Option<u16>,
+    /// Opacity of the dim overlay on inactive windows (0.0=off, 1.0=fully black).
+    /// Default: 0.0 (disabled).
+    pub dim_inactive_windows: Option<f64>,
+    /// Hex color for the dim overlay, e.g. "#000000".
+    /// Default: "#000000" (black).
+    pub dim_inactive_color: Option<String>,
+    /// Whether to draw a border around the active (focused) window.
+    /// Default: false.
+    pub border_active_window: Option<bool>,
+    /// Hex color for the active window border, e.g. "#FF0000".
+    /// Default: "#FFFFFF" (white).
+    pub border_color: Option<String>,
+    /// Opacity of the active window border (0.0–1.0).
+    /// Default: 1.0.
+    pub border_opacity: Option<f64>,
+    /// Width of the active window border in pixels.
+    /// Default: 2.0.
+    pub border_width: Option<f64>,
+    /// Corner radius of the active window border.
+    /// Default: 10.0.
+    pub border_radius: Option<f64>,
+    /// Override the system menubar height (in pixels).
+    /// When set, this value is used instead of the height reported by macOS.
+    pub menubar_height: Option<u16>,
 
     /// Swiping keeps sliding windows until the first or last window.
     /// Set to false to clamp so edge windows stay on-screen. Default: true.
@@ -532,6 +615,8 @@ pub struct WindowParams {
     /// Grid placement for floating windows: "cols:rows:x:y:w:h".
     /// Divides the display into a grid and positions the window at the given cell/span.
     pub grid: Option<String>,
+    /// Per-window override for the active window border corner radius.
+    pub border_radius: Option<f64>,
 }
 
 impl WindowParams {
@@ -947,4 +1032,46 @@ index = 1
     let props = config.find_window_properties("picture in picture", "com.something.apple");
     assert_eq!(props[0].floating, Some(true));
     assert_eq!(props[0].index, Some(1));
+}
+
+#[test]
+fn test_parse_hex_color_valid() {
+    assert_eq!(parse_hex_color("#89b4fa"), (0x89 as f64 / 255.0, 0xb4 as f64 / 255.0, 0xfa as f64 / 255.0));
+    assert_eq!(parse_hex_color("#000000"), (0.0, 0.0, 0.0));
+    assert_eq!(parse_hex_color("#FFFFFF"), (1.0, 1.0, 1.0));
+    assert_eq!(parse_hex_color("#FF0000"), (1.0, 0.0, 0.0));
+}
+
+#[test]
+fn test_parse_hex_color_no_hash() {
+    assert_eq!(parse_hex_color("89b4fa"), (0x89 as f64 / 255.0, 0xb4 as f64 / 255.0, 0xfa as f64 / 255.0));
+    assert_eq!(parse_hex_color("FF0000"), (1.0, 0.0, 0.0));
+}
+
+#[test]
+fn test_parse_hex_color_invalid_length() {
+    // Short strings fall back to white.
+    assert_eq!(parse_hex_color("#FFF"), (1.0, 1.0, 1.0));
+    assert_eq!(parse_hex_color(""), (1.0, 1.0, 1.0));
+    assert_eq!(parse_hex_color("#FF"), (1.0, 1.0, 1.0));
+}
+
+#[test]
+fn test_parse_hex_color_malformed_hex() {
+    // Non-hex digits fall back to 255 per channel.
+    assert_eq!(parse_hex_color("ZZZZZZ"), (1.0, 1.0, 1.0));
+    assert_eq!(parse_hex_color("GG0000"), (1.0, 0.0, 0.0));
+}
+
+#[test]
+fn test_config_defaults() {
+    let config = Config::default();
+    assert_eq!(config.dim_inactive_opacity(), 0.0);
+    assert_eq!(config.dim_inactive_color(), (0.0, 0.0, 0.0));
+    assert!(!config.border_active_window());
+    assert_eq!(config.border_color(), (1.0, 1.0, 1.0));
+    assert_eq!(config.border_opacity(), 1.0);
+    assert_eq!(config.border_width(), 2.0);
+    assert_eq!(config.border_radius(), 10.0);
+    assert_eq!(config.menubar_height(), None);
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -67,6 +67,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
             systems::fresh_marker_cleanup,
             systems::timeout_ticker,
             systems::window_update_frame,
+            systems::sync_menubar_height,
             systems::displays_rearranged,
             systems::reposition_dragged_window,
             systems::find_orphaned_workspaces.run_if(on_timer(Duration::from_millis(
@@ -91,6 +92,9 @@ pub fn register_systems(app: &mut bevy::app::App) {
             systems::reshuffle_layout_strip,
             systems::animate_windows.after(systems::reshuffle_layout_strip),
             systems::animate_resize_windows.after(systems::reshuffle_layout_strip),
+            systems::update_overlays
+                .after(systems::animate_windows)
+                .after(systems::animate_resize_windows),
         ),
     );
 }
@@ -329,7 +333,9 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
 
     let mut platform_callbacks = PlatformCallbacks::new(sender);
     platform_callbacks.setup_handlers()?;
+    let overlay_manager = crate::overlay::OverlayManager::new(platform_callbacks.main_thread_marker);
     app.insert_non_send_resource(platform_callbacks);
+    app.insert_non_send_resource(overlay_manager);
     app.insert_non_send_resource(receiver);
 
     Ok(app)

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,4 +1,5 @@
 use bevy::app::AppExit;
+use bevy::ecs::change_detection::DetectChanges;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
@@ -17,8 +18,8 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
     ActiveDisplayMarker, BProcess, ExistingMarker, FocusedMarker, FreshMarker,
-    PollForNotifications, RepositionMarker, ResizeMarker, SpawnWindowTrigger, Timeout,
-    WMEventTrigger,
+    MissionControlActive, PollForNotifications, RepositionMarker, ResizeMarker,
+    SpawnWindowTrigger, Timeout, WMEventTrigger,
 };
 use crate::config::Config;
 use crate::ecs::params::{ActiveDisplay, Windows};
@@ -744,7 +745,7 @@ pub(super) fn window_swiper(
     let get_window_h_pad = |entity: Entity| {
         windows
             .get(entity)
-            .map(|(w, _, _)| w.horizontal_padding())
+            .map(|(w, _, _)| w.horizontal_padding() as i32)
             .unwrap_or(0)
     };
     let mut viewport = active_display.bounds();
@@ -856,7 +857,7 @@ pub(super) fn reshuffle_layout_strip(
     let get_window_h_pad = |entity: Entity| {
         windows
             .get(entity)
-            .map(|(w, _, _)| w.horizontal_padding())
+            .map(|(w, _, _)| w.horizontal_padding() as i32)
             .unwrap_or(0)
     };
 
@@ -1207,6 +1208,20 @@ fn get_moving_window_frame(
         .ok()
 }
 
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn sync_menubar_height(
+    config: Res<Config>,
+    mut displays: Query<&mut Display>,
+) {
+    if !config.is_changed() {
+        return;
+    }
+    let height = config.menubar_height();
+    for mut display in &mut displays {
+        display.set_menubar_height_override(height);
+    }
+}
+
 fn get_display_height(active_display: &ActiveDisplay) -> i32 {
     let dock_size = active_display.dock().map_or(0, |dock| {
         if let DockPosition::Bottom(offset) = dock {
@@ -1361,4 +1376,100 @@ pub(crate) fn reposition_dragged_window(
             reshuffle_around(*entity, &mut commands);
         }
     }
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub(super) fn update_overlays(
+    windows: Query<(
+        &Window,
+        Has<FocusedMarker>,
+        Option<&Unmanaged>,
+        Option<&ChildOf>,
+    )>,
+    applications: Query<&Application>,
+    config: Res<Config>,
+    mission_control: Res<MissionControlActive>,
+    overlay_mgr: Option<NonSendMut<crate::overlay::OverlayManager>>,
+) {
+    use crate::overlay::BorderParams;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    let Some(mut overlay_mgr) = overlay_mgr else {
+        return;
+    };
+
+    let dim_opacity = config.dim_inactive_opacity();
+    let border_enabled = config.border_active_window();
+
+    if mission_control.0 {
+        overlay_mgr.hide_all();
+        return;
+    }
+
+    if dim_opacity == 0.0 && !border_enabled {
+        overlay_mgr.remove_all();
+        return;
+    }
+
+    // Find the focused managed window's absolute CG frame.
+    // Skip floating/unmanaged windows — no overlay or border for those.
+    let mut focused_abs_cg: Option<NSRect> = None;
+    let mut focused_border_radius: Option<f64> = None;
+    let mut floating_focused = false;
+    for (window, is_focused, unmanaged, child_of) in &windows {
+        if !is_focused {
+            continue;
+        }
+        if unmanaged.is_some() {
+            floating_focused = true;
+            continue;
+        }
+
+        let frame = window.frame();
+        let h_pad = window.horizontal_padding();
+        let v_pad = window.vertical_padding();
+        focused_abs_cg = Some(NSRect::new(
+            NSPoint::new(
+                f64::from(frame.min.x) + h_pad,
+                f64::from(frame.min.y) + v_pad,
+            ),
+            NSSize::new(
+                f64::from(frame.width()) - 2.0 * h_pad,
+                f64::from(frame.height()) - 2.0 * v_pad,
+            ),
+        ));
+
+        // Look up per-window border_radius from config (dynamic, respects hot-reload).
+        let title = window.title().unwrap_or_default();
+        let bundle_id = child_of
+            .and_then(|c| applications.get(c.parent()).ok())
+            .map(|app| app.bundle_id().unwrap_or_default())
+            .unwrap_or_default();
+        let properties = config.find_window_properties(&title, bundle_id);
+        focused_border_radius = properties.iter().find_map(|p| p.border_radius);
+        break;
+    }
+
+    if floating_focused {
+        overlay_mgr.hide_all();
+        return;
+    }
+
+    if focused_abs_cg.is_none() {
+        // No managed window has focus — hide the overlay rather than
+        // dimming everything (e.g. during startup or when only floating
+        // windows exist).
+        overlay_mgr.hide_all();
+        return;
+    }
+
+    let border_params = border_enabled.then(|| BorderParams {
+        color: config.border_color(),
+        opacity: config.border_opacity(),
+        width: config.border_width(),
+        radius: focused_border_radius.unwrap_or_else(|| config.border_radius()),
+    });
+
+    let dim_color = config.dim_inactive_color();
+    overlay_mgr.update(dim_opacity, dim_color, focused_abs_cg, border_params.as_ref());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod ecs;
 mod errors;
 mod events;
 mod manager;
+mod overlay;
 mod platform;
 mod reader;
 mod util;

--- a/src/manager/display.rs
+++ b/src/manager/display.rs
@@ -19,8 +19,10 @@ pub struct Display {
     id: CGDirectDisplayID,
     /// The physical bounds (origin and size) of the display.
     bounds: IRect,
-    /// The height of the menubar on this display.
+    /// The height of the menubar on this display (from the system).
     menubar_height: i32,
+    /// Optional config override for the menubar height.
+    menubar_height_override: Option<i32>,
 }
 
 impl Display {
@@ -41,6 +43,7 @@ impl Display {
             id,
             bounds,
             menubar_height,
+            menubar_height_override: None,
         }
     }
 
@@ -101,9 +104,9 @@ impl Display {
             DockPosition::Left(visible_frame.min.x - self.bounds.min.x)
         } else if visible_frame.width() < self.bounds.width() {
             DockPosition::Right(self.bounds.max.x - visible_frame.max.x)
-        } else if visible_frame.height() < self.bounds.height() - self.menubar_height {
+        } else if visible_frame.height() < self.bounds.height() - self.menubar_height() {
             DockPosition::Bottom(
-                self.bounds.height() - visible_frame.height() - self.menubar_height,
+                self.bounds.height() - visible_frame.height() - self.menubar_height(),
             )
         } else {
             DockPosition::Hidden
@@ -116,7 +119,7 @@ impl Display {
 
     pub fn bounds(&self) -> IRect {
         let mut bounds = self.bounds;
-        bounds.min.y += self.menubar_height;
+        bounds.min.y += self.menubar_height();
         bounds
     }
 
@@ -129,6 +132,10 @@ impl Display {
     }
 
     pub fn menubar_height(&self) -> i32 {
-        self.menubar_height
+        self.menubar_height_override.unwrap_or(self.menubar_height)
+    }
+
+    pub fn set_menubar_height_override(&mut self, height: Option<i32>) {
+        self.menubar_height_override = height;
     }
 }

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -52,7 +52,8 @@ pub trait WindowApi: Send + Sync {
     fn width_ratio(&self) -> f64;
     fn pid(&self) -> Result<Pid>;
     fn set_padding(&mut self, padding: WindowPadding);
-    fn horizontal_padding(&self) -> i32;
+    fn horizontal_padding(&self) -> f64;
+    fn vertical_padding(&self) -> f64;
 }
 
 #[derive(Component, Deref, DerefMut)]
@@ -470,7 +471,11 @@ impl WindowApi for WindowOS {
         }
     }
 
-    fn horizontal_padding(&self) -> i32 {
-        self.horizontal_padding
+    fn horizontal_padding(&self) -> f64 {
+        self.horizontal_padding.into()
+    }
+
+    fn vertical_padding(&self) -> f64 {
+        self.vertical_padding.into()
     }
 }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,0 +1,323 @@
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send};
+use objc2_app_kit::{
+    NSBackingStoreType, NSBezierPath, NSColor, NSCompositingOperation, NSFloatingWindowLevel,
+    NSGraphicsContext, NSScreen, NSView, NSWindow, NSWindowCollectionBehavior, NSWindowStyleMask,
+};
+use objc2_core_foundation::CGFloat;
+use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+#[derive(Clone, PartialEq)]
+pub struct BorderParams {
+    pub color: (f64, f64, f64),
+    pub opacity: f64,
+    pub width: f64,
+    pub radius: f64,
+}
+
+/// Parameters for the fullscreen dim + cutout overlay.
+#[derive(Clone, PartialEq)]
+pub struct DimParams {
+    pub opacity: f64,
+    pub color: (f64, f64, f64),
+    /// The focused window rect to cut out (in Cocoa screen coordinates).
+    /// `None` means dim everything (no focused window).
+    pub cutout: Option<NSRect>,
+    pub border: Option<BorderParams>,
+}
+
+// ── DimView: fullscreen dark overlay with a transparent cutout + border ──
+
+#[derive(Debug, Clone)]
+struct DimViewIvars {
+    opacity: f64,
+    dim_r: f64,
+    dim_g: f64,
+    dim_b: f64,
+    // Cutout rect in the view's local coordinates.
+    cutout_x: f64,
+    cutout_y: f64,
+    cutout_w: f64,
+    cutout_h: f64,
+    has_cutout: bool,
+    // Border params (only drawn if has_border is true).
+    has_border: bool,
+    border_r: f64,
+    border_g: f64,
+    border_b: f64,
+    border_opacity: f64,
+    border_width: f64,
+    border_radius: f64,
+}
+
+define_class!(
+    #[unsafe(super(NSView))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PaneruDimView"]
+    #[ivars = DimViewIvars]
+    #[derive(Debug)]
+    struct DimView;
+
+    impl DimView {
+        #[unsafe(method(drawRect:))]
+        fn draw_rect(&self, _dirty_rect: NSRect) {
+            let ivars = self.ivars();
+            let bounds = self.bounds();
+
+            // Fill the entire view with the dim color.
+            let dim_color = NSColor::colorWithSRGBRed_green_blue_alpha(
+                ivars.dim_r as CGFloat,
+                ivars.dim_g as CGFloat,
+                ivars.dim_b as CGFloat,
+                ivars.opacity as CGFloat,
+            );
+            dim_color.setFill();
+            NSBezierPath::fillRect(bounds);
+
+            if ivars.has_cutout {
+                let half = if ivars.has_border { ivars.border_width / 2.0 } else { 0.0 };
+                let radius = ivars.border_radius as CGFloat;
+
+                // Expand the cutout by half the border width so the clear hole
+                // extends just past the window edge. The border straddles the
+                // window edge: outer half visible in the cutout, inner half
+                // hidden behind the window.
+                let cutout = NSRect::new(
+                    NSPoint::new(ivars.cutout_x - half, ivars.cutout_y - half),
+                    NSSize::new(ivars.cutout_w + ivars.border_width, ivars.cutout_h + ivars.border_width),
+                );
+
+                // Punch a rounded transparent hole using Clear compositing.
+                if let Some(ctx) = NSGraphicsContext::currentContext() {
+                    ctx.setCompositingOperation(NSCompositingOperation::Clear);
+                    let hole = NSBezierPath::bezierPathWithRoundedRect_xRadius_yRadius(
+                        cutout, radius, radius,
+                    );
+                    hole.fill();
+                    ctx.setCompositingOperation(NSCompositingOperation::SourceOver);
+                }
+
+                // Draw border centered on the window edge — half grows
+                // outward (visible in the cutout), half grows inward (behind
+                // the window).
+                if ivars.has_border {
+                    let border_rect = NSRect::new(
+                        NSPoint::new(ivars.cutout_x, ivars.cutout_y),
+                        NSSize::new(ivars.cutout_w, ivars.cutout_h),
+                    );
+                    let path = NSBezierPath::bezierPathWithRoundedRect_xRadius_yRadius(
+                        border_rect, radius, radius,
+                    );
+                    path.setLineWidth(ivars.border_width as CGFloat);
+                    let border_color = NSColor::colorWithSRGBRed_green_blue_alpha(
+                        ivars.border_r as CGFloat,
+                        ivars.border_g as CGFloat,
+                        ivars.border_b as CGFloat,
+                        ivars.border_opacity as CGFloat,
+                    );
+                    border_color.setStroke();
+                    path.stroke();
+                }
+            }
+        }
+
+        #[unsafe(method(isFlipped))]
+        fn is_flipped(&self) -> bool {
+            true
+        }
+    }
+);
+
+impl DimView {
+    fn new(mtm: MainThreadMarker, frame: NSRect, params: &DimParams) -> Retained<Self> {
+        let (has_cutout, cx, cy, cw, ch) = params.cutout.map_or(
+            (false, 0.0, 0.0, 0.0, 0.0),
+            |r| (true, r.origin.x, r.origin.y, r.size.width, r.size.height),
+        );
+        let (has_border, br, bg, bb, bo, bw, brad) = params.border.as_ref().map_or(
+            (false, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            |b| (true, b.color.0, b.color.1, b.color.2, b.opacity, b.width, b.radius),
+        );
+        let this = Self::alloc(mtm).set_ivars(DimViewIvars {
+            opacity: params.opacity,
+            dim_r: params.color.0,
+            dim_g: params.color.1,
+            dim_b: params.color.2,
+            cutout_x: cx,
+            cutout_y: cy,
+            cutout_w: cw,
+            cutout_h: ch,
+            has_cutout,
+            has_border,
+            border_r: br,
+            border_g: bg,
+            border_b: bb,
+            border_opacity: bo,
+            border_width: bw,
+            border_radius: brad,
+        });
+        unsafe { msg_send![super(this), initWithFrame: frame] }
+    }
+}
+
+// ── Coordinate helpers ──────────────────────────────────────────────────
+
+/// Convert an absolute CG screen frame (origin top-left, y-down) to Cocoa
+/// screen coordinates (origin bottom-left of primary screen, y-up).
+fn cg_abs_to_cocoa(frame: NSRect, primary_screen_height: f64) -> NSRect {
+    let cocoa_y = primary_screen_height - frame.origin.y - frame.size.height;
+    NSRect::new(NSPoint::new(frame.origin.x, cocoa_y), frame.size)
+}
+
+fn primary_screen_height(mtm: MainThreadMarker) -> f64 {
+    let screens = NSScreen::screens(mtm);
+    if screens.is_empty() {
+        return 0.0;
+    }
+    screens.objectAtIndex(0).frame().size.height
+}
+
+/// Get the full Cocoa screen rect covering all displays.
+fn full_screen_rect(mtm: MainThreadMarker) -> NSRect {
+    let screens = NSScreen::screens(mtm);
+    if screens.is_empty() {
+        return NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0));
+    }
+    let mut min_x = f64::MAX;
+    let mut min_y = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut max_y = f64::MIN;
+    for screen in &screens {
+        let f = screen.frame();
+        min_x = min_x.min(f.origin.x);
+        min_y = min_y.min(f.origin.y);
+        max_x = max_x.max(f.origin.x + f.size.width);
+        max_y = max_y.max(f.origin.y + f.size.height);
+    }
+    NSRect::new(
+        NSPoint::new(min_x, min_y),
+        NSSize::new(max_x - min_x, max_y - min_y),
+    )
+}
+
+// ── Overlay window factory ──────────────────────────────────────────────
+
+fn make_overlay_window(mtm: MainThreadMarker, cocoa_frame: NSRect) -> Retained<NSWindow> {
+    let window = unsafe {
+        NSWindow::initWithContentRect_styleMask_backing_defer(
+            NSWindow::alloc(mtm),
+            cocoa_frame,
+            NSWindowStyleMask::Borderless,
+            NSBackingStoreType::Buffered,
+            false,
+        )
+    };
+    window.setOpaque(false);
+    window.setBackgroundColor(Some(&NSColor::clearColor()));
+    window.setIgnoresMouseEvents(true);
+    window.setHasShadow(false);
+    window.setLevel(NSFloatingWindowLevel);
+    window.setCollectionBehavior(
+        NSWindowCollectionBehavior::Transient
+            | NSWindowCollectionBehavior::IgnoresCycle
+            | NSWindowCollectionBehavior::CanJoinAllSpaces,
+    );
+    window
+}
+
+// ── OverlayManager ──────────────────────────────────────────────────────
+
+pub struct OverlayManager {
+    mtm: MainThreadMarker,
+    /// Single fullscreen overlay window (dim + cutout + border).
+    overlay: Option<(Retained<NSWindow>, DimParams)>,
+    hidden: bool,
+}
+
+impl OverlayManager {
+    pub fn new(mtm: MainThreadMarker) -> Self {
+        Self {
+            mtm,
+            overlay: None,
+            hidden: false,
+        }
+    }
+
+    /// Update the single fullscreen overlay.
+    /// `focused_abs_cg` is the focused window rect in absolute CG coords,
+    /// or `None` if no window is focused.
+    pub fn update(
+        &mut self,
+        dim_opacity: f64,
+        dim_color: (f64, f64, f64),
+        focused_abs_cg: Option<NSRect>,
+        border: Option<&BorderParams>,
+    ) {
+        let screen_h = primary_screen_height(self.mtm);
+        let screen_rect = full_screen_rect(self.mtm);
+
+        // Convert the focused window rect from absolute CG to Cocoa coords,
+        // then to the overlay window's local coordinate system.
+        let cutout_local = focused_abs_cg.map(|cg_frame| {
+            let cocoa = cg_abs_to_cocoa(cg_frame, screen_h);
+            // Convert from screen coords to local (window-relative) coords.
+            NSRect::new(
+                NSPoint::new(
+                    cocoa.origin.x - screen_rect.origin.x,
+                    // The view is flipped (isFlipped=true), so y goes top-down.
+                    // screen_rect top in Cocoa = screen_rect.origin.y + screen_rect.size.height
+                    // We need: local_y = screen_top - cocoa_top
+                    (screen_rect.origin.y + screen_rect.size.height)
+                        - (cocoa.origin.y + cocoa.size.height),
+                ),
+                cocoa.size,
+            )
+        });
+
+        let params = DimParams {
+            opacity: dim_opacity,
+            color: dim_color,
+            cutout: cutout_local,
+            border: border.cloned(),
+        };
+
+        if let Some((window, stored)) = &mut self.overlay {
+            if *stored != params {
+                // Recreate the content view with new params.
+                let view = DimView::new(self.mtm, screen_rect, &params);
+                window.setContentView(Some(&view));
+                window.setFrame_display(screen_rect, true);
+            }
+            if self.hidden {
+                window.orderFront(None::<&AnyObject>);
+                self.hidden = false;
+            }
+            *stored = params;
+        } else {
+            let window = make_overlay_window(self.mtm, screen_rect);
+            let view = DimView::new(self.mtm, screen_rect, &params);
+            window.setContentView(Some(&view));
+            window.orderFront(None::<&AnyObject>);
+            self.overlay = Some((window, params));
+            self.hidden = false;
+        }
+    }
+
+    pub fn remove_all(&mut self) {
+        if let Some((window, _)) = self.overlay.take() {
+            window.orderOut(None::<&AnyObject>);
+        }
+        self.hidden = false;
+    }
+
+    pub fn hide_all(&mut self) {
+        if self.hidden {
+            return;
+        }
+        if let Some((window, _)) = &self.overlay {
+            window.orderOut(None::<&AnyObject>);
+        }
+        self.hidden = true;
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -440,8 +440,12 @@ impl WindowApi for MockWindow {
         debug!("{}:", function_name!());
     }
 
-    fn horizontal_padding(&self) -> i32 {
-        0
+    fn horizontal_padding(&self) -> f64 {
+        0.0
+    }
+
+    fn vertical_padding(&self) -> f64 {
+        0.0
     }
 
     #[instrument(level = Level::TRACE, skip(self), ret)]


### PR DESCRIPTION
Note: this PR is based on top of #97 so it includes the commits.

**Summary**

- Dim inactive windows with a configurable opacity and color overlay
- Draw a border around the active (focused) window with configurable color, opacity, width, and radius
- Allow per-window border_radius override in window rules
- Add menubar_height config option to override the system-reported value

<img width="3008" height="1692" alt="image" src="https://github.com/user-attachments/assets/cb3ce919-5eb9-41a3-bf49-f3a4e61d36c9" />


**New config options**

```
[options]
dim_inactive_windows = 0.3       # 0.0 (off) – 1.0 (fully opaque)
dim_inactive_color = "#000000"
border_active_window = true
border_color = "#89b4fa"
border_opacity = 1.0
border_width = 2.0
border_radius = 10.0
menubar_height = 38


[windows.some_app]
title = ".*"
border_radius = 0.0              # per-window override
```