### PR TITLE
feat: add paneru to home manager packages when configured

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,9 @@
 
           config = lib.mkIf cfg.enable {
             assertions = [ (lib.hm.assertions.assertPlatform "services.paneru" pkgs lib.platforms.darwin) ];
+
+            home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
             launchd.agents.paneru = {
               enable = true;
               config = {


### PR DESCRIPTION
Currently the home manager module configures paneru, but it doesn't actually make the `paneru` command available.