### PR TITLE
fix: skip make_key_window on macOS 14 to prevent SIGABRT

### DIFF
--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -20,7 +20,7 @@ use super::skylight::{
 };
 use crate::errors::{Error, Result};
 use crate::manager::{Origin, Size, irect_from};
-use crate::platform::{Pid, ProcessSerialNumber, WinID};
+use crate::platform::{Pid, ProcessSerialNumber, WinID, macos_major_version};
 use crate::util::{AXUIAttributes, AXUIWrapper, MacResult};
 
 #[derive(Debug)]
@@ -186,6 +186,13 @@ impl WindowOS {
     ///
     /// * `psn` - The process serial number of the application.
     fn make_key_window(&self, psn: &ProcessSerialNumber) {
+        // Reason: On macOS 14 (Sonoma), CGSEncodeEventRecord serializes the raw event
+        // buffer via NSKeyedArchiver, misinterpreting 0xFF fill as an ObjC class pointer,
+        // causing SIGABRT. See https://github.com/karinushka/paneru/issues/123
+        if macos_major_version() == 14 {
+            debug!("make_key_window: skipped on macOS 14 (Sonoma) to prevent crash");
+            return;
+        }
         let window_id = self.id();
         let mut event_bytes = [0u8; 0xf8];
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use accessibility_sys::{AXError, AXObserverRef, AXUIElementRef};
 use objc2::MainThreadMarker;
 use objc2::rc::{Retained, autoreleasepool};
@@ -240,5 +242,41 @@ impl PlatformCallbacks {
             // Housekeeping for UI/Notifications
             self.cocoa_app.updateWindows();
         });
+    }
+}
+
+/// Cached macOS major version (e.g. 14 for Sonoma, 15 for Sequoia).
+pub fn macos_major_version() -> u32 {
+    static VERSION: OnceLock<u32> = OnceLock::new();
+    *VERSION.get_or_init(|| {
+        let mut size: libc::size_t = 0;
+        let name = c"kern.osproductversion";
+        unsafe {
+            libc::sysctlbyname(name.as_ptr(), std::ptr::null_mut(), &mut size, std::ptr::null_mut(), 0);
+        }
+        let mut buf = vec![0u8; size];
+        unsafe {
+            libc::sysctlbyname(
+                name.as_ptr(),
+                buf.as_mut_ptr().cast(),
+                &mut size,
+                std::ptr::null_mut(),
+                0,
+            );
+        }
+        String::from_utf8_lossy(&buf)
+            .split('.')
+            .next()
+            .and_then(|s| s.trim_matches('\0').parse().ok())
+            .unwrap_or(0)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn macos_major_version_returns_valid() {
+        let v = super::macos_major_version();
+        assert!(v >= 13, "expected macOS 13+, got {v}");
     }
 }


### PR DESCRIPTION
Fixes #123

As discussed in the issue, `make_key_window()` crashes on macOS 14 (Sonoma) because `SLPSPostEventRecordTo` feeds the raw event buffer through `NSKeyedArchiver`, which treats the 0xFF fill bytes as an ObjC class pointer and aborts.

This adds a cached `macos_major_version()` helper using `sysctlbyname("kern.osproductversion")` and gates `make_key_window()` with an early return on version 14.

`focus_follows_mouse` won't work on Sonoma with this change, but all other focus operations (`_SLPSSetFrontProcessWithOptions` + `AXRaiseAction`) are unaffected.

Tested on macOS 14.2.1: paneru starts cleanly, focus switching works, no crash. All existing tests pass, plus one new test for the version detection.