### PR TITLE
feat!: group config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,13 @@ Paneru provides a home manager module to install and configure paneru.
           0.66
           0.75
         ];
-        swipe_gesture_fingers = 4;
-        swipe_gesture_direction = "Natural";
         animation_speed = 4000;
+      };
+      swipe = {
+        gesture = {
+          fingers_count = 4;
+          direction = "Natural";
+        };
       };
       bindings = {
         window_focus_west = "cmd - h";
@@ -189,7 +193,7 @@ Additionally it allows overriding the location with `$PANERU_CONFIG` environment
 
 You can use the following example configuration as a starting point:
 
-```
+```toml
 # syntax=toml
 #
 # Example configuration for Paneru.
@@ -204,24 +208,6 @@ You can use the following example configuration as a starting point:
 # Array of widths used by the `window_resize` action to cycle between.
 # Defaults to 25%, 33%, 50%, 66% and 75%.
 preset_column_widths = [ 0.25, 0.33, 0.50, 0.66, 0.75 ]
-
-# How many fingers to use for moving windows left and right.
-# Make sure that it doesn't clash with OS setting for workspace switching.
-# Values lower than 3 will be ignored.
-# Remove the line to disable the gesture feature.
-# Apple touchpads support gestures with more than five fingers (!),
-# but it is probably not that useful to use two hands :)
-swipe_gesture_fingers = 4
-
-# Which direction should windows move with a swipe gesture.
-# "Natural" => Swipe fingers to the right, windows move to the right.
-# "Reversed" => Swipe fingers to the right, windows move to the left.
-# Default: "Natural"
-# swipe_gesture_direction = "Natural"
-
-# Swiping keeps sliding windows until the first or last window.
-# Set to false to clamp so edge windows stay on-screen. Enabled by default.
-# continuous_swipe = true
 
 # Animation speed in 1/10th of display resolution per second.
 # E.g. a value of 20 means: move at a speed of two display sizes per second.
@@ -242,18 +228,47 @@ animation_speed = 50
 # Default: 5 pixels.
 # sliver_width = 5
 
-# Padding applied at screen edges (in pixels). Independent from the
-# between-window gaps set by per-window horizontal/vertical_padding.
-# Default: 0 on all sides.
-# padding_top = 0
-# padding_bottom = 0
-# padding_left = 0
-# padding_right = 0
-
 # Override the system-reported menubar height (in pixels).
 # Useful when auto-hiding the menubar or when the detected value is wrong.
 # When unset, the height reported by macOS is used.
 # menubar_height = 25
+
+[swipe]
+# Swipe sensitivity multiplier. Lower values = less distance per finger movement.
+# Range: 0.1–2.0. Default: 0.35.
+# sensitivity = 0.35
+
+# Swipe inertia deceleration rate. Higher values = faster stop.
+# Range: 1.0–10.0. Default: 4.0.
+# deceleration = 4.0
+
+# Swiping keeps sliding windows until the first or last window.
+# Set to false to clamp so edge windows stay on-screen. Default: true.
+# continuous = true
+
+[swipe.gesture]
+# How many fingers to use for moving windows left and right.
+# Make sure that it doesn't clash with OS setting for workspace switching.
+# Values lower than 3 will be ignored.
+# Remove the line to disable the gesture feature.
+# Apple touchpads support gestures with more than five fingers (!),
+# but it is probably not that useful to use two hands :)
+fingers_count = 4
+
+# Which direction should windows move with a swipe gesture.
+# "Natural" => Swipe fingers to the right, windows move to the right.
+# "Reversed" => Swipe fingers to the right, windows move to the left.
+# Default: "Natural"
+# direction = "Natural"
+
+[padding]
+# Padding applied at screen edges (in pixels). Independent from the
+# between-window gaps set by per-window horizontal/vertical_padding.
+# Default: 0 on all sides.
+# top = 0
+# bottom = 0
+# left = 0
+# right = 0
 
 [bindings]
 # Moves the focus between windows. If there are no windows when moving up or
@@ -348,7 +363,7 @@ grid = "6:6:1:1:4:4"
 # Matches all windows and adds a few pixels of spacing to their borders.
 # Note: horizontal_padding and vertical_padding create gaps on all sides of
 # each window. At screen edges, the gap is cancelled out so padding only
-# appears between windows. Use the [options] padding_* settings above to
+# appears between windows. Use the [padding] settings above to
 # control screen edge margins independently.
 title = ".*"
 horizontal_padding = 4
@@ -467,35 +482,35 @@ scripts, `cron` jobs, or other automation tools:
 
 ### Inactive window dimming
 
-For a macOS antive window dimming, set option `dim_inactive_windows` only. Do
+For a macOS antive window dimming, set `opacity` only under `[decorations.inactive.dim]`. Do
 not set the other options, like inactive color.
 In this mode the option takes values between `-1.0` and `1.0`, where `-1.0` is
 completely dark and `1.0` is fully white. A reasonable option to start with is
 `-0.15`.
 
 ```toml
-[options]
+[decorations.inactive.dim]
 # Setting this option only will toggle native macOS dimming.
 # -1.0 is fully black and 1.0 is fully white.
 # Default: 0.0 (disabled).
-dim_inactive_windows = -0.15
+opacity = -0.15
 ```
 
 Another dimming option is drawing a translucent overlay on every inactive
 window to visually emphasise the focused one.
-To enable this option, set both the `dim_inactive_windows` and the `dim_inactive_color`:
-In this mode, the `dim_inactive_windows` range is from `0.0` to `1.0`.
+To enable this option, set both `opacity` and `color` under `[decorations.inactive.dim]`:
+In this mode, the `opacity` range is from `0.0` to `1.0`.
 
 ```toml
-[options]
+[decorations.inactive.dim]
 # Opacity of the dim overlay drawn on inactive windows (0.0–1.0).
 # 0.0 disables the overlay entirely. Higher values make inactive windows darker.
 # Default: 0.0 (disabled).
-dim_inactive_windows = 0.3
+opacity = 0.3
 
 # Hex color for the dim overlay on inactive windows.
 # Default: "#000000" (black).
-dim_inactive_color = "#000000"
+color = "#000000"
 ```
 
 ### Active window border
@@ -503,26 +518,26 @@ dim_inactive_color = "#000000"
 Draws a coloured border around the currently focused window.
 
 ```toml
-[options]
+[decorations.active.border]
 # Draw a border around the active (focused) window.
 # Default: false.
-border_active_window = true
+enabled = true
 
 # Hex color for the active window border.
 # Default: "#FFFFFF" (white).
-# border_color = "#89b4fa"
+# color = "#89b4fa"
 
 # Opacity of the active window border (0.0–1.0).
 # Default: 1.0.
-# border_opacity = 1.0
+# opacity = 1.0
 
 # Width of the active window border in pixels.
 # Default: 2.0.
-# border_width = 2.0
+# width = 2.0
 
 # Corner radius of the active window border in pixels.
 # Default: 10.0.
-# border_radius = 10.0
+# radius = 10.0
 ```
 
 Per-window border radius can be overridden in the `[windows]` section:

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,6 @@
               description = "Configuration to put in `~/.paneru.toml`.";
               example = {
                 options = {
-                  focus_follows_mouse = true;
                   preset_column_widths = [
                     0.25
                     0.33
@@ -111,9 +110,13 @@
                     0.66
                     0.75
                   ];
-                  swipe_gesture_fingers = 4;
-                  swipe_gesture_direction = "Natural";
                   animation_speed = 4000;
+                };
+                swipe = {
+                  gesture = {
+                    fingers_count = 4;
+                    direction = "Natural";
+                  };
                 };
                 bindings = {
                   window_focus_west = "cmd - h";
@@ -126,6 +129,7 @@
                   window_swap_last = "alt + shift - l";
                   window_center = "alt - c";
                   window_resize = "alt - r";
+                  window_fullwidth = "alt - f";
                   window_manage = "ctrl + alt - t";
                   window_stack = "alt - ]";
                   window_unstack = "alt + shift - ]";

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ use std::{
 use stdext::function_name;
 use tracing::{error, info, warn};
 
+use self::decorations::BorderRadiusOption;
+use self::swipe::SwipeGestureDirection;
 use crate::{
     commands::{Command, Direction, MouseMove, Operation, ResizeDirection},
     platform::{Modifiers, OSStatus},
@@ -30,10 +32,21 @@ use crate::{platform::CFStringRef, util::AXUIWrapper};
 /// It checks the `PANERU_CONFIG` environment variable first, then standard XDG locations and user home directory.
 /// If no configuration file is found, the application will panic.
 pub static CONFIGURATION_FILE: LazyLock<PathBuf> = LazyLock::new(|| {
+    discover_configuration_file().unwrap_or_else(|| {
+        panic!(
+            "{}: Configuration file not found. Tried: $PANERU_CONFIG, $HOME/.paneru, $HOME/.paneru.toml, $XDG_CONFIG_HOME/paneru/paneru.toml",
+            function_name!()
+        )
+    })
+});
+
+/// Finds the first existing configuration file from supported locations.
+/// Unlike [`CONFIGURATION_FILE`], this does not panic when no file is found.
+pub fn discover_configuration_file() -> Option<PathBuf> {
     if let Ok(path_str) = env::var("PANERU_CONFIG") {
         let path = PathBuf::from(path_str);
         if path.exists() {
-            return path;
+            return Some(path);
         }
         warn!(
             "{}: $PANERU_CONFIG is set to {}, but the file does not exist. Falling back to default locations.",
@@ -58,13 +71,46 @@ pub static CONFIGURATION_FILE: LazyLock<PathBuf> = LazyLock::new(|| {
         .into_iter()
         .flatten()
         .find(|path| path.exists())
-        .unwrap_or_else(|| {
-            panic!(
-                "{}: Configuration file not found. Tried: $PANERU_CONFIG, $HOME/.paneru, $HOME/.paneru.toml, $XDG_CONFIG_HOME/paneru/paneru.toml",
-                function_name!()
-            )
-        })
-});
+}
+
+/// Returns the list of deprecated top-level `[options]` keys present in a TOML config.
+pub fn deprecated_options_in_input(input: &str) -> Result<Vec<String>> {
+    let value: toml::Value = toml::from_str(input)?;
+    let Some(options) = value.get("options").and_then(toml::Value::as_table) else {
+        return Ok(Vec::new());
+    };
+
+    const DEPRECATED_KEYS: [&str; 16] = [
+        "padding_top",
+        "padding_bottom",
+        "padding_left",
+        "padding_right",
+        "dim_inactive_windows",
+        "dim_inactive_color",
+        "border_active_window",
+        "border_color",
+        "border_opacity",
+        "border_width",
+        "border_radius",
+        "swipe_gesture_fingers",
+        "swipe_gesture_direction",
+        "continuous_swipe",
+        "swipe_sensitivity",
+        "swipe_deceleration",
+    ];
+
+    Ok(DEPRECATED_KEYS
+        .into_iter()
+        .filter(|key| options.contains_key(*key))
+        .map(str::to_string)
+        .collect())
+}
+
+/// Returns deprecated top-level `[options]` keys present in the config file.
+pub fn deprecated_options_in_file(path: &Path) -> Result<Vec<String>> {
+    let input = read_to_string(path)?;
+    deprecated_options_in_input(&input)
+}
 
 /// Parses a string into a `Direction` enum.
 ///
@@ -319,12 +365,14 @@ impl Config {
     }
 
     pub fn edge_padding(&self) -> (i32, i32, i32, i32) {
-        let o = self.options();
+        let config = self.inner();
+        let o = &config.options;
+        let p = config.padding.as_ref();
         (
-            i32::from(o.padding_top.unwrap_or(0)),
-            i32::from(o.padding_right.unwrap_or(0)),
-            i32::from(o.padding_bottom.unwrap_or(0)),
-            i32::from(o.padding_left.unwrap_or(0)),
+            i32::from(p.and_then(|p| p.top).or(o.padding_top).unwrap_or(0)),
+            i32::from(p.and_then(|p| p.right).or(o.padding_right).unwrap_or(0)),
+            i32::from(p.and_then(|p| p.bottom).or(o.padding_bottom).unwrap_or(0)),
+            i32::from(p.and_then(|p| p.left).or(o.padding_left).unwrap_or(0)),
         )
     }
 
@@ -333,51 +381,134 @@ impl Config {
     }
 
     pub fn swipe_gesture_direction(&self) -> SwipeGestureDirection {
-        self.options()
-            .swipe_gesture_direction
+        let config = self.inner();
+        config
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.gesture.as_ref())
+            .and_then(|gesture| gesture.direction.clone())
+            .clone()
+            .or(config.options.swipe_gesture_direction.clone())
             .unwrap_or(SwipeGestureDirection::Natural)
     }
+
+    pub fn swipe_gesture_fingers(&self) -> Option<usize> {
+        let config = self.inner();
+        config
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.gesture.as_ref())
+            .and_then(|gesture| gesture.fingers_count)
+            .or(config.options.swipe_gesture_fingers)
+    }
+
+    pub fn has_dim_inactive_color(&self) -> bool {
+        let config = self.inner();
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.inactive.as_ref())
+            .and_then(|inactive| inactive.dim.as_ref())
+            .and_then(|dim| dim.color.as_ref())
+            .is_some()
+            || config.options.dim_inactive_color.is_some()
+    }
+
     pub fn dim_inactive_opacity(&self) -> f32 {
-        if self.options().dim_inactive_color.is_none() {
+        let config = self.inner();
+        let color = config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.inactive.as_ref())
+            .and_then(|inactive| inactive.dim.as_ref())
+            .and_then(|dim| dim.color.as_ref())
+            .or(config.options.dim_inactive_color.as_ref());
+        if color.is_none() {
             return 0.0;
         }
-        self.options()
-            .dim_inactive_windows
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.inactive.as_ref())
+            .and_then(|inactive| inactive.dim.as_ref())
+            .and_then(|dim| dim.opacity)
+            .or(config.options.dim_inactive_windows)
             .unwrap_or(0.0)
             .clamp(0.0, 1.0)
     }
 
     pub fn dim_inactive_color(&self) -> (f64, f64, f64) {
-        self.options()
-            .dim_inactive_color
-            .as_deref()
+        let config = self.inner();
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.inactive.as_ref())
+            .and_then(|inactive| inactive.dim.as_ref())
+            .and_then(|dim| dim.color.as_deref())
+            .or(config.options.dim_inactive_color.as_deref())
             .map_or((0.0, 0.0, 0.0), parse_hex_color)
     }
 
     pub fn border_active_window(&self) -> bool {
-        self.options().border_active_window.unwrap_or(false)
+        let config = self.inner();
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.active.as_ref())
+            .and_then(|active| active.border.as_ref())
+            .and_then(|border| border.enabled)
+            .or(config.options.border_active_window)
+            .unwrap_or(false)
     }
 
     pub fn border_color(&self) -> (f64, f64, f64) {
-        self.options()
-            .border_color
-            .as_deref()
+        let config = self.inner();
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.active.as_ref())
+            .and_then(|active| active.border.as_ref())
+            .and_then(|border| border.color.as_deref())
+            .or(config.options.border_color.as_deref())
             .map_or((1.0, 1.0, 1.0), parse_hex_color)
     }
 
     pub fn border_opacity(&self) -> f64 {
-        self.options().border_opacity.unwrap_or(1.0).clamp(0.0, 1.0)
+        let config = self.inner();
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.active.as_ref())
+            .and_then(|active| active.border.as_ref())
+            .and_then(|border| border.opacity)
+            .or(config.options.border_opacity)
+            .unwrap_or(1.0)
+            .clamp(0.0, 1.0)
     }
 
     pub fn border_width(&self) -> f64 {
-        self.options().border_width.unwrap_or(2.0).max(0.0)
+        let config = self.inner();
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.active.as_ref())
+            .and_then(|active| active.border.as_ref())
+            .and_then(|border| border.width)
+            .or(config.options.border_width)
+            .unwrap_or(2.0)
+            .max(0.0)
     }
 
     pub fn border_radius(&self) -> BorderRadiusOption {
         let version = NSProcessInfo::processInfo().operatingSystemVersion();
-        match self
-            .options()
-            .border_radius
+        let config = self.inner();
+        match config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.active.as_ref())
+            .and_then(|active| active.border.as_ref())
+            .and_then(|border| border.radius.clone())
+            .or(config.options.border_radius.clone())
             .unwrap_or(BorderRadiusOption::Auto)
         {
             BorderRadiusOption::Auto if version.majorVersion == 26 => BorderRadiusOption::Auto,
@@ -391,25 +522,48 @@ impl Config {
     }
 
     pub fn swipe_sensitivity(&self) -> f64 {
-        self.options()
-            .swipe_sensitivity
+        let config = self.inner();
+        config
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.sensitivity)
+            .or(config.options.swipe_sensitivity)
             .unwrap_or(0.35)
             .clamp(0.1, 2.0)
     }
 
     pub fn swipe_deceleration(&self) -> f64 {
-        self.options()
-            .swipe_deceleration
+        let config = self.inner();
+        config
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.deceleration)
+            .or(config.options.swipe_deceleration)
             .unwrap_or(4.0)
             .clamp(1.0, 10.0)
     }
 
     pub fn window_dim_ratio(&self) -> Option<f32> {
-        if self.options().dim_inactive_color.is_some() {
+        let config = self.inner();
+        if config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.inactive.as_ref())
+            .and_then(|inactive| inactive.dim.as_ref())
+            .and_then(|dim| dim.color.as_ref())
+            .is_some()
+            || config.options.dim_inactive_color.is_some()
+        {
             // This is not our dimming - it's the color one.
             return None;
         }
-        self.options().dim_inactive_windows
+        config
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.inactive.as_ref())
+            .and_then(|inactive| inactive.dim.as_ref())
+            .and_then(|dim| dim.opacity)
+            .or(config.options.dim_inactive_windows)
     }
 }
 
@@ -493,6 +647,9 @@ struct InnerConfig {
     options: MainOptions,
     bindings: HashMap<String, OneOrMore>,
     windows: Option<HashMap<String, WindowParams>>,
+    decorations: Option<decorations::DecorationsOptions>,
+    swipe: Option<swipe::SwipeOptions>,
+    padding: Option<padding::PaddingOptions>,
 }
 
 impl InnerConfig {
@@ -562,44 +719,6 @@ impl InnerConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub enum SwipeGestureDirection {
-    Natural,
-    Reversed,
-}
-#[derive(Clone, Debug, PartialEq)]
-pub enum BorderRadiusOption {
-    Auto,
-    Value(f64),
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum BorderRadiusValue {
-    Number(f64),
-    Text(String),
-}
-
-fn deserialize_border_radius_option<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<BorderRadiusOption>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let input = Option::<BorderRadiusValue>::deserialize(deserializer)?;
-    input
-        .map(|value| match value {
-            BorderRadiusValue::Number(radius) => Ok(BorderRadiusOption::Value(radius)),
-            BorderRadiusValue::Text(value) if value.eq_ignore_ascii_case("auto") => {
-                Ok(BorderRadiusOption::Auto)
-            }
-            BorderRadiusValue::Text(value) => Err(de::Error::custom(format!(
-                "invalid border_radius value: {value}. Expected a number or \"auto\"",
-            ))),
-        })
-        .transpose()
-}
-
 /// `MainOptions` represents the primary configuration options for the window manager.
 /// These options control various behaviors such as mouse focus, gesture recognition, and window animation.
 #[derive(Deserialize, Clone, Debug, Default)]
@@ -608,10 +727,6 @@ pub struct MainOptions {
     pub focus_follows_mouse: Option<bool>,
     /// Enables or disables mouse follows focus behavior.
     pub mouse_follows_focus: Option<bool>,
-    /// The number of fingers required for swipe gestures to move windows.
-    pub swipe_gesture_fingers: Option<usize>,
-    /// Which direction swipe gestures should move windows.
-    pub swipe_gesture_direction: Option<SwipeGestureDirection>,
     /// A list of preset column widths (as ratios) used for resizing windows.
     #[serde(default = "default_preset_column_widths")]
     pub preset_column_widths: Vec<f64>,
@@ -626,50 +741,40 @@ pub struct MainOptions {
     /// Width of off-screen window slivers in pixels.
     /// Default: 5 pixels.
     pub sliver_width: Option<u16>,
-    /// Padding applied at screen edges (in pixels). Independent from between-window gaps.
-    /// Default: 0 on all sides.
+    /// Legacy top-level padding (deprecated; use `[padding]`).
     pub padding_top: Option<u16>,
     pub padding_bottom: Option<u16>,
     pub padding_left: Option<u16>,
     pub padding_right: Option<u16>,
-    /// Opacity of the dim overlay on inactive windows (0.0=off, 1.0=fully black).
-    /// Default: 0.0 (disabled).
+    /// Legacy top-level dim options (deprecated; use `[decorations.inactive.dim]`).
     pub dim_inactive_windows: Option<f32>,
-    /// Hex color for the dim overlay, e.g. "#000000".
-    /// Default: "#000000" (black).
     pub dim_inactive_color: Option<String>,
-    /// Whether to draw a border around the active (focused) window.
-    /// Default: false.
+    /// Legacy top-level border options (deprecated; use `[decorations.active.border]`).
     pub border_active_window: Option<bool>,
-    /// Hex color for the active window border, e.g. "#FF0000".
-    /// Default: "#FFFFFF" (white).
     pub border_color: Option<String>,
-    /// Opacity of the active window border (0.0–1.0).
-    /// Default: 1.0.
     pub border_opacity: Option<f64>,
-    /// Width of the active window border in pixels.
-    /// Default: 2.0.
     pub border_width: Option<f64>,
-    /// Corner radius of the active window border.
-    /// Default: 10.0.
-    #[serde(default, deserialize_with = "deserialize_border_radius_option")]
+    #[serde(
+        default,
+        deserialize_with = "decorations::deserialize_border_radius_option"
+    )]
     pub border_radius: Option<BorderRadiusOption>,
+    /// Legacy top-level swipe options (deprecated; use `[swipe]`).
+    pub swipe_gesture_fingers: Option<usize>,
+    pub swipe_gesture_direction: Option<SwipeGestureDirection>,
+
+    #[allow(dead_code)]
+    pub continuous_swipe: Option<bool>,
+    pub swipe_sensitivity: Option<f64>,
+    pub swipe_deceleration: Option<f64>,
     /// Override the system menubar height (in pixels).
     /// When set, this value is used instead of the height reported by macOS.
     pub menubar_height: Option<u16>,
-
-    /// Swiping keeps sliding windows until the first or last window.
-    /// Set to false to clamp so edge windows stay on-screen. Default: true.
-    pub continuous_swipe: Option<bool>,
-
-    /// Swipe sensitivity multiplier. Lower values = less distance per finger
-    /// movement. Range: 0.1–2.0. Default: 0.35.
-    pub swipe_sensitivity: Option<f64>,
-
-    /// Swipe inertia deceleration rate. Higher values = faster stop.
-    /// Range: 1.0–10.0. Default: 4.0.
-    pub swipe_deceleration: Option<f64>,
 }
+
+pub mod decorations;
+pub mod padding;
+pub mod swipe;
 
 /// Returns a default set of column widths.
 pub fn default_preset_column_widths() -> Vec<f64> {

--- a/src/config/decorations.rs
+++ b/src/config/decorations.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Deserializer, de};
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct DecorationsOptions {
+    pub active: Option<GeneralDecorationsOptions>,
+    pub inactive: Option<GeneralDecorationsOptions>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct GeneralDecorationsOptions {
+    pub border: Option<GeneralBorderOptions>,
+    pub dim: Option<GeneralDimOptions>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct GeneralBorderOptions {
+    /// Is border enabled
+    /// Default: false.
+    pub enabled: Option<bool>,
+    /// Hex color for the window border, e.g. "#FF0000".
+    /// Default: "#FFFFFF" (white).
+    pub color: Option<String>,
+    /// Opacity of the window border (0.0–1.0).
+    /// Default: 1.0.
+    pub opacity: Option<f64>,
+
+    /// Width of the window border in pixels.
+    /// Default: 2.0.
+    pub width: Option<f64>,
+    /// Corner radius of the window border.
+    /// Default: 10.0.
+    #[serde(default, deserialize_with = "deserialize_border_radius_option")]
+    pub radius: Option<BorderRadiusOption>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct GeneralDimOptions {
+    /// Opacity of the dim overlay on inactive windows (0.0=off, 1.0=fully black).
+    /// Default: 0.0 (disabled).
+    pub opacity: Option<f32>,
+    /// Hex color for the dim overlay, e.g. "#000000".
+    /// Default: "#000000" (black).
+    pub color: Option<String>,
+}
+#[derive(Clone, Debug, PartialEq)]
+pub enum BorderRadiusOption {
+    Auto,
+    Value(f64),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BorderRadiusValue {
+    Number(f64),
+    Text(String),
+}
+
+pub fn deserialize_border_radius_option<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<BorderRadiusOption>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let input = Option::<BorderRadiusValue>::deserialize(deserializer)?;
+    input
+        .map(|value| match value {
+            BorderRadiusValue::Number(radius) => Ok(BorderRadiusOption::Value(radius)),
+            BorderRadiusValue::Text(value) if value.eq_ignore_ascii_case("auto") => {
+                Ok(BorderRadiusOption::Auto)
+            }
+            BorderRadiusValue::Text(value) => Err(de::Error::custom(format!(
+                "invalid border_radius value: {value}. Expected a number or \"auto\"",
+            ))),
+        })
+        .transpose()
+}

--- a/src/config/padding.rs
+++ b/src/config/padding.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct PaddingOptions {
+    /// Padding applied at screen edges (in pixels). Independent from between-window gaps.
+    /// Default: 0 on all sides.
+    pub top: Option<u16>,
+    pub bottom: Option<u16>,
+    pub left: Option<u16>,
+    pub right: Option<u16>,
+}

--- a/src/config/swipe.rs
+++ b/src/config/swipe.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub enum SwipeGestureDirection {
+    Natural,
+    Reversed,
+}
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct SwipeOptions {
+    /// Swipe sensitivity multiplier. Lower values = less distance per finger
+    /// movement. Range: 0.1–2.0. Default: 0.35.
+    pub sensitivity: Option<f64>,
+
+    /// Swipe inertia deceleration rate. Higher values = faster stop.
+    /// Range: 1.0–10.0. Default: 4.0.
+    pub deceleration: Option<f64>,
+
+    /// Swiping keeps sliding windows until the first or last window.
+    /// Set to false to clamp so edge windows stay on-screen. Default: true.
+    #[allow(dead_code)]
+    pub continuous: Option<bool>,
+
+    pub gesture: Option<GestureOptions>,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct GestureOptions {
+    /// The number of fingers required for swipe gestures to move windows.
+    pub fingers_count: Option<usize>,
+
+    /// Which direction swipe gestures should move windows.
+    pub direction: Option<SwipeGestureDirection>,
+}

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -103,8 +103,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 .after(systems::animate_resize_entities)
                 .run_if(|config: Option<Res<Config>>| {
                     config.is_some_and(|config| {
-                        config.options().dim_inactive_color.is_some()
-                            || config.border_active_window()
+                        config.has_dim_inactive_color() || config.border_active_window()
                     })
                 }),
             systems::commit_window_position.after(systems::animate_entities),

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -73,7 +73,7 @@ impl Configuration<'_> {
     ///
     /// An `Option<usize>` containing the number of fingers, or `None` if not configured.
     pub fn swipe_gesture_fingers(&self) -> Option<usize> {
-        self.config.options().swipe_gesture_fingers
+        self.config.swipe_gesture_fingers()
     }
 
     /// Finds window properties for a given `title` and `bundle_id` based on the application configuration.

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -11,7 +11,6 @@ use bevy::tasks::AsyncComputeTaskPool;
 use bevy::tasks::futures_lite::future;
 use bevy::time::Time;
 use objc2_core_graphics::CGDirectDisplayID;
-use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
 use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
@@ -23,7 +22,7 @@ use super::{
     PollForNotifications, RepositionMarker, ResizeMarker, SpawnWindowTrigger, Timeout,
     WMEventTrigger,
 };
-use crate::config::{BorderRadiusOption, Config, SwipeGestureDirection};
+use crate::config::{Config, decorations::BorderRadiusOption, swipe::SwipeGestureDirection};
 use crate::ecs::params::{ActiveDisplay, Configuration, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, BruteforceWindows, DockPosition, Initializing,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use clap::{Parser, Subcommand};
+use tracing::warn;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 mod commands;
@@ -98,7 +99,10 @@ fn main() -> Result<()> {
 
     let service = || service::Service::try_new(service::ID);
 
-    match Paneru::parse().subcmd.unwrap_or_default() {
+    let subcmd = Paneru::parse().subcmd.unwrap_or_default();
+    maybe_warn_deprecated_options_for_service(&subcmd);
+
+    match subcmd {
         SubCmd::Launch => {
             let (sender, receiver) = EventSender::new();
             CommandReader::new(sender.clone()).start();
@@ -113,4 +117,39 @@ fn main() -> Result<()> {
         SubCmd::SendCmd { cmd } => CommandReader::send_command(cmd)?,
     }
     Ok(())
+}
+
+fn should_check_deprecated_options(subcmd: &SubCmd) -> bool {
+    matches!(
+        subcmd,
+        SubCmd::Install | SubCmd::Uninstall | SubCmd::Start | SubCmd::Stop | SubCmd::Restart
+    )
+}
+
+fn maybe_warn_deprecated_options_for_service(subcmd: &SubCmd) {
+    if !should_check_deprecated_options(subcmd) {
+        return;
+    }
+
+    let Some(path) = config::discover_configuration_file() else {
+        return;
+    };
+
+    match config::deprecated_options_in_file(&path) {
+        Ok(keys) if !keys.is_empty() => {
+            warn!(
+                "detected deprecated [options] keys in `{}` while running a service command: {}. \
+                 Please migrate to `[padding]`, `[swipe]`, and `[decorations.*]`.",
+                path.display(),
+                keys.join(", ")
+            );
+        }
+        Ok(_) => {}
+        Err(err) => {
+            warn!(
+                "could not inspect `{}` for deprecated options: {err}",
+                path.display()
+            );
+        }
+    }
 }


### PR DESCRIPTION
This pr changes the config format, internally it still uses old names in methods, i want to do follow up prs, with changes for padding and borders, and do the relevant changes in them, swipe should probably stay until next release with the same internal structure for compat reasons, this pr contains code to warn people about breaking changes and deprecation.