### PR TITLE
Use toml syntax highlighting for sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Additionally it allows overriding the location with `$PANERU_CONFIG` environment
 
 You can use the following example configuration as a starting point:
 
-```
+```toml
 # syntax=toml
 #
 # Example configuration for Paneru.


### PR DESCRIPTION
Just added `\```toml` to the example configuration in the readme. This improves readability