### PR TITLE
Focus lost

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -70,6 +70,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
             systems::add_launched_application,
             systems::fresh_marker_cleanup,
             systems::timeout_ticker,
+            systems::retry_front_switch,
             systems::window_update_frame,
             systems::refresh_workspace_window_sizes.run_if(on_timer(Duration::from_millis(
                 REFRESH_WINDOW_CHECK_FREQ_MS,
@@ -301,6 +302,11 @@ impl Timeout {
 /// Component used as a retry mechanism for stray focus events that arrive before the target window is fully created.
 #[derive(Component)]
 pub struct StrayFocusEvent(pub WinID);
+
+/// Component used as a retry mechanism when `focused_window_id()` fails during
+/// an `ApplicationFrontSwitched` event (e.g. transient `kAXErrorCannotComplete`).
+#[derive(Component)]
+pub struct RetryFrontSwitch(pub Entity);
 
 #[derive(Component)]
 pub struct BruteforceWindows(Task<Vec<Window>>);

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -19,8 +19,8 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
     ActiveDisplayMarker, BProcess, ExistingMarker, FocusedMarker, FreshMarker,
-    PollForNotifications, RepositionMarker, ResizeMarker, SpawnWindowTrigger, Timeout,
-    WMEventTrigger,
+    PollForNotifications, RepositionMarker, ResizeMarker, RetryFrontSwitch, SpawnWindowTrigger,
+    Timeout, WMEventTrigger,
 };
 use crate::config::{Config, decorations::BorderRadiusOption};
 use crate::ecs::layout::LayoutStrip;
@@ -457,6 +457,31 @@ pub(super) fn timeout_ticker(
             trace!("Timer {}", timeout.timer.elapsed().as_secs_f32());
             timeout.timer.tick(clock.delta());
         }
+    }
+}
+
+/// Retries querying the focused window for applications that had a transient AX error
+/// during `ApplicationFrontSwitched`. Runs each frame until success or timeout.
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn retry_front_switch(
+    retries: Populated<(Entity, &RetryFrontSwitch)>,
+    applications: Query<&Application>,
+    mut commands: Commands,
+) {
+    for (entity, retry) in retries.iter() {
+        let Ok(app) = applications.get(retry.0) else {
+            // Application entity no longer exists, clean up.
+            commands.entity(entity).despawn();
+            continue;
+        };
+        if let Ok(focused_id) = app.focused_window_id() {
+            debug!("Front switch retry succeeded for window {focused_id}.");
+            commands.trigger(WMEventTrigger(Event::WindowFocused {
+                window_id: focused_id,
+            }));
+            commands.entity(entity).despawn();
+        }
+        // Otherwise, let timeout_ticker handle expiry.
     }
 }
 

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -17,8 +17,8 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
     ActiveDisplayMarker, BProcess, FocusedMarker, FreshMarker, MissionControlActive,
-    NativeFullscreenMarker, SpawnWindowTrigger, StrayFocusEvent, Timeout, Unmanaged,
-    WMEventTrigger, WindowDraggedMarker,
+    NativeFullscreenMarker, RetryFrontSwitch, SpawnWindowTrigger, StrayFocusEvent, Timeout,
+    Unmanaged, WMEventTrigger, WindowDraggedMarker,
 };
 use crate::commands::ON_FULLSCREEN_SPACE;
 use crate::config::{Config, WindowParams};
@@ -507,13 +507,13 @@ pub(super) fn display_change_trigger(
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn front_switched_trigger(
     trigger: On<WMEventTrigger>,
-    windows: Windows,
     processes: Query<(&BProcess, &Children)>,
     applications: Query<&Application>,
     window_manager: Res<WindowManager>,
     mut config: Configuration,
     mut commands: Commands,
 ) {
+    const FRONT_SWITCH_RETRY_SEC: u64 = 2;
     let Event::ApplicationFrontSwitched { ref psn } = trigger.event().0 else {
         return;
     };
@@ -527,10 +527,11 @@ pub(super) fn front_switched_trigger(
     if children.len() > 1 {
         warn!("Multiple apps registered to process '{}'.", process.name());
     }
-    let Some(app) = children
-        .first()
-        .and_then(|entity| applications.get(*entity).ok())
-    else {
+    let Some(&app_entity) = children.first() else {
+        error!("No application for process '{}'.", process.name());
+        return;
+    };
+    let Some(app) = applications.get(app_entity).ok() else {
         error!("No application for process '{}'.", process.name());
         return;
     };
@@ -552,10 +553,17 @@ pub(super) fn front_switched_trigger(
         commands.trigger(WMEventTrigger(Event::WindowFocused {
             window_id: focused_id,
         }));
-    } else if let Some((_, entity)) = windows.focused() {
-        warn!("front_switched: removing FocusedMarker from {entity} with no replacement!");
-        config.set_ffm_flag(None);
-        commands.entity(entity).try_remove::<FocusedMarker>();
+    } else {
+        // Transient AX error (e.g. kAXErrorCannotComplete during app transitions).
+        // Schedule a retry to query the focused window once the app is ready.
+        let timeout = Timeout::new(
+            Duration::from_secs(FRONT_SWITCH_RETRY_SEC),
+            Some(format!(
+                "Front switch retry for '{}' timed out.",
+                process.name()
+            )),
+        );
+        commands.spawn((timeout, RetryFrontSwitch(app_entity)));
     }
 }
 


### PR DESCRIPTION
When ApplicationFrontSwitched fires and focused_window_id() fails (e.g. kAXErrorCannotComplete during app transitions), the else branch was removing FocusedMarker with no replacement, causing complete loss of keyboard focus control.

Replace the destructive else branch with a retry mechanism: spawn a RetryFrontSwitch entity with a 2s timeout that re-queries the focused window each frame. On success, trigger WindowFocused and despawn. On timeout, give up gracefully (existing focus preserved).