### PR TITLE
feat: add lazy viewport mode, window_snap command, and click derral

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ animation_speed = 50
 # When unset, the height reported by macOS is used.
 # menubar_height = 25
 
+# How much of a window may be hidden before a focus change forces it into view.
+# 0.0 (default) = always bring into view (eager).
+# 1.0 = never move unless fully invisible (lazy).
+# E.g. 0.5 = tolerate up to 50% hidden.
+# Clicking a window defers the scroll until mouse-up so content doesn't shift
+# mid-click. Use the window_snap binding to manually snap a window into view.
+# window_hidden_ratio = 0.0
+
 [swipe]
 # Swipe sensitivity multiplier. Lower values = less distance per finger movement.
 # Range: 0.1–2.0. Default: 0.35.
@@ -320,6 +328,11 @@ mouse_nextdisplay = "alt - n"
 
 # Size stacked windows in the column to equal heights.
 window_equalize = "alt + shift - e"
+
+# Snap the focused window into view by sliding the strip. Left-aligned when
+# the window overflows left, right-aligned when overflows right. No resize.
+# Useful in lazy viewport mode when a window is partially offscreen.
+# window_snap = "alt + shift - f"
 
 # Quits the window manager.
 quit = "ctrl + alt - q"
@@ -425,6 +438,7 @@ $ paneru send-cmd <command> [args...]
 | `window stack`             | Stack the focused window onto its left neighbour |
 | `window unstack`           | Unstack the focused window into its own column   |
 | `window nextdisplay`       | Move the focused window to the next display      |
+| `window snap`     | Snap the focused window into the visible viewport    |
 | `mouse nextdisplay`        | Warp the mouse pointer to the next display       |
 | `printstate`               | Print the internal ECS state to the debug log    |
 | `quit`                     | Quit Paneru                                      |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -64,6 +64,9 @@ pub enum Operation {
     Manage,
     /// Stacks or unstacks a window. The boolean indicates whether to stack (`true`) or unstack (`false`).
     Stack(bool),
+    /// Resizes and repositions the focused window to fit within the visible viewport
+    /// (including edge padding).
+    Snap,
 }
 
 /// Defines operations that can be performed on the mouse.
@@ -101,6 +104,7 @@ pub fn register_commands(app: &mut bevy::app::App) {
             stack_windows_handler,
             command_move_focus,
             command_swap_focus,
+            snap_window,
         ),
     );
 }
@@ -258,6 +262,10 @@ fn command_move_focus(
         && let Some(psn) = windows.psn(window.id(), &apps)
     {
         window.focus_with_raise(psn);
+        // Explicitly reshuffle so the target window is brought into view.
+        // This avoids a race where focus-follows-mouse leaves skip_reshuffle
+        // set, causing the WindowFocused handler to skip the reshuffle.
+        reshuffle_around(entity, &mut commands);
         return;
     }
 
@@ -403,14 +411,20 @@ fn command_center_window(
     }
 
     if let Some((_, entity)) = windows.focused()
+        && let Some(layout_position) = windows.layout_position(entity)
         && let Some(size) = windows.size(entity)
         && let Some(mut origin) = windows.origin(entity)
     {
         let center = active_display.bounds().center().x;
         origin.x = center - size.x / 2;
-        reposition_entity(entity, origin, &mut commands);
+        // Directly reposition the strip (bypasses hidden_ratio check).
+        let strip_position = origin - layout_position.0;
+        reposition_entity(
+            active_display.active_strip_entity(),
+            strip_position,
+            &mut commands,
+        );
         window_manager.warp_mouse(active_display.bounds().center());
-        reshuffle_around(entity, &mut commands);
     }
 }
 
@@ -758,6 +772,55 @@ fn equalize_column(
             }
         }
     }
+}
+
+/// Slides the strip so the focused window is fully visible, snapping to the
+/// nearest edge: left-aligned when the window overflows left, right-aligned
+/// when it overflows right. No resize — the window keeps its current size.
+/// Bypasses the lazy-viewport check since the user explicitly asked to reveal.
+#[allow(clippy::needless_pass_by_value)]
+fn snap_window(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    active_display: ActiveDisplay,
+    config: Res<Config>,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| matches!(op, Operation::Snap))
+        .next()
+        .is_none()
+    {
+        return;
+    }
+
+    let Some((_, entity)) = windows.focused() else {
+        return;
+    };
+    let Some(layout_position) = windows.layout_position(entity) else {
+        return;
+    };
+    let Some(mut frame) = windows.moving_frame(entity) else {
+        return;
+    };
+
+    let display_bounds = active_display
+        .display()
+        .actual_display_bounds(active_display.dock(), &config);
+
+    // Clamp the frame into the display and reposition the *strip* (not the
+    // window) so the layout stays consistent.
+    let size = frame.size();
+    frame.min = frame
+        .min
+        .clamp(display_bounds.min, display_bounds.max - size);
+    frame.max = frame.min + size;
+
+    let strip_position = frame.min - layout_position.0;
+    reposition_entity(
+        active_display.active_strip_entity(),
+        strip_position,
+        &mut commands,
+    );
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,7 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "stack" => Operation::Stack(true),
         "unstack" => Operation::Stack(false),
         "nextdisplay" => Operation::ToNextDisplay,
+        "snap" => Operation::Snap,
         _ => {
             return Err(err);
         }
@@ -530,6 +531,17 @@ impl Config {
             .clamp(0.1, 2.0)
     }
 
+    pub fn continuous_swipe(&self) -> bool {
+        let config = self.inner();
+        config
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.continuous)
+            .or(config.options.continuous_swipe)
+            // Default: true (enabled).
+            .unwrap_or(true)
+    }
+
     pub fn swipe_deceleration(&self) -> f64 {
         let config = self.inner();
         config
@@ -562,6 +574,16 @@ impl Config {
             .and_then(|inactive| inactive.dim.as_ref())
             .and_then(|dim| dim.opacity)
             .or(config.options.dim_inactive_windows)
+    }
+
+    /// Returns the allowed hidden fraction of a window before a focus change
+    /// forces it into view. 0.0 = always bring into view (eager),
+    /// 1.0 = never move unless fully invisible (lazy). Default: 0.0.
+    pub fn window_hidden_ratio(&self) -> f64 {
+        self.options()
+            .window_hidden_ratio
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0)
     }
 
     pub fn auto_center(&self) -> bool {
@@ -772,6 +794,10 @@ pub struct MainOptions {
     /// Override the system menubar height (in pixels).
     /// When set, this value is used instead of the height reported by macOS.
     pub menubar_height: Option<u16>,
+    /// How much of a window may be hidden before a focus change forces it into
+    /// view. 0.0 (default) = always bring into view. 1.0 = never move unless
+    /// fully invisible. E.g. 0.5 = tolerate up to 50% hidden.
+    pub window_hidden_ratio: Option<f64>,
 }
 
 pub mod decorations;

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -136,6 +136,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
 pub fn register_triggers(app: &mut bevy::app::App) {
     app.add_observer(triggers::mouse_moved_trigger)
         .add_observer(triggers::mouse_down_trigger)
+        .add_observer(triggers::mouse_up_trigger)
         .add_observer(triggers::mouse_dragged_trigger)
         .add_observer(triggers::workspace_change_trigger)
         .add_observer(triggers::active_workspace_trigger)
@@ -338,6 +339,11 @@ impl RefreshWindowSizes {
 /// Resource to control whether window reshuffling should be skipped.
 #[derive(Resource)]
 pub struct SkipReshuffle(pub bool);
+
+/// Component marking a deferred reshuffle while the mouse button is held down.
+/// Spawned with a `Timeout` so it auto-despawns if the mouse-up event is lost.
+#[derive(Component)]
+pub struct MouseHeldMarker(pub Entity);
 
 /// Resource indicating whether Mission Control is currently active.
 #[derive(PartialEq, Resource)]

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -584,8 +584,23 @@ pub(super) fn reshuffle_layout_strip(
             continue;
         };
 
-        // Expose the window if it's offscreen.
         let size = frame.size();
+
+        // Check how much of the window is hidden. Slivers don't count as
+        // meaningfully visible, so subtract sliver_width from the visible
+        // portion. If the hidden fraction is within the allowed ratio, skip.
+        let hidden_ratio = config.window_hidden_ratio();
+        if hidden_ratio > 0.0 {
+            let visible_width = display_bounds.intersect(frame).width();
+            let meaningful = (visible_width - config.sliver_width()).max(0);
+            let visible_fraction = f64::from(meaningful) / f64::from(frame.width().max(1));
+            let hidden_fraction = 1.0 - visible_fraction;
+            if hidden_fraction <= hidden_ratio {
+                continue;
+            }
+        }
+
+        // Expose the window by clamping it into the viewport.
         frame.min = frame
             .min
             .clamp(display_bounds.min, display_bounds.max - size);

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -64,6 +64,10 @@ impl Configuration<'_> {
         self.config.auto_center()
     }
 
+    pub fn window_hidden_ratio(&self) -> f64 {
+        self.config.window_hidden_ratio()
+    }
+
     /// Returns the configured number of fingers for swipe gestures.
     ///
     /// # Returns

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -258,8 +258,7 @@ where
         })
         .map(|(position, frame)| position.x + frame.width())?;
 
-    // Continous swipe is on by default.
-    let continuous_swipe = config.options().continuous_swipe.is_none_or(|swipe| swipe);
+    let continuous_swipe = config.continuous_swipe();
     let strip_position = |column: Result<Column>| {
         column
             .ok()

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -17,8 +17,8 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
     ActiveDisplayMarker, BProcess, FocusedMarker, FreshMarker, MissionControlActive,
-    NativeFullscreenMarker, RetryFrontSwitch, SpawnWindowTrigger, StrayFocusEvent, Timeout,
-    Unmanaged, WMEventTrigger, WindowDraggedMarker,
+    MouseHeldMarker, NativeFullscreenMarker, RetryFrontSwitch, SpawnWindowTrigger,
+    StrayFocusEvent, Timeout, Unmanaged, WMEventTrigger, WindowDraggedMarker,
 };
 use crate::commands::ON_FULLSCREEN_SPACE;
 use crate::config::{Config, WindowParams};
@@ -146,13 +146,15 @@ pub(super) fn mouse_moved_trigger(
 /// * `main_cid` - The main connection ID resource.
 /// * `mission_control_active` - A resource indicating if Mission Control is active.
 /// * `commands` - Bevy commands to trigger a reshuffle.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub(super) fn mouse_down_trigger(
     trigger: On<WMEventTrigger>,
     windows: Windows,
     active_workspace: Query<(Entity, Option<&Scrolling>), With<ActiveWorkspaceMarker>>,
     window_manager: Res<WindowManager>,
     mission_control_active: Res<MissionControlActive>,
+    config: Configuration,
+    mouse_held: Query<Entity, With<MouseHeldMarker>>,
     mut commands: Commands,
 ) {
     let Event::MouseDown { point } = trigger.event().0 else {
@@ -178,8 +180,39 @@ pub(super) fn mouse_down_trigger(
         }
     }
 
-    reshuffle_around(entity, &mut commands);
+    // Clean up any stale marker from a previous click.
+    for held in &mouse_held {
+        commands.entity(held).despawn();
+    }
+
+    if config.window_hidden_ratio() >= 1.0 {
+        // At max hidden ratio, never reshuffle on click.
+    } else {
+        // Defer reshuffle until mouse-up so the window doesn't shift
+        // mid-click. The Timeout auto-despawns if mouse-up is lost.
+        let timeout = Timeout::new(Duration::from_secs(5), None);
+        commands.spawn((MouseHeldMarker(entity), timeout));
+    }
 }
+
+/// Handles mouse-up events. Triggers the deferred reshuffle so the clicked
+/// window slides into view after the user releases the button.
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn mouse_up_trigger(
+    trigger: On<WMEventTrigger>,
+    mouse_held: Query<(Entity, &MouseHeldMarker)>,
+    mut commands: Commands,
+) {
+    let Event::MouseUp { .. } = trigger.event().0 else {
+        return;
+    };
+    for (held_entity, marker) in &mouse_held {
+        reshuffle_around(marker.0, &mut commands);
+        commands.entity(held_entity).despawn();
+    }
+}
+
+
 
 /// Handles mouse dragged events.
 ///
@@ -660,6 +693,7 @@ pub(super) fn window_focused_trigger(
     windows: Windows,
     active_display: ActiveDisplay,
     mut config: Configuration,
+    mouse_held: Query<&MouseHeldMarker>,
     mut commands: Commands,
 ) {
     const STRAY_FOCUS_RETRY_SEC: u64 = 2;
@@ -703,7 +737,7 @@ pub(super) fn window_focused_trigger(
 
     commands.entity(entity).try_insert(FocusedMarker);
 
-    if !(config.skip_reshuffle() || config.initializing()) {
+    if !(config.skip_reshuffle() || config.initializing() || !mouse_held.is_empty()) {
         if config.auto_center()
             && let Some((_, _, None)) = windows.get_managed(entity)
             && let Some(size) = windows.size(entity)


### PR DESCRIPTION
window_hidden_ratio option (replaces viewport_mode enum):
- Controls how much of a window may be hidden before a focus change forces
  it into view. Continuous 0.0–1.0 instead of a binary eager/lazy toggle.
- 0.0 (default) = always bring into view (eager).
- 1.0 = never move unless fully invisible (lazy).
- Slivers are excluded from the visible width calculation.

window_snap command:
- Slides the strip so the focused window snaps to the nearest screen edge.
  Left-aligned when overflowing left, right-aligned when overflowing right.
  No resize. Bypasses the hidden ratio check.

Mouse-click deferral:
- Clicking a window defers the reshuffle until mouse-up so content doesn't
  shift mid-click. Uses a MouseHeldMarker component with a Timeout that
  auto-despawns after 5s if the mouse-up event is lost.

Focus fixes:
- Keyboard focus (command_move_focus) now explicitly calls reshuffle_around
  to avoid a race where focus-follows-mouse leaves skip_reshuffle set,
  causing the WindowFocused handler to skip the viewport scroll.
- command_center_window now directly repositions the strip instead of going
  through reshuffle_around, which would be skipped at high hidden ratios.
- Added debug logging to window_focused_trigger for diagnosing focus marker
  transitions.

Bug fixes:
- Wire [swipe] continuous option to scroll constraints (was only reading
  the deprecated top-level continuous_swipe key).