### PR TITLE
fix: match swipe touches by identity instead of NSSet iteration order

### DIFF
--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -1,5 +1,6 @@
 use arc_swap::ArcSwap;
 use core::ptr::NonNull;
+use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2_app_kit::{NSEvent, NSEventType, NSTouch, NSTouchPhase};
 use objc2_core_foundation::{CFMachPort, CFRetained, CFRunLoop, kCFRunLoopCommonModes};
@@ -254,10 +255,20 @@ impl InputHandler {
         if fingers.iter().all(|f| f.phase() != NSTouchPhase::Began)
             && let Some(prev) = &self.finger_position
         {
-            let deltas = prev
+            // Match touches by identity rather than relying on NSSet
+            // iteration order, which is not guaranteed to be stable.
+            let deltas = fingers
                 .iter()
-                .zip(&fingers)
-                .map(|(p, c)| p.normalizedPosition().x - c.normalizedPosition().x)
+                .filter_map(|current| {
+                    let id = current.identity();
+                    prev.iter()
+                        .find(|p| {
+                            let p_id = p.identity();
+                            let equal: bool = unsafe { msg_send![&*p_id, isEqual: &*id] };
+                            equal
+                        })
+                        .map(|p| p.normalizedPosition().x - current.normalizedPosition().x)
+                })
                 .collect::<Vec<_>>();
             if deltas.iter().all(|p| p.abs() > SWIPE_THRESHOLD)
                 && let Some(events) = &self.events


### PR DESCRIPTION
## Summary

I was having an issue with the swipe gestures so I just put it in to Claude Code and told it to fix it. This might not be correct but do merge it if it's proper. 

- **Bug**: `handle_swipe` zipped two `NSSet` iterators to pair previous/current touch positions. Since `NSSet` has no guaranteed iteration order, this paired arbitrary fingers together, producing incorrect deltas that cancelled out — making swipe gestures non-functional.
- **Fix**: Match each touch to its counterpart across frames using `NSTouch.identity()` with `isEqual:`, ensuring correct per-finger delta computation.

## Test plan

- [x] `cargo test` — all 28 tests pass
- [x] `cargo check` / `cargo build --release` — compiles cleanly
- [ ] Manual: verify 3-finger and 4-finger swipe gestures scroll the window strip correctly
- [ ] Manual: verify swipe direction (Natural vs Reversed) still works as configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)