### PR TITLE
feat: support compound modifier keys for scroll wheel swiping

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,7 +60,7 @@ Configure trackpad gestures and scroll-wheel window sliding.
 ### `[swipe.scroll]`
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `modifier` | String | `"alt"` | Modifier key required to slide windows with the scroll wheel: `"alt"` or `"cmd"`. |
+| `modifier` | String | `"alt"` | Modifier key(s) required to slide windows with the scroll wheel: `"alt"`, `"cmd"`, `"alt + cmd"`, `"ctrl + alt + cmd"`, etc. |
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -557,14 +557,14 @@ impl Config {
             .clamp(1.0, 10.0)
     }
 
-    pub fn swipe_scroll_modifier(&self) -> swipe::SwipeScrollModifier {
+    pub fn swipe_scroll_modifier(&self) -> Modifiers {
         let config = self.inner();
         config
             .swipe
             .as_ref()
             .and_then(|swipe| swipe.scroll.as_ref())
-            .and_then(|scroll| scroll.modifier.clone())
-            .unwrap_or(swipe::SwipeScrollModifier::Alt)
+            .and_then(|scroll| scroll.modifier)
+            .unwrap_or(Modifiers::ALT)
     }
 
     pub fn window_dim_ratio(&self, is_dark: bool) -> Option<f32> {

--- a/src/config/swipe.rs
+++ b/src/config/swipe.rs
@@ -1,15 +1,11 @@
 use serde::Deserialize;
 
+use crate::platform::Modifiers;
+
 #[derive(Clone, Debug, Deserialize)]
 pub enum SwipeGestureDirection {
     Natural,
     Reversed,
-}
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum SwipeScrollModifier {
-    Alt,
-    Cmd,
 }
 
 #[derive(Deserialize, Clone, Debug, Default)]
@@ -42,6 +38,32 @@ pub struct GestureOptions {
 
 #[derive(Deserialize, Clone, Debug, Default)]
 pub struct ScrollOptions {
-    /// The modifier key required for scroll wheel swiping.
-    pub modifier: Option<SwipeScrollModifier>,
+    /// Modifier key(s) required for scroll wheel swiping.
+    /// Accepts the same format as keybindings: "alt", "cmd", "alt + cmd", etc.
+    #[serde(default, deserialize_with = "deserialize_modifier")]
+    pub modifier: Option<Modifiers>,
+}
+
+fn deserialize_modifier<'de, D>(deserializer: D) -> Result<Option<Modifiers>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(s) = Option::<String>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    let mut out = Modifiers::empty();
+    for part in s.split('+').map(str::trim) {
+        out |= match part {
+            "alt" => Modifiers::ALT,
+            "shift" => Modifiers::SHIFT,
+            "cmd" => Modifiers::CMD,
+            "ctrl" => Modifiers::CTRL,
+            other => {
+                return Err(serde::de::Error::custom(format!(
+                    "invalid modifier: {other}"
+                )));
+            }
+        };
+    }
+    Ok(Some(out))
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -19,7 +19,6 @@ use stdext::function_name;
 use tracing::{error, info};
 
 use crate::config::Config;
-use crate::config::swipe::SwipeScrollModifier;
 use crate::errors::{Error, Result};
 use crate::events::{Event, EventSender};
 use crate::platform::Modifiers;
@@ -235,10 +234,7 @@ impl InputHandler {
         let flags = CGEvent::flags(Some(event));
         let modifiers = get_modifiers(flags);
 
-        let target_modifier = match self.config.swipe_scroll_modifier() {
-            SwipeScrollModifier::Alt => Modifiers::ALT,
-            SwipeScrollModifier::Cmd => Modifiers::CMD,
-        };
+        let target_modifier = self.config.swipe_scroll_modifier();
 
         // Only intercept if the configured modifier is held
         if !modifiers.contains(target_modifier) {


### PR DESCRIPTION
Helps avoid false triggers when your workflow already relies on alt or cmd for other things. 

For example, holding cmd to cycle through find matches with Cmd+G while scrolling would
 unintentionally slide windows around.