### PR TITLE
fix: Recover focus after app termination

### DIFF
--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -270,12 +270,7 @@ pub(super) fn window_focused_trigger(
         column.move_to_front(entity);
     }
 
-    if windows
-        .focused()
-        .is_some_and(|(window, _)| window.id() != window_id)
-        && let Some((_, entity)) = windows.find(window_id)
-        && let Ok(mut entity_commands) = commands.get_entity(entity)
-    {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
         entity_commands.try_insert(FocusedMarker);
         debug!("window {} ({entity}) focused.", window.id());
     }


### PR DESCRIPTION
After quitting an app, keybindings and the border sometimes stop working permanently. Clicking windows still works but keyboard shortcuts do nothing. Restarting paneru was the only fix.

When an app terminates, the process entity gets cascade-despawned along with all its windows. If the focused window was one of them, `FocusedMarker` is gone and `windows.focused()` returns `None`.

The `window_focused_trigger` handler had a redundant guard before inserting `FocusedMarker`:

```rust
if windows.focused().is_some_and(|(w, _)| w.id() != window_id)
    && let Some((_, entity)) = windows.find(window_id)
```

The early return at L234 already handles the "same window re-focused" case, so by the time we reach the insert, `focused()` is guaranteed to be either `None` or a different window. The guard was always true and the `find()` was a redundant scan since the entity was already resolved by `find_parent` earlier in the function.

Removing both simplifies the code and fixes the bug: `None.is_some_and(...)` was always `false`, which is what prevented focus recovery.

## Test plan
- Focus a window, quit that app
- Verify focus moves to the next window (border visible, keybindings work)
- Repeat a few times, make sure focus doesnt get stuck