### PR TITLE
fix: Update passthrough keybindings before early-return in window_foc…

### DIFF
--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -231,12 +231,6 @@ pub(super) fn window_focused_trigger(
         return;
     };
 
-    if let Some((window, _)) = windows.focused()
-        && window.id() == window_id
-    {
-        return;
-    }
-
     let Some((window, entity, parent)) = windows.find_parent(window_id) else {
         let timeout = Timeout::new(Duration::from_secs(STRAY_FOCUS_RETRY_SEC), None);
         commands.spawn((timeout, StrayFocusEvent(window_id)));
@@ -247,6 +241,17 @@ pub(super) fn window_focused_trigger(
         warn!("Unable to get parent for window {}.", window.id());
         return;
     };
+
+    // Always keep passthrough in sync. An internal focus_entity call races
+    // with the OS WindowFocused event; without this the passthrough keys
+    // remain stale from a previously focused window.
+    update_passthrough(window, app, config.config());
+
+    if let Some((focused, _)) = windows.focused()
+        && focused.id() == window_id
+    {
+        return;
+    }
 
     // Guard against stale focus events. Without these checks, delayed
     // events (e.g. from RetryFrontSwitch or dont_focus re-assertions)
@@ -274,8 +279,6 @@ pub(super) fn window_focused_trigger(
         entity_commands.try_insert(FocusedMarker);
         debug!("window {} ({entity}) focused.", window.id());
     }
-
-    update_passthrough(window, app, config.config());
 }
 
 /// Handles Mission Control events, updating the `MissionControlActive` resource.


### PR DESCRIPTION
…used_trigger

When focus moves via keyboard (focus_entity), FocusedMarker is set before the OS WindowFocused event arrives. The early-return guard in window_focused_trigger then skips update_passthrough, leaving stale passthrough keys from a previously focused window.

This causes keybindings to be silently swallowed: e.g. after focusing away from a window with bindings_passthrough (like neovide with ctrl-h/l), the passthrough remains active on the newly focused window, preventing paneru from intercepting those keys.

Move update_passthrough before the early-return so it always runs when the OS confirms focus, regardless of whether FocusedMarker is already set.