### PR TITLE
fix: pass XDG_CONFIG_HOME to launchd service environment.

### DIFF
--- a/assets/launchd.plist
+++ b/assets/launchd.plist
@@ -21,6 +21,8 @@
     <dict>
       <key>NO_COLOR</key>
       <string>1</string>
+      <key>XDG_CONFIG_HOME</key>
+      <string>{xdg_config_home}</string>
     </dict>
     <key>RunAtLoad</key>
     <true />

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,7 @@ pub fn discover_configuration_file() -> Option<PathBuf> {
             .map(|h| PathBuf::from(h).join(".paneru.toml")),
         env::var("XDG_CONFIG_HOME")
             .ok()
+            .or_else(|| env::var("HOME").ok().map(|h| format!("{h}/.config")))
             .map(|x| PathBuf::from(x).join("paneru/paneru.toml")),
     ];
 

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -19,6 +19,8 @@ pub struct Service {
     pub raw: launchctl::Service,
     /// The absolute path to the `paneru` executable.
     pub bin_path: PathBuf,
+    /// The user's home directory.
+    home_dir: PathBuf,
 }
 
 impl Service {
@@ -33,6 +35,10 @@ impl Service {
     ///
     /// `Ok(Self)` if the service is created successfully, otherwise `Err(Error)` if the executable path or home directory cannot be found.
     pub fn try_new(name: &str) -> Result<Self> {
+        let home_dir = env::home_dir().ok_or(Error::new(
+            ErrorKind::NotFound,
+            "Cannot find home directory.",
+        ))?;
         Ok(Self {
             bin_path: exe_path().ok_or(Error::new(
                 ErrorKind::NotFound,
@@ -43,14 +49,10 @@ impl Service {
                 .uid(unsafe { libc::getuid() }.to_string())
                 .plist_path(format!(
                     "{home}/Library/LaunchAgents/{name}.plist",
-                    home = env::home_dir()
-                        .ok_or(Error::new(
-                            ErrorKind::NotFound,
-                            "Cannot find home directory.",
-                        ))?
-                        .display()
+                    home = home_dir.display()
                 ))
                 .build(),
+            home_dir,
         })
     }
 
@@ -175,12 +177,15 @@ impl Service {
     /// This string is formatted with the service name, executable path, and log paths.
     #[must_use]
     pub fn launchd_plist(&self) -> String {
+        let xdg_config_home = env::var("XDG_CONFIG_HOME")
+            .unwrap_or_else(|_| format!("{}/.config", self.home_dir.display()));
         format!(
             include_str!("../../assets/launchd.plist"),
             name = self.raw.name,
             bin_path = self.bin_path.display(),
             out_log_path = self.raw.out_log_path,
             error_log_path = self.raw.error_log_path,
+            xdg_config_home = xdg_config_home,
         )
     }
 }


### PR DESCRIPTION
  Paneru couldn't find user config when running as a launchd service because launchd doesn't
  inherit shell environment variables like `XDG_CONFIG_HOME`.

**What changed**

  - launchd plist — `XDG_CONFIG_HOME` is now written into the service's environment at install
   time, so the service sees the same value your shell had.
  - Config discovery — When `XDG_CONFIG_HOME` isn't set, we now fall back to `$HOME/.config`
  per the [XDG spec](https://specifications.freedesktop.org/basedir-spec/latest/). This means `~/.config/paneru/paneru.toml` is always checked, even outside launchd.

  Both fixes are needed: the plist captures your real `XDG_CONFIG_HOME` (which could be a custom
  path), while the fallback makes sure the default XDG location always works.