### PR TITLE
fix: Undim windows on quit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "bitflags 2.11.0",
  "chrono",
  "clap",
+ "ctrlc",
  "derive_more",
  "embed_plist",
  "launchctl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,4 @@ stdext = "0.3.3"
 toml = "1.1.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+ctrlc = { version = "3.5.2", features = ["termination"] }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -856,17 +856,17 @@ pub fn stack_windows_handler(
 ///
 /// # Arguments
 ///
-/// * `trigger` - The `On<CommandTrigger>` event trigger containing the command to process.
+/// * `messages` - Bevy's `MessageReader`, containing events to process.
 /// * `windows` - A query for `Window` components, their `Entity`, and whether they have the `Unmanaged` marker.
-/// * `active_display` - A mutable reference to the `ActiveDisplayMut` resource.
 /// * `window_manager` - The `WindowManager` resource for interacting with the window management logic.
-/// * `commands` - Bevy commands to trigger events and modify entities.
 /// * `config` - The `Config` resource, containing application settings.
 #[instrument(level = Level::DEBUG, skip_all)]
 #[allow(clippy::needless_pass_by_value)]
 pub fn command_quit_handler(
     mut messages: MessageReader<Event>,
+    windows: Windows,
     window_manager: Res<WindowManager>,
+    config: Res<Config>,
 ) {
     if messages.read().any(|event| {
         matches!(
@@ -876,6 +876,14 @@ pub fn command_quit_handler(
             }
         )
     }) {
+        let window_list = windows
+            .all_iter()
+            .map(|(window, _, _)| window.id())
+            .collect::<Vec<_>>();
+        if config.window_dim_ratio(false).is_some() {
+            // we don't need dim ratio since dimming is just set as 0.0
+            window_manager.dim_windows(&window_list, 0.0);
+        }
         _ = window_manager.quit();
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -856,17 +856,17 @@ pub fn stack_windows_handler(
 ///
 /// # Arguments
 ///
-/// * `messages` - Bevy's `MessageReader`, containing events to process.
+/// * `trigger` - The `On<CommandTrigger>` event trigger containing the command to process.
 /// * `windows` - A query for `Window` components, their `Entity`, and whether they have the `Unmanaged` marker.
+/// * `active_display` - A mutable reference to the `ActiveDisplayMut` resource.
 /// * `window_manager` - The `WindowManager` resource for interacting with the window management logic.
+/// * `commands` - Bevy commands to trigger events and modify entities.
 /// * `config` - The `Config` resource, containing application settings.
 #[instrument(level = Level::DEBUG, skip_all)]
 #[allow(clippy::needless_pass_by_value)]
 pub fn command_quit_handler(
     mut messages: MessageReader<Event>,
-    windows: Windows,
     window_manager: Res<WindowManager>,
-    config: Res<Config>,
 ) {
     if messages.read().any(|event| {
         matches!(
@@ -876,14 +876,6 @@ pub fn command_quit_handler(
             }
         )
     }) {
-        let window_list = windows
-            .all_iter()
-            .map(|(window, _, _)| window.id())
-            .collect::<Vec<_>>();
-        if config.window_dim_ratio(false).is_some() {
-            // we don't need dim ratio since dimming is just set as 0.0
-            window_manager.dim_windows(&window_list, 0.0);
-        }
         _ = window_manager.quit();
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1198,6 +1198,7 @@ pub(super) fn cleanup_on_exit(
     window_manager: Res<WindowManager>,
 ) {
     for _ in exit_events.read() {
+        info!("Cleaning up before exit");
         let ids = windows
             .iter()
             .map(|(window, _)| window.id())

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,12 @@ fn main() -> Result<()> {
     match subcmd {
         SubCmd::Launch => {
             let (sender, receiver) = EventSender::new();
+            let sender_c = sender.clone();
+            // bevy's `TerminalCtrlCHandlerPlugin` was not fast enough. maybe because of its use of `Relaxed` atomic variable?
+            ctrlc::set_handler(move || {
+                let _ = sender_c.send(events::Event::Exit); // just drop the err. we are exiting anyway.
+            })
+            .expect("setting Ctrl-C handler should succeed");
             CommandReader::new(sender.clone()).start();
             match setup_bevy_app(sender, receiver) {
                 Ok(mut app) => {


### PR DESCRIPTION
Should be very straightforward.
Although as I write this I noticed that changing config should also update dimming. Which is not as big of an issue as not undimming on quit, so maybe later.