### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Note, that you will need to grant acessibility priviledge to the binary.
 If you are using Homebrew, you can install from the formula with:
 
 ```shell
-$ brew install karinushka/paneru/paneru
+$ brew install paneru
 ```
 
 Or by first adding the tap and then installing by name:


### PR DESCRIPTION
Update the installation instructions for Homebrew. Paneru is now [available](https://github.com/Homebrew/homebrew-core/commit/5511030be7f81d777189dca64cc8033f63c11796) without the need for a custom Tap.