### PR TITLE
use xdg crate to discover config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,6 +2572,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "xdg",
 ]
 
 [[package]]
@@ -4084,6 +4085,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ stdext = "0.3.3"
 toml = "1.1.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+xdg = "^3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use stdext::function_name;
 use tracing::{error, info, warn};
+use xdg;
 
 use self::decorations::BorderRadiusOption;
 use self::swipe::SwipeGestureDirection;
@@ -65,15 +66,15 @@ pub fn discover_configuration_file() -> Option<PathBuf> {
         env::var("HOME")
             .ok()
             .map(|h| PathBuf::from(h).join(".paneru.toml")),
-        env::var("XDG_CONFIG_HOME")
-            .ok()
-            .or_else(|| env::var("HOME").ok().map(|h| format!("{h}/.config")))
-            .map(|x| PathBuf::from(x).join("paneru/paneru.toml")),
     ];
+
+    let xdg_dirs = xdg::BaseDirectories::with_prefix("paneru");
+    let xdg_config_paths = xdg_dirs.find_config_files("paneru.toml");
 
     standard_paths
         .into_iter()
         .flatten()
+        .chain(xdg_config_paths)
         .find(|path| path.exists())
 }
 


### PR DESCRIPTION

Rather than figuring out how to inject `XDG_CONFIG_HOME` into the `launchd` environment, let me suggest using a crate that already handles this situation correctly.

When using the current release of `paneru` (v0.4.0 at time of writing), when I created a config file at `~/.config/paneru/paneru.toml`, the service panicked at launch:
```
$ RUST_BACKTRACE=1 paneru
thread 'main' (176157) panicked at src/config.rs:39:9:
paneru::config::CONFIGURATION_FILE::{{closure}}::{{closure}}: Configuration file not found.
Tried: $PANERU_CONFIG, $HOME/.paneru, $HOME/.paneru.toml, $XDG_CONFIG_HOME/paneru/paneru.toml
stack backtrace:
    0: __rustc::rust_begin_unwind
    1: core::panicking::panic_fmt
    2: paneru::config::CONFIGURATION_FILE::{{closure}}::{{closure}}
    3: core::ops::function::FnOnce::call_once
    4: std::sync::once::Once::call_once_force::{{closure}}
    5: std::sys::sync::once::queue::Once::call
    6: paneru::ecs::setup_bevy_app
    7: paneru::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

When running the binary built from this branch, that crash no longer occurs.

Fixes #64, #80