### PR TITLE
fix: don't tile or reposition windows during init

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -111,14 +111,20 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 scroll::swiping_timeout,
             )
                 .chain(),
-            layout::layout_sizes_changed,
+            // Wait for finish_setup before tiling: until then every window
+            // sits in the active strip regardless of its real display.
             (
-                layout::layout_strip_changed,
-                layout::reshuffle_layout_strip,
-                layout::position_layout_strips,
-                layout::position_layout_windows,
+                layout::layout_sizes_changed,
+                (
+                    layout::layout_strip_changed,
+                    layout::reshuffle_layout_strip,
+                    layout::position_layout_strips,
+                    layout::position_layout_windows,
+                )
+                    .chain(),
             )
-                .chain(),
+                .after(systems::finish_setup)
+                .run_if(not(resource_exists::<Initializing>)),
         ),
     );
     app.add_systems(
@@ -135,10 +141,14 @@ pub fn register_systems(app: &mut bevy::app::App) {
     app.add_systems(
         PostUpdate,
         (
-            (systems::animate_entities, systems::commit_window_position).chain(),
+            (
+                systems::animate_entities,
+                systems::commit_window_position.run_if(not(resource_exists::<Initializing>)),
+            )
+                .chain(),
             (
                 systems::animate_resize_entities,
-                systems::commit_window_size,
+                systems::commit_window_size.run_if(not(resource_exists::<Initializing>)),
             )
                 .chain(),
             (

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -524,36 +524,41 @@ pub(super) fn window_unmanaged_trigger(
 
     let properties = WindowProperties::new(app, window, config.config());
 
-    if let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
-        let x = (f64::from(display_bounds.width()) * rx) as i32;
-        let y = (f64::from(display_bounds.height()) * ry) as i32;
-        let w = (f64::from(display_bounds.width()) * rw) as i32;
-        let h = (f64::from(display_bounds.height()) * rh) as i32;
-        reposition_entity(entity, Origin::new(x, y), &mut commands);
-        resize_entity(entity, Size::new(w, h), &mut commands);
-    } else {
-        let max_width = display_bounds.width() * UNMANAGED_MAX_SCREEN_RATIO_NUM
-            / UNMANAGED_MAX_SCREEN_RATIO_DEN;
-        let max_height = display_bounds.height() * UNMANAGED_MAX_SCREEN_RATIO_NUM
-            / UNMANAGED_MAX_SCREEN_RATIO_DEN;
-        let new_width = frame.width().min(max_width);
-        let new_height = frame.height().min(max_height);
+    // Skip the active-display reposition/resize during init; the strip
+    // removal below still has to run.
+    if !config.initializing() {
+        if let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
+            let x = (f64::from(display_bounds.width()) * rx) as i32;
+            let y = (f64::from(display_bounds.height()) * ry) as i32;
+            let w = (f64::from(display_bounds.width()) * rw) as i32;
+            let h = (f64::from(display_bounds.height()) * rh) as i32;
+            reposition_entity(entity, Origin::new(x, y), &mut commands);
+            resize_entity(entity, Size::new(w, h), &mut commands);
+        } else {
+            let max_width = display_bounds.width() * UNMANAGED_MAX_SCREEN_RATIO_NUM
+                / UNMANAGED_MAX_SCREEN_RATIO_DEN;
+            let max_height = display_bounds.height() * UNMANAGED_MAX_SCREEN_RATIO_NUM
+                / UNMANAGED_MAX_SCREEN_RATIO_DEN;
+            let new_width = frame.width().min(max_width);
+            let new_height = frame.height().min(max_height);
 
-        let mut target_frame =
-            IRect::from_corners(frame.min, frame.min + Origin::new(new_width, new_height));
-        target_frame = clamp_origin_to_bounds(target_frame, target_frame.size(), display_bounds);
-        target_frame =
-            offset_frame_within_bounds(target_frame, display_bounds, UNMANAGED_POP_OFFSET);
+            let mut target_frame =
+                IRect::from_corners(frame.min, frame.min + Origin::new(new_width, new_height));
+            target_frame =
+                clamp_origin_to_bounds(target_frame, target_frame.size(), display_bounds);
+            target_frame =
+                offset_frame_within_bounds(target_frame, display_bounds, UNMANAGED_POP_OFFSET);
 
-        if target_frame.size() != frame.size() {
-            resize_entity(
-                entity,
-                Size::new(target_frame.width(), target_frame.height()),
-                &mut commands,
-            );
-        }
-        if target_frame.min != frame.min {
-            reposition_entity(entity, target_frame.min, &mut commands);
+            if target_frame.size() != frame.size() {
+                resize_entity(
+                    entity,
+                    Size::new(target_frame.width(), target_frame.height()),
+                    &mut commands,
+                );
+            }
+            if target_frame.min != frame.min {
+                reposition_entity(entity, target_frame.min, &mut commands);
+            }
         }
     }
 
@@ -606,15 +611,19 @@ pub(super) fn window_managed_trigger(
     mut active_display: ActiveDisplayMut,
     windows: Windows,
     apps: Query<(Entity, &Application)>,
-    config: Res<Config>,
+    config: Configuration,
     mut commands: Commands,
 ) {
+    // finish_setup handles the initial strip assignment during init.
+    if config.initializing() {
+        return;
+    }
     let entity = trigger.event().entity;
 
     debug!("Entity {entity} is managed again.");
     let display_bounds = active_display
         .display()
-        .actual_display_bounds(active_display.dock(), &config);
+        .actual_display_bounds(active_display.dock(), config.config());
     let active_strip = active_display.active_strip();
 
     if let Some(window) = windows.get(entity)
@@ -622,10 +631,10 @@ pub(super) fn window_managed_trigger(
             .find_parent(window.id())
             .and_then(|(_, _, parent)| apps.get(parent).ok())
     {
-        let properties = WindowProperties::new(app, window, &config);
+        let properties = WindowProperties::new(app, window, config.config());
 
         if let Some(width_ratio) = properties.width_ratio() {
-            let (_, pad_right, _, pad_left) = config.edge_padding();
+            let (_, pad_right, _, pad_left) = config.config().edge_padding();
             let padded_width = display_bounds.width() - pad_left - pad_right;
             let width = (f64::from(padded_width) * width_ratio).round() as i32;
             let height = display_bounds.height();
@@ -805,7 +814,7 @@ pub(super) fn spawn_window_trigger(
             &mut window,
             &mut active_display,
             &properties.params,
-            config.config(),
+            &config,
         );
 
         // update_frame expands the OS rect by the per-window padding, so calling it *after*
@@ -858,7 +867,7 @@ fn apply_window_defaults(
     window: &mut Window,
     active_display: &mut ActiveDisplayMut,
     properties: &[WindowParams],
-    config: &Config,
+    config: &Configuration,
 ) {
     let floating = properties
         .iter()
@@ -877,7 +886,10 @@ fn apply_window_defaults(
         window.set_padding(WindowPadding::Horizontal(padding.clamp(0, 50)));
     }
     if floating {
-        if let Some((rx, ry, rw, rh)) = properties.iter().find_map(WindowParams::grid_ratios) {
+        // Skip grid_ratios during init: we don't know this window's display.
+        if !config.initializing()
+            && let Some((rx, ry, rw, rh)) = properties.iter().find_map(WindowParams::grid_ratios)
+        {
             let bounds = active_display.bounds();
             let x = (f64::from(bounds.width()) * rx) as i32;
             let y = (f64::from(bounds.height()) * ry) as i32;
@@ -891,10 +903,12 @@ fn apply_window_defaults(
 
     // Apply configured width AFTER update_frame so it isn't overwritten.
     // Use padded display width (matching window_resize command behavior).
+    // Safe during init: this only resizes, it doesn't reposition, so a
+    // window on an inactive display stays put.
     if let Some(width) = properties.iter().find_map(|props| props.width) {
         _ = window.update_frame().inspect_err(|err| error!("{err}"));
         let bounds = active_display.bounds();
-        let (_, pad_right, _, pad_left) = config.edge_padding();
+        let (_, pad_right, _, pad_left) = config.config().edge_padding();
         let padded_width = bounds.width() - pad_left - pad_right;
         let new_width = (f64::from(padded_width) * width).round() as i32;
         let height = window.frame().height();

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -10,7 +10,7 @@ use crate::ecs::Timeout;
 use crate::ecs::layout::LayoutStrip;
 use crate::events::Event;
 use crate::manager::{Display, Origin, Size, Window};
-use crate::{assert_not_on_workspace, assert_on_workspace, assert_window_size};
+use crate::{assert_not_on_workspace, assert_on_workspace, assert_window_at, assert_window_size};
 
 use super::*;
 
@@ -349,6 +349,74 @@ fn test_send_next_display_stays_on_source() {
                 EXT_DISPLAY_ID,
                 "active display should still be the external display after sendnextdisplay"
             );
+        })
+        .run(commands);
+}
+
+/// Regression test: paneru's init pass must not drag windows that live on
+/// inactive displays onto the active display. `apply_window_properties`
+/// initially appends every observed window to the active strip; if the
+/// layout writers run before `finish_setup` has reassigned them, they
+/// cache active-display coordinates into `Position` and `commit_window_position`
+/// later pushes those to macOS, moving the windows.
+#[test]
+fn test_init_keeps_windows_on_their_real_displays() {
+    // Internal (test) display is active. Window 100 lives on the external
+    // display's space, window 200 lives on the active display's space.
+    let active_display = Arc::new(AtomicU32::new(TEST_DISPLAY_ID));
+
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+
+    let eq1 = internal_queue.clone();
+    let eq2 = internal_queue.clone();
+    let app1 = mock_app.clone();
+    let app2 = mock_app;
+    let ext_origin = Origin::new(0, -EXT_DISPLAY_HEIGHT + TEST_MENUBAR_HEIGHT);
+    let int_origin = Origin::new(0, TEST_MENUBAR_HEIGHT);
+    let windows: TestWindowSpawner = Box::new(move |workspace_id| {
+        if workspace_id == EXT_WORKSPACE_ID {
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            vec![Window::new(Box::new(MockWindow::new(
+                100,
+                IRect::from_corners(ext_origin, ext_origin + size),
+                eq1.clone(),
+                app1.clone(),
+            )))]
+        } else if workspace_id == TEST_WORKSPACE_ID {
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            vec![Window::new(Box::new(MockWindow::new(
+                200,
+                IRect::from_corners(int_origin, int_origin + size),
+                eq2.clone(),
+                app2.clone(),
+            )))]
+        } else {
+            vec![]
+        }
+    });
+
+    let wm = TwoDisplayMock {
+        windows,
+        active_display,
+    };
+    harness = harness.with_wm(wm);
+
+    let commands = vec![Event::Command {
+        command: Command::PrintState,
+    }];
+
+    harness
+        .on_iteration(0, move |world| {
+            assert_on_workspace!(world, 100, EXT_WORKSPACE_ID);
+            assert_not_on_workspace!(world, 100, TEST_WORKSPACE_ID);
+            assert_on_workspace!(world, 200, TEST_WORKSPACE_ID);
+            assert_not_on_workspace!(world, 200, EXT_WORKSPACE_ID);
+            // The OS frame for window 100 must stay within the external
+            // display's vertical bounds (negative y); if init moved it
+            // onto the active display the frame would land at y >= 0.
+            assert_window_at!(world, 100, ext_origin.x, ext_origin.y);
         })
         .run(commands);
 }


### PR DESCRIPTION
On a multi-monitor setup, paneru launching with windows on inactive displays drags every window onto the active display within ~120ms. Fires on every cold start.

`apply_window_properties` appends every new window to `active_display.active_strip()` regardless of physical display. `finish_setup` later reassigns each window to its real strip from `windows_in_workspace`. The problem is timing: the layout writers run within the same tick using the pre-`finish_setup` strips, cache active-display coordinates into each window's `Position`, and the next `commit_window_position` pushes those to macOS.

Gate the layout writers and the macOS commit systems on `!Initializing`, and order the layout group `.after(finish_setup)` so it only sees corrected strip membership. After init the layout chain runs once with the right inputs and commits in a single pass.

Three other init-time paths bypass the ECS layer and call `window.reposition` / `window.resize` directly against `active_display.bounds()`. Same root issue. Gate them too:

- `apply_window_defaults` (floating + `grid_ratios`, configured `width`)
- `window_unmanaged_trigger` (clamping a new floating window into the active viewport)
- `window_managed_trigger` (reachable via `WindowDeminimized` / `ApplicationVisible`)

Strip removal in `window_unmanaged_trigger` still runs during init so floating windows aren't double-tracked.

Test plan:
- Manual: lid closed, LC49 (active) + external monitor, windows on both. Restart paneru. Each monitor keeps its windows.
- `cargo build`, `cargo clippy --all-targets`, `cargo test` clean (61 tests pass).