### PR TITLE
feat: add window_resize_cycle option

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -27,6 +27,7 @@ General behavior settings for the window manager.
 | `sliver_width` | Integer (px) | `5` | Horizontal width of off-screen windows kept visible. |
 | `menubar_height` | Integer (px) | *Auto* | Manually override the detected macOS menubar height. |
 | `window_hidden_ratio` | Float (0.0–1.0) | `0.0` | How much of a window can be hidden before it's forced into view on focus change. `0.0` = eager, `1.0` = lazy. |
+| `window_resize_cycle` | Boolean | `true` | If disabled, `window_resize` and `window_shrink` stop at the largest/smallest preset instead of cycling back. |
 
 ---
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -448,19 +448,24 @@ fn resize_window(
     let current_ratio = f64::from(frame.width()) / f64::from(padded_width);
     let widths = config.preset_column_widths();
     let fallback = *widths.first().unwrap_or(&0.5);
+    let cycle = config.window_resize_cycle();
     let next_ratio = match direction {
-        ResizeDirection::Grow => widths
-            .iter()
-            .copied()
-            .find(|&r| r > current_ratio + 0.05)
-            .unwrap_or(fallback),
-        ResizeDirection::Shrink => widths
-            .iter()
-            .rev()
-            .copied()
-            .find(|&r| r < current_ratio - 0.05)
-            .unwrap_or_else(|| *widths.last().unwrap_or(&fallback)),
-    };
+    ResizeDirection::Grow => widths
+        .iter()
+        .copied()
+        .find(|&r| r > current_ratio + 0.05)
+        .unwrap_or_else(|| {
+            if cycle { fallback } else { *widths.last().unwrap_or(&fallback) }
+        }),
+    ResizeDirection::Shrink => widths
+        .iter()
+        .rev()
+        .copied()
+        .find(|&r| r < current_ratio - 0.05)
+        .unwrap_or_else(|| {
+            if cycle { *widths.last().unwrap_or(&fallback) } else { fallback }
+        }),
+};
 
     let new_width = (next_ratio * f64::from(padded_width)).round() as i32;
     let size = Size::new(new_width, frame.height());

--- a/src/config.rs
+++ b/src/config.rs
@@ -627,6 +627,12 @@ impl Config {
             .clamp(0.0, 1.0)
     }
 
+    pub fn window_resize_cycle(&self) -> bool {
+    self.options()
+        .window_resize_cycle
+        .unwrap_or(true)
+    }
+
     pub fn auto_center(&self) -> bool {
         self.options().auto_center.is_some_and(|center| center)
     }
@@ -845,6 +851,10 @@ pub struct MainOptions {
     /// view. 0.0 (default) = always bring into view. 1.0 = never move unless
     /// fully invisible. E.g. 0.5 = tolerate up to 50% hidden.
     pub window_hidden_ratio: Option<f64>,
+
+    /// Whether grow/shrink cycles back when reaching the end of presets.
+    /// Default: true (cycles). Set to false to stop at the limits.
+    pub window_resize_cycle: Option<bool>,
 }
 
 /// Returns a default set of column widths.


### PR DESCRIPTION
When cycling through preset widths with `window_resize` and `window_shrink`, the commands currently wrap around when reaching the last/first preset. This adds a `window_resize_cycle` option to control this behavior.

When set to `false`, grow stops at the largest preset and shrink stops at the smallest instead of cycling back.

**Usage:**
```toml
[options]
window_resize_cycle = false  # default: true
```