### PR TITLE
feat(api): add JSON state and absolute workspaces

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -186,6 +186,9 @@ $ paneru send-cmd window virtualmovenum 3
 $ paneru send-cmd window virtualsendnum 3
 ```
 
+See [QUERY_AND_SUBSCRIBE_FORMAT.md](QUERY_AND_SUBSCRIBE_FORMAT.md) for the
+structured `paneru query` responses and `paneru subscribe` event stream.
+
 ---
 
 ## 6. Window Rules (`[windows]`)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -147,8 +147,11 @@ Virtual workspaces can also be navigated using trackpad gestures. If `[swipe.ges
 | Action | Description |
 | :--- | :--- |
 | `window_virtual_north` / `_south` | Switch to the previous/next virtual workspace (row of windows). |
+| `window_virtualnum_<number>` | Switch directly to the numbered virtual workspace. |
 | `window_virtualmove_north` / `_south` | Move currently focused window to the previous/next virtual workspace and follow it. |
 | `window_virtualsend_north` / `_south` | Move currently focused window to the previous/next virtual workspace but stay on the current one. |
+| `window_virtualmovenum_<number>` | Move currently focused window to the numbered virtual workspace and follow it. |
+| `window_virtualsendnum_<number>` | Move currently focused window to the numbered virtual workspace but stay on the current one. |
 
 
 **Example:**
@@ -158,6 +161,15 @@ window_virtual_north = "cmd + shift - k"
 window_virtual_south = "cmd + shift - j"
 window_virtualmove_north = "cmd + alt - k"
 window_virtualmove_south = "cmd + alt - j"
+window_virtualnum_1 = "cmd + alt - 1"
+window_virtualnum_2 = "cmd + alt - 2"
+window_virtualnum_3 = "cmd + alt - 3"
+window_virtualmovenum_1 = "cmd + alt + ctrl - 1"
+window_virtualmovenum_2 = "cmd + alt + ctrl - 2"
+window_virtualmovenum_3 = "cmd + alt + ctrl - 3"
+window_virtualsendnum_1 = "cmd + alt + shift - 1"
+window_virtualsendnum_2 = "cmd + alt + shift - 2"
+window_virtualsendnum_3 = "cmd + alt + shift - 3"
 ```
 
 **Example command line:**
@@ -166,6 +178,12 @@ window_virtualmove_south = "cmd + alt - j"
 $ paneru send-cmd window virtual north
 # Move the current window to the next virtual workspace.
 $ paneru send-cmd window virtualmove south
+# Move directly to virtual workspace 3.
+$ paneru send-cmd window virtualnum 3
+# Move the current window to virtual workspace 3 and follow it.
+$ paneru send-cmd window virtualmovenum 3
+# Send the current window to virtual workspace 3 and stay here.
+$ paneru send-cmd window virtualsendnum 3
 ```
 
 ---

--- a/QUERY_AND_SUBSCRIBE_FORMAT.md
+++ b/QUERY_AND_SUBSCRIBE_FORMAT.md
@@ -1,0 +1,226 @@
+# Query and Subscribe Format
+
+Paneru exposes structured state over the same Unix socket used by `send-cmd`.
+The CLI commands below require a running Paneru daemon.
+
+All query responses are JSON followed by a newline. `subscribe` emits
+line-delimited JSON, with one complete event object per line.
+
+## Query Commands
+
+```shell
+paneru query state --json
+paneru query virtual-workspaces --json
+paneru query active --json
+```
+
+`--json` is accepted for clarity. The socket protocol also accepts the query
+without it, but callers should include `--json`.
+
+### `paneru query state --json`
+
+Returns the complete state document.
+
+```json
+{
+  "version": 1,
+  "timestamp": 1777740000,
+  "active": {
+    "display_id": 1,
+    "native_workspace_id": 4,
+    "virtual_workspace_number": 3,
+    "focused_window_id": 321,
+    "focused_bundle_id": "com.apple.Terminal",
+    "focused_app_name": "Terminal",
+    "focused_window_title": "paneru"
+  },
+  "virtual_workspaces": [
+    {
+      "number": 1,
+      "native_workspace_id": 4,
+      "active": false,
+      "windows": []
+    },
+    {
+      "number": 2,
+      "native_workspace_id": 4,
+      "active": false,
+      "windows": []
+    },
+    {
+      "number": 3,
+      "native_workspace_id": 4,
+      "active": true,
+      "windows": [
+        {
+          "window_id": 321,
+          "bundle_id": "com.apple.Terminal",
+          "app_name": "Terminal",
+          "title": "paneru",
+          "focused": true,
+          "floating": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+### `paneru query virtual-workspaces --json`
+
+Returns only the `virtual_workspaces` array from the complete state document.
+
+```json
+[
+  {
+    "number": 1,
+    "native_workspace_id": 4,
+    "active": false,
+    "windows": []
+  },
+  {
+    "number": 2,
+    "native_workspace_id": 4,
+    "active": false,
+    "windows": []
+  },
+  {
+    "number": 3,
+    "native_workspace_id": 4,
+    "active": true,
+    "windows": [
+      {
+        "window_id": 321,
+        "bundle_id": "com.apple.Terminal",
+        "app_name": "Terminal",
+        "title": "paneru",
+        "focused": true,
+        "floating": false
+      }
+    ]
+  }
+]
+```
+
+### `paneru query active --json`
+
+Returns only the active display, workspace, and focused-window state.
+
+```json
+{
+  "display_id": 1,
+  "native_workspace_id": 4,
+  "virtual_workspace_number": 3,
+  "focused_window_id": 321,
+  "focused_bundle_id": "com.apple.Terminal",
+  "focused_app_name": "Terminal",
+  "focused_window_title": "paneru"
+}
+```
+
+## Fields
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `version` | number | State document format version. Currently `1`. |
+| `timestamp` | number | Unix timestamp in seconds when the response was built. |
+| `active` | object | Current active display/native workspace/virtual workspace/focused window. |
+| `display_id` | number or null | CoreGraphics display id for the active display, when known. |
+| `native_workspace_id` | number or null | macOS Space id for the active native workspace, when known. |
+| `virtual_workspace_number` | number or null | One-based Paneru virtual workspace number, when known. |
+| `focused_window_id` | number or null | Focused window id, when known. |
+| `focused_bundle_id` | string or null | Bundle id of the focused window's app, when known. |
+| `focused_app_name` | string or null | Display name of the focused window's app, when known. |
+| `focused_window_title` | string or null | Title of the focused window, when known. |
+| `virtual_workspaces` | array | Virtual workspace rows known to Paneru. |
+| `number` | number | One-based virtual workspace number. |
+| `active` | boolean | Whether this virtual workspace is currently selected. |
+| `windows` | array | Managed windows in this virtual workspace row. |
+| `window_id` | number | Window id. |
+| `bundle_id` | string | Bundle id for the owning application, or an empty string if unknown. |
+| `app_name` | string | Display name for the owning application, or an empty string if unknown. |
+| `title` | string | Window title, or an empty string if unknown. |
+| `focused` | boolean | Whether this window is focused. |
+| `floating` | boolean | Whether this window is unmanaged/floating. |
+
+Paneru may include empty `windows` arrays for missing virtual workspace numbers
+inside a native workspace so integrations can render stable numbered slots.
+
+## Subscribe Command
+
+```shell
+paneru subscribe --json
+```
+
+`subscribe` keeps the socket open and writes one JSON event per line. The stream
+is intended for integrations such as SketchyBar, so it emits changes that are
+useful for keeping a bar in sync: focus changes, native or virtual workspace
+changes, managed window-list changes, window title changes, and display changes.
+Paneru coalesces duplicate internal events from the same ECS tick and skips
+events whose relevant state has not changed since the last emitted event.
+Consumers should parse each line independently and then call
+`paneru query state --json` when they need a full refresh.
+
+### Event Types
+
+```json
+{"event":"virtual_workspace_changed","active":{"display_id":1,"native_workspace_id":4,"virtual_workspace_number":3,"focused_window_id":321,"focused_bundle_id":"com.apple.Terminal","focused_app_name":"Terminal","focused_window_title":"paneru"}}
+```
+
+Emitted after native Space changes and Paneru virtual workspace switches. Paneru
+derives this from both incoming workspace events and ECS active-workspace marker
+changes, so integrations receive the event when the visible workspace state
+changes.
+
+```json
+{"event":"windows_changed","virtual_workspace_number":3,"active":{"display_id":1,"native_workspace_id":4,"virtual_workspace_number":3,"focused_window_id":321,"focused_bundle_id":"com.apple.Terminal","focused_app_name":"Terminal","focused_window_title":"paneru"}}
+```
+
+Emitted after managed window creation/destruction/minimize/deminimize events and
+after Paneru moves or sends a window between virtual workspaces. The event is
+emitted only when Paneru's virtual workspace/window state differs from the last
+emitted `windows_changed` event.
+
+```json
+{"event":"window_focused","window_id":321,"bundle_id":"com.apple.Terminal","title":"paneru","virtual_workspace_number":3}
+```
+
+Emitted when focus changes. Paneru derives this from both incoming focus events
+and ECS focused-window marker changes, so internally handled focus transitions
+are visible to subscribers. The `window_id`, `bundle_id`, `title`, and
+`virtual_workspace_number` fields are taken from the final active state for the
+tick, so stale lower-level focus notifications are not forwarded with mismatched
+window metadata.
+
+```json
+{"event":"window_title_changed","window_id":321,"title":"paneru"}
+```
+
+Emitted when a window title changes.
+
+```json
+{"event":"display_changed","display_id":1}
+```
+
+Emitted when display configuration changes. `display_id` can be `null` when the
+event is a global display-change notification and Paneru cannot resolve an
+active display id.
+
+## Virtual Workspace Commands
+
+Absolute virtual workspace selection is addressed as a window command:
+
+```shell
+paneru send-cmd window virtualnum 3
+paneru send-cmd window virtualmovenum 3
+paneru send-cmd window virtualsendnum 3
+```
+
+The matching config binding names are:
+
+```toml
+[bindings]
+window_virtualnum_3 = "cmd + alt - 3"
+window_virtualmovenum_3 = "cmd + alt + ctrl - 3"
+window_virtualsendnum_3 = "cmd + alt + shift - 3"
+```

--- a/README.md
+++ b/README.md
@@ -238,6 +238,24 @@ $ paneru send-cmd window virtualnum 3
 $ paneru send-cmd window virtualsendnum 3
 ```
 
+### Querying and Subscribing to State
+
+Paneru also exposes structured JSON state for scripts and status bars:
+
+```shell
+$ paneru query state --json
+$ paneru query virtual-workspaces --json
+$ paneru query active --json
+$ paneru subscribe --json
+```
+
+`query` prints a JSON snapshot and exits. `subscribe --json` keeps the socket
+open and emits line-delimited JSON events for changes that integrations usually
+care about, including focus changes, virtual workspace changes, window-list
+changes, title changes, and display changes. See
+[`QUERY_AND_SUBSCRIBE_FORMAT.md`](./QUERY_AND_SUBSCRIBE_FORMAT.md) for the
+full payload contract.
+
 #### Scripting ideas
 
 Because `send-cmd` works over a Unix socket, you can drive Paneru from shell
@@ -257,6 +275,8 @@ scripts, `cron` jobs, or other automation tools:
   ```shell
   paneru send-cmd window nextdisplay && paneru send-cmd mouse nextdisplay
   ```
+- **Status bar integration.** Use `paneru query state --json` to render the
+  initial workspace labels, then keep them current with `paneru subscribe --json`.
 
 
 ## Future Enhancements

--- a/README.md
+++ b/README.md
@@ -201,8 +201,11 @@ $ paneru send-cmd <command> [args...]
 | `window nextdisplay`       | Move the focused window to the next display      |
 | `window nextdisplaysend`   | Move the window to the next display but stay here |
 | `window virtual <dir>`     | Switch to the previous/next virtual workspace     |
+| `window virtualnum <n>`    | Switch directly to numbered virtual workspace    |
 | `window virtualmove <dir>` | Move the window to a different virtual workspace  |
+| `window virtualmovenum <n>` | Move the window to numbered virtual workspace and follow it |
 | `window virtualsend <dir>` | Send the window to a virtual workspace but stay  |
+| `window virtualsendnum <n>` | Send the window to numbered virtual workspace but stay |
 | `window snap`              | Snap the focused window into the visible viewport |
 | `mouse nextdisplay`        | Warp the mouse pointer to the next display       |
 | `printstate`               | Print the internal ECS state to the debug log    |
@@ -227,6 +230,12 @@ $ paneru send-cmd window shrink
 
 # Jump to the left-most window.
 $ paneru send-cmd window focus first
+
+# Switch directly to virtual workspace 3.
+$ paneru send-cmd window virtualnum 3
+
+# Send the focused window to virtual workspace 3 without following it.
+$ paneru send-cmd window virtualsendnum 3
 ```
 
 #### Scripting ideas

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
                 self.packages.aarch64-darwin.default
                 pkgs.rustc
                 pkgs.cargo
+                pkgs.rustfmt
+                pkgs.clippy
               ];
             };
           };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,6 +8,8 @@ use bevy::math::IRect;
 use tracing::{Level, instrument};
 use tracing::{debug, info};
 
+mod query;
+
 use crate::config::Config;
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
@@ -112,6 +114,7 @@ pub enum Command {
 }
 
 pub fn register_commands(app: &mut bevy::app::App) {
+    query::register_query_commands(app);
     app.add_systems(
         PreUpdate,
         (

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -84,8 +84,12 @@ pub enum Operation {
     Snap,
     /// Cyclically selects the virtual strip for the current workspace.
     Virtual(Direction),
+    /// Selects a virtual strip by its zero-based index for the current workspace.
+    VirtualNumber(u32),
     /// Moves the focused window to the virtual strip.
     VirtualMove(Direction, MoveFocus),
+    /// Moves the focused window to a virtual strip by its zero-based index.
+    VirtualMoveNumber(u32, MoveFocus),
 }
 
 /// Defines operations that can be performed on the mouse.

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,0 +1,452 @@
+use bevy::app::{App, PostUpdate, PreUpdate};
+use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::message::MessageReader;
+use bevy::ecs::query::{Added, Has};
+use bevy::ecs::resource::Resource;
+use bevy::ecs::system::{Query, ResMut};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+
+use super::{Command, Operation};
+use crate::ecs::layout::LayoutStrip;
+use crate::ecs::params::Windows;
+use crate::ecs::state::{PaneruActiveState, PaneruQueryState, PaneruVirtualWorkspaceState};
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker};
+use crate::events::Event;
+use crate::manager::{Application, Display};
+use crate::platform::WinID;
+
+#[derive(Default, Resource)]
+struct StateSubscribers {
+    streams: Vec<Arc<Mutex<UnixStream>>>,
+}
+
+#[derive(Default, Resource)]
+struct StateBroadcastCache {
+    workspace: Option<WorkspaceBroadcastSnapshot>,
+    focus: Option<FocusBroadcastSnapshot>,
+    virtual_workspaces: Option<Vec<PaneruVirtualWorkspaceState>>,
+    titles: BTreeMap<WinID, String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct WorkspaceBroadcastSnapshot {
+    display_id: Option<u32>,
+    native_workspace_id: Option<u64>,
+    virtual_workspace_number: Option<u32>,
+}
+
+impl From<&PaneruActiveState> for WorkspaceBroadcastSnapshot {
+    fn from(active: &PaneruActiveState) -> Self {
+        Self {
+            display_id: active.display_id,
+            native_workspace_id: active.native_workspace_id,
+            virtual_workspace_number: active.virtual_workspace_number,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct FocusBroadcastSnapshot {
+    window_id: Option<WinID>,
+    bundle_id: Option<String>,
+    title: Option<String>,
+    virtual_workspace_number: Option<u32>,
+}
+
+impl From<&PaneruActiveState> for FocusBroadcastSnapshot {
+    fn from(active: &PaneruActiveState) -> Self {
+        Self {
+            window_id: active.focused_window_id,
+            bundle_id: active.focused_bundle_id.clone(),
+            title: active.focused_window_title.clone(),
+            virtual_workspace_number: active.virtual_workspace_number,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct StateBroadcastSignals {
+    virtual_workspace_changed: bool,
+    window_focused: bool,
+}
+
+pub(super) fn register_query_commands(app: &mut App) {
+    app.init_resource::<StateSubscribers>();
+    app.init_resource::<StateBroadcastCache>();
+    app.add_systems(PreUpdate, (state_subscribe_handler, state_query_handler));
+    app.add_systems(PostUpdate, state_event_broadcast_handler);
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn state_query_handler(
+    mut messages: MessageReader<Event>,
+    workspaces: Query<(&ChildOf, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
+    windows: Windows,
+    apps: Query<&Application>,
+) {
+    for event in messages.read() {
+        let Event::StateQuery { kind, respond_to } = event else {
+            continue;
+        };
+
+        let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
+        let response = state
+            .to_query_json(*kind)
+            .unwrap_or_else(|err| json!({ "error": err.to_string() }).to_string());
+        _ = respond_to.send(response);
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn state_subscribe_handler(
+    mut messages: MessageReader<Event>,
+    mut subscribers: ResMut<StateSubscribers>,
+) {
+    for event in messages.read() {
+        let Event::StateSubscribe { stream } = event else {
+            continue;
+        };
+        subscribers.streams.push(stream.clone());
+    }
+}
+
+fn collect_state_broadcast_events<'a>(
+    events: impl IntoIterator<Item = &'a Event>,
+    state: &PaneruQueryState,
+    cache: &mut StateBroadcastCache,
+    title_for_window: impl Fn(WinID) -> Option<String>,
+    signals: StateBroadcastSignals,
+) -> Vec<Value> {
+    let mut virtual_workspace_changed = signals.virtual_workspace_changed;
+    let mut windows_changed = false;
+    let mut window_focused = signals.window_focused;
+    let mut title_changes = BTreeMap::new();
+    let mut display_changes = Vec::new();
+
+    for event in events {
+        match event {
+            Event::SpaceChanged
+            | Event::Command {
+                command: Command::Window(Operation::Virtual(_) | Operation::VirtualNumber(_)),
+            } => virtual_workspace_changed = true,
+            Event::WindowCreated { .. }
+            | Event::WindowDestroyed { .. }
+            | Event::WindowMinimized { .. }
+            | Event::WindowDeminimized { .. }
+            | Event::Command {
+                command:
+                    Command::Window(Operation::VirtualMove(_, _) | Operation::VirtualMoveNumber(_, _)),
+            } => windows_changed = true,
+            Event::WindowFocused { .. } => window_focused = true,
+            Event::WindowTitleChanged { window_id } => {
+                title_changes.insert(*window_id, title_for_window(*window_id).unwrap_or_default());
+            }
+            Event::DisplayAdded { display_id }
+            | Event::DisplayRemoved { display_id }
+            | Event::DisplayMoved { display_id }
+            | Event::DisplayResized { display_id }
+            | Event::DisplayConfigured { display_id } => {
+                let display_id = Some(*display_id);
+                if !display_changes.contains(&display_id) {
+                    display_changes.push(display_id);
+                }
+            }
+            Event::DisplayChanged => {
+                if !display_changes.contains(&state.active.display_id) {
+                    display_changes.push(state.active.display_id);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut outgoing = Vec::new();
+
+    if virtual_workspace_changed {
+        let workspace = WorkspaceBroadcastSnapshot::from(&state.active);
+        if cache.workspace.as_ref() != Some(&workspace)
+            && (workspace.native_workspace_id.is_some()
+                || workspace.virtual_workspace_number.is_some())
+        {
+            outgoing.push(json!({
+                "event": "virtual_workspace_changed",
+                "active": state.active.clone(),
+            }));
+            cache.workspace = Some(workspace);
+        }
+    }
+
+    if windows_changed && cache.virtual_workspaces.as_ref() != Some(&state.virtual_workspaces) {
+        outgoing.push(json!({
+            "event": "windows_changed",
+            "virtual_workspace_number": state.active.virtual_workspace_number,
+            "active": state.active.clone(),
+        }));
+        cache.virtual_workspaces = Some(state.virtual_workspaces.clone());
+    }
+
+    if window_focused {
+        let focus = FocusBroadcastSnapshot::from(&state.active);
+        if focus.window_id.is_some() && cache.focus.as_ref() != Some(&focus) {
+            outgoing.push(json!({
+                "event": "window_focused",
+                "window_id": focus.window_id,
+                "bundle_id": focus.bundle_id,
+                "title": focus.title,
+                "virtual_workspace_number": focus.virtual_workspace_number,
+            }));
+            cache.focus = Some(focus);
+        }
+    }
+
+    for (window_id, title) in title_changes {
+        if cache.titles.get(&window_id) == Some(&title) {
+            continue;
+        }
+        outgoing.push(json!({
+            "event": "window_title_changed",
+            "window_id": window_id,
+            "title": title,
+        }));
+        cache.titles.insert(window_id, title);
+    }
+
+    for display_id in display_changes {
+        outgoing.push(json!({
+            "event": "display_changed",
+            "display_id": display_id,
+        }));
+    }
+
+    outgoing
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+fn state_event_broadcast_handler(
+    mut messages: MessageReader<Event>,
+    mut subscribers: ResMut<StateSubscribers>,
+    mut cache: ResMut<StateBroadcastCache>,
+    workspaces: Query<(&ChildOf, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    focused_changes: Query<Entity, Added<FocusedMarker>>,
+    active_workspace_changes: Query<Entity, Added<ActiveWorkspaceMarker>>,
+    displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
+    windows: Windows,
+    apps: Query<&Application>,
+) {
+    let events = messages.read().collect::<Vec<_>>();
+
+    if subscribers.streams.is_empty() {
+        return;
+    }
+
+    let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
+    let signals = StateBroadcastSignals {
+        virtual_workspace_changed: !active_workspace_changes.is_empty(),
+        window_focused: !focused_changes.is_empty(),
+    };
+    let outgoing = collect_state_broadcast_events(
+        events,
+        &state,
+        &mut cache,
+        |window_id| {
+            windows
+                .find(window_id)
+                .and_then(|(window, _)| window.title().ok())
+        },
+        signals,
+    );
+
+    if outgoing.is_empty() {
+        return;
+    }
+
+    let mut payload = outgoing
+        .into_iter()
+        .map(|event| event.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    payload.push('\n');
+
+    subscribers.streams.retain(|stream| {
+        let Ok(mut stream) = stream.lock() else {
+            return false;
+        };
+        stream.write_all(payload.as_bytes()).is_ok()
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ecs::state::{PaneruVirtualWorkspaceState, PaneruWindowState};
+    use crate::events::Event as PaneruEvent;
+
+    fn query_state_with_active_window(
+        window_id: WinID,
+        bundle_id: &str,
+        title: &str,
+        virtual_workspace_number: u32,
+        window_ids: Vec<WinID>,
+    ) -> PaneruQueryState {
+        let active = PaneruActiveState {
+            display_id: Some(1),
+            native_workspace_id: Some(10),
+            virtual_workspace_number: Some(virtual_workspace_number),
+            focused_window_id: Some(window_id),
+            focused_bundle_id: Some(bundle_id.to_string()),
+            focused_app_name: Some("Test App".to_string()),
+            focused_window_title: Some(title.to_string()),
+        };
+        let windows = window_ids
+            .into_iter()
+            .map(|window_id| PaneruWindowState {
+                window_id,
+                bundle_id: bundle_id.to_string(),
+                app_name: "Test App".to_string(),
+                title: title.to_string(),
+                focused: active.focused_window_id == Some(window_id),
+                floating: false,
+            })
+            .collect();
+
+        PaneruQueryState {
+            version: 1,
+            timestamp: 123,
+            active,
+            virtual_workspaces: vec![PaneruVirtualWorkspaceState {
+                number: virtual_workspace_number,
+                native_workspace_id: 10,
+                active: true,
+                windows,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_state_broadcast_coalesces_focus_events_to_current_state() {
+        let state = query_state_with_active_window(
+            26_261,
+            "com.cmuxterm.app",
+            "aicommit2 ~/P/nixos-config",
+            2,
+            vec![26_261],
+        );
+        let mut cache = StateBroadcastCache::default();
+        let events = [
+            PaneruEvent::WindowFocused { window_id: 18_639 },
+            PaneruEvent::WindowFocused { window_id: 26_261 },
+            PaneruEvent::WindowFocused { window_id: 26_261 },
+        ];
+
+        let outgoing = collect_state_broadcast_events(
+            events.iter(),
+            &state,
+            &mut cache,
+            |_| None,
+            StateBroadcastSignals::default(),
+        );
+
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0]["event"], "window_focused");
+        assert_eq!(outgoing[0]["window_id"], 26_261);
+        assert_eq!(outgoing[0]["bundle_id"], "com.cmuxterm.app");
+        assert_eq!(outgoing[0]["title"], "aicommit2 ~/P/nixos-config");
+
+        let duplicate = collect_state_broadcast_events(
+            events.iter(),
+            &state,
+            &mut cache,
+            |_| None,
+            StateBroadcastSignals::default(),
+        );
+
+        assert!(duplicate.is_empty());
+    }
+
+    #[test]
+    fn test_state_broadcast_coalesces_windows_changed_and_skips_unchanged_state() {
+        let state =
+            query_state_with_active_window(26_261, "com.cmuxterm.app", "term", 2, vec![26_261]);
+        let mut cache = StateBroadcastCache::default();
+        let events = [
+            PaneruEvent::WindowMinimized { window_id: 26_261 },
+            PaneruEvent::WindowDeminimized { window_id: 26_261 },
+        ];
+
+        let outgoing = collect_state_broadcast_events(
+            events.iter(),
+            &state,
+            &mut cache,
+            |_| None,
+            StateBroadcastSignals::default(),
+        );
+
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0]["event"], "windows_changed");
+        assert_eq!(outgoing[0]["virtual_workspace_number"], 2);
+        assert_eq!(outgoing[0]["active"]["focused_window_id"], 26_261);
+
+        let duplicate = collect_state_broadcast_events(
+            events.iter(),
+            &state,
+            &mut cache,
+            |_| None,
+            StateBroadcastSignals::default(),
+        );
+
+        assert!(duplicate.is_empty());
+
+        let changed_state = query_state_with_active_window(
+            26_261,
+            "com.cmuxterm.app",
+            "term",
+            2,
+            vec![26_261, 26_262],
+        );
+        let changed = collect_state_broadcast_events(
+            events.iter(),
+            &changed_state,
+            &mut cache,
+            |_| None,
+            StateBroadcastSignals::default(),
+        );
+
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0]["event"], "windows_changed");
+    }
+
+    #[test]
+    fn test_state_broadcast_emits_focus_when_focused_marker_changes_without_event_message() {
+        let state = query_state_with_active_window(
+            26_262,
+            "com.openai.codex",
+            "Codex",
+            2,
+            vec![26_261, 26_262],
+        );
+        let mut cache = StateBroadcastCache::default();
+
+        let outgoing = collect_state_broadcast_events(
+            std::iter::empty(),
+            &state,
+            &mut cache,
+            |_| None,
+            StateBroadcastSignals {
+                window_focused: true,
+                ..StateBroadcastSignals::default()
+            },
+        );
+
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0]["event"], "window_focused");
+        assert_eq!(outgoing[0]["window_id"], 26_262);
+        assert_eq!(outgoing[0]["bundle_id"], "com.openai.codex");
+        assert_eq!(outgoing[0]["title"], "Codex");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,22 @@ fn parse_direction(dir: &str) -> Result<Direction> {
     })
 }
 
+fn parse_virtual_workspace_number(input: &str) -> Result<u32> {
+    let number = input.parse::<u32>().map_err(|_| {
+        Error::InvalidConfig(format!(
+            "{}: Unhandled virtual workspace {input}",
+            function_name!()
+        ))
+    })?;
+    if number == 0 {
+        return Err(Error::InvalidConfig(format!(
+            "{}: Virtual workspace numbers start at 1",
+            function_name!()
+        )));
+    }
+    Ok(number - 1)
+}
+
 /// Parses a string into a `ResizeDirection` enum.
 fn parse_resize_direction(direction: &str) -> Result<ResizeDirection> {
     Ok(match direction {
@@ -188,13 +204,47 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "nextdisplay" => Operation::ToNextDisplay(MoveFocus::Follow),
         "nextdisplaysend" => Operation::ToNextDisplay(MoveFocus::Stay),
         "snap" => Operation::Snap,
-        "virtual" => Operation::Virtual(parse_direction(argv.get(1).ok_or(err)?)?),
+        "virtual" => {
+            let target = argv.get(1).ok_or(err)?;
+            target.parse::<u32>().map_or_else(
+                |_| parse_direction(target).map(Operation::Virtual),
+                |_| parse_virtual_workspace_number(target).map(Operation::VirtualNumber),
+            )?
+        }
+        "virtualnum" => {
+            Operation::VirtualNumber(parse_virtual_workspace_number(argv.get(1).ok_or(err)?)?)
+        }
         "virtualmove" => {
-            Operation::VirtualMove(parse_direction(argv.get(1).ok_or(err)?)?, MoveFocus::Follow)
+            let target = argv.get(1).ok_or(err)?;
+            target.parse::<u32>().map_or_else(
+                |_| {
+                    parse_direction(target)
+                        .map(|dir| Operation::VirtualMove(dir, MoveFocus::Follow))
+                },
+                |_| {
+                    parse_virtual_workspace_number(target)
+                        .map(|index| Operation::VirtualMoveNumber(index, MoveFocus::Follow))
+                },
+            )?
         }
+        "virtualmovenum" => Operation::VirtualMoveNumber(
+            parse_virtual_workspace_number(argv.get(1).ok_or(err)?)?,
+            MoveFocus::Follow,
+        ),
         "virtualsend" => {
-            Operation::VirtualMove(parse_direction(argv.get(1).ok_or(err)?)?, MoveFocus::Stay)
+            let target = argv.get(1).ok_or(err)?;
+            target.parse::<u32>().map_or_else(
+                |_| parse_direction(target).map(|dir| Operation::VirtualMove(dir, MoveFocus::Stay)),
+                |_| {
+                    parse_virtual_workspace_number(target)
+                        .map(|index| Operation::VirtualMoveNumber(index, MoveFocus::Stay))
+                },
+            )?
         }
+        "virtualsendnum" => Operation::VirtualMoveNumber(
+            parse_virtual_workspace_number(argv.get(1).ok_or(err)?)?,
+            MoveFocus::Stay,
+        ),
         _ => {
             return Err(err);
         }
@@ -769,6 +819,13 @@ impl InnerConfig {
     /// `Ok(InnerConfig)` if the parsing is successful, otherwise `Err(Error)` with an error message.
     fn parse_config(input: &str) -> Result<InnerConfig> {
         let virtual_keys = generate_virtual_keymap();
+        Self::parse_config_with_virtual_keys(input, &virtual_keys)
+    }
+
+    fn parse_config_with_virtual_keys(
+        input: &str,
+        virtual_keys: &[(String, u8)],
+    ) -> Result<InnerConfig> {
         let mut config: InnerConfig = toml::from_str(input)?;
 
         for (command, bindings) in &mut config.bindings {
@@ -798,7 +855,7 @@ impl InnerConfig {
         if let Some(windows) = &mut config.windows {
             for params in windows.values_mut() {
                 for input in &params.bindings_passthrough {
-                    match resolve_keybinding_str(input, &virtual_keys) {
+                    match resolve_keybinding_str(input, virtual_keys) {
                         Ok(pair) => params.parsed_passthrough.push(pair),
                         Err(err) => error!("passthrough: {err}"),
                     }
@@ -1389,6 +1446,13 @@ fn generate_virtual_keymap() -> Vec<(String, u8)> {
         .collect()
 }
 
+#[cfg(test)]
+fn test_virtual_keymap() -> Vec<(String, u8)> {
+    virtual_keycode()
+        .map(|(key, code)| ((*key).to_string(), *code))
+        .collect()
+}
+
 #[test]
 #[allow(clippy::float_cmp)]
 fn test_config_parsing() {
@@ -1410,9 +1474,11 @@ bundle_id = "com.something.apple"
 floating = true
 index = 1
 "#;
+    let virtual_keys = test_virtual_keymap();
     let config = Config {
         inner: Arc::new(ArcSwap::from_pointee(
-            InnerConfig::parse_config(input).expect("Failed to parse config"),
+            InnerConfig::parse_config_with_virtual_keys(input, &virtual_keys)
+                .expect("Failed to parse config"),
         )),
     };
     let find_key = |k| {
@@ -1513,6 +1579,41 @@ index = 1
 }
 
 #[test]
+fn test_config_parsing_absolute_virtual_workspace_bindings() {
+    let input = r#"
+[options]
+
+[bindings]
+window_virtualnum_3 = "cmd + alt - 3"
+window_virtualsendnum_3 = "cmd + alt + shift - 3"
+"#;
+    let virtual_keys = test_virtual_keymap();
+    let config = Config {
+        inner: Arc::new(ArcSwap::from_pointee(
+            InnerConfig::parse_config_with_virtual_keys(input, &virtual_keys)
+                .expect("Failed to parse config"),
+        )),
+    };
+    let find_key = |k| {
+        virtual_keycode()
+            .find_map(|(s, v)| (format!("{k}") == *s).then_some(*v))
+            .unwrap()
+    };
+    let keycode = find_key('3');
+    assert!(matches!(
+        config.find_keybind(keycode, Modifiers::CMD | Modifiers::ALT),
+        Some(Command::Window(Operation::VirtualNumber(2)))
+    ));
+    assert!(matches!(
+        config.find_keybind(keycode, Modifiers::CMD | Modifiers::ALT | Modifiers::SHIFT),
+        Some(Command::Window(Operation::VirtualMoveNumber(
+            2,
+            MoveFocus::Stay
+        )))
+    ));
+}
+
+#[test]
 fn test_parse_resize_commands() {
     assert!(matches!(
         parse_command(&["window", "resize"]).unwrap(),
@@ -1529,6 +1630,31 @@ fn test_parse_resize_commands() {
     assert!(matches!(
         parse_command(&["window", "shrink"]).unwrap(),
         Command::Window(Operation::Resize(ResizeDirection::Shrink))
+    ));
+}
+
+#[test]
+fn test_parse_absolute_virtual_workspace_commands() {
+    assert!(matches!(
+        parse_command(&["window", "virtualnum", "3"]).unwrap(),
+        Command::Window(Operation::VirtualNumber(2))
+    ));
+    assert!(parse_command(&["workspace", "virtual", "3"]).is_err());
+    assert!(matches!(
+        parse_command(&["window", "virtualmove", "3"]).unwrap(),
+        Command::Window(Operation::VirtualMoveNumber(2, MoveFocus::Follow))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "virtualsend", "3"]).unwrap(),
+        Command::Window(Operation::VirtualMoveNumber(2, MoveFocus::Stay))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "virtualmovenum", "3"]).unwrap(),
+        Command::Window(Operation::VirtualMoveNumber(2, MoveFocus::Follow))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "virtualsendnum", "3"]).unwrap(),
+        Command::Window(Operation::VirtualMoveNumber(2, MoveFocus::Stay))
     ));
 }
 

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -113,6 +113,10 @@ impl ActiveDisplay<'_, '_> {
         self.display.0.id()
     }
 
+    pub fn entity(&self) -> Entity {
+        self.display.1
+    }
+
     /// Returns an iterator over immutable references to all other displays (non-active).
     pub fn other(&self) -> impl Iterator<Item = &Display> {
         self.other_displays.iter()

--- a/src/ecs/state.rs
+++ b/src/ecs/state.rs
@@ -1,17 +1,22 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bevy::app::AppExit;
 use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;
+use bevy::ecs::query::Has;
 use bevy::ecs::resource::Resource;
 use bevy::ecs::system::Query;
+use objc2_core_graphics::CGDirectDisplayID;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::Windows;
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::manager::Display;
 use crate::manager::{Application, Window};
 use crate::platform::{Pid, ProcessSerialNumber, WinID, WorkspaceId};
 
@@ -62,6 +67,50 @@ pub struct SavedWindow {
     pub identifier: String,
     pub role: String,
     pub subrole: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StateQueryKind {
+    State,
+    VirtualWorkspaces,
+    Active,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PaneruQueryState {
+    pub version: u32,
+    pub timestamp: u64,
+    pub active: PaneruActiveState,
+    pub virtual_workspaces: Vec<PaneruVirtualWorkspaceState>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct PaneruActiveState {
+    pub display_id: Option<CGDirectDisplayID>,
+    pub native_workspace_id: Option<WorkspaceId>,
+    pub virtual_workspace_number: Option<u32>,
+    pub focused_window_id: Option<WinID>,
+    pub focused_bundle_id: Option<String>,
+    pub focused_app_name: Option<String>,
+    pub focused_window_title: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PaneruVirtualWorkspaceState {
+    pub number: u32,
+    pub native_workspace_id: WorkspaceId,
+    pub active: bool,
+    pub windows: Vec<PaneruWindowState>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PaneruWindowState {
+    pub window_id: WinID,
+    pub bundle_id: String,
+    pub app_name: String,
+    pub title: String,
+    pub focused: bool,
+    pub floating: bool,
 }
 
 impl SavedWindow {
@@ -175,10 +224,7 @@ impl PaneruState {
 
         Self {
             version: 1,
-            timestamp: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            timestamp: now_timestamp(),
             workspaces,
         }
     }
@@ -280,6 +326,129 @@ impl PaneruState {
             self.find_match(window.id(), window.pid().ok()?, bundle_id)?;
         Some((workspace_id, virtual_index, col_idx))
     }
+}
+
+impl PaneruQueryState {
+    #[allow(clippy::type_complexity)]
+    pub fn extract(
+        workspaces: &Query<(&ChildOf, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+        displays: &Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
+        windows: &Windows,
+        apps: &Query<&Application>,
+    ) -> Self {
+        let focused = windows.focused();
+        let focused_entity = focused.map(|(_, entity)| entity);
+
+        let active_display = displays
+            .iter()
+            .find(|(_, _, active)| *active)
+            .map(|(display, entity, _)| (display.id(), entity));
+
+        let mut virtual_workspaces = Vec::new();
+        let mut workspace_max_numbers: HashMap<WorkspaceId, u32> = HashMap::new();
+        let mut active = PaneruActiveState {
+            display_id: active_display.map(|(display_id, _)| display_id),
+            ..PaneruActiveState::default()
+        };
+
+        for (child, strip, active_workspace) in workspaces {
+            let row_windows = strip
+                .all_windows()
+                .iter()
+                .filter_map(|entity| {
+                    let (window, _, unmanaged) = windows.get_managed(*entity)?;
+                    let (_, _, app_entity) = windows.find_parent(window.id())?;
+                    let app = apps.get(app_entity).ok()?;
+                    let bundle_id = app.bundle_id().unwrap_or_default().to_string();
+                    let app_name = app.name().to_string();
+                    let title = window.title().unwrap_or_default();
+                    Some(PaneruWindowState {
+                        window_id: window.id(),
+                        bundle_id,
+                        app_name,
+                        title,
+                        focused: focused_entity == Some(*entity),
+                        floating: unmanaged.is_some(),
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            let number = strip.virtual_index + 1;
+            workspace_max_numbers
+                .entry(strip.id())
+                .and_modify(|max| *max = (*max).max(number))
+                .or_insert(number);
+            if active_workspace {
+                active.native_workspace_id = Some(strip.id());
+                active.virtual_workspace_number = Some(number);
+            }
+
+            if active_workspace
+                && let Some(window) = row_windows.iter().find(|window| window.focused)
+            {
+                active.focused_window_id = Some(window.window_id);
+                active.focused_bundle_id = Some(window.bundle_id.clone());
+                active.focused_app_name = Some(window.app_name.clone());
+                active.focused_window_title = Some(window.title.clone());
+            }
+
+            virtual_workspaces.push(PaneruVirtualWorkspaceState {
+                number,
+                native_workspace_id: strip.id(),
+                active: active_workspace,
+                windows: row_windows,
+            });
+
+            if active_workspace
+                && let Some((display_id, display_entity)) = active_display
+                && child.parent() == display_entity
+            {
+                active.display_id = Some(display_id);
+            }
+        }
+
+        let present_numbers = virtual_workspaces
+            .iter()
+            .map(|workspace| (workspace.native_workspace_id, workspace.number))
+            .collect::<HashSet<_>>();
+        for (workspace_id, max_number) in workspace_max_numbers {
+            for number in 1..=max_number {
+                if !present_numbers.contains(&(workspace_id, number)) {
+                    virtual_workspaces.push(PaneruVirtualWorkspaceState {
+                        number,
+                        native_workspace_id: workspace_id,
+                        active: false,
+                        windows: Vec::new(),
+                    });
+                }
+            }
+        }
+
+        virtual_workspaces
+            .sort_by_key(|workspace| (workspace.native_workspace_id, workspace.number));
+
+        Self {
+            version: 1,
+            timestamp: now_timestamp(),
+            active,
+            virtual_workspaces,
+        }
+    }
+
+    pub fn to_query_json(&self, kind: StateQueryKind) -> serde_json::Result<String> {
+        match kind {
+            StateQueryKind::State => serde_json::to_string(self),
+            StateQueryKind::VirtualWorkspaces => serde_json::to_string(&self.virtual_workspaces),
+            StateQueryKind::Active => serde_json::to_string(&self.active),
+        }
+    }
+}
+
+fn now_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -43,7 +43,6 @@ impl Plugin for WorkspaceEventsPlugin {
             Update,
             (
                 show_active_workspace,
-                cleanup_virtual_workspaces,
                 handle_virtual_window_moves,
                 detect_moved_windows.run_if(not(resource_exists::<Initializing>)),
                 refresh_workspace_window_sizes.run_if(on_timer(Duration::from_millis(
@@ -558,48 +557,6 @@ fn cleanup_selected_space_marker(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn cleanup_virtual_workspaces(
-    changed: Single<Entity, Added<ActiveWorkspaceMarker>>,
-    mut strips: Populated<(Entity, &mut LayoutStrip)>,
-    mut commands: Commands,
-) {
-    let changed_entity = *changed;
-    let Some(workspace_id) = strips.get(changed_entity).ok().map(|(_, strip)| strip.id()) else {
-        return;
-    };
-    debug!("cleaning up virtual workspaces on space {workspace_id}");
-    let mut rows = strips
-        .iter_mut()
-        .filter(|(_, strip)| strip.id() == workspace_id)
-        .collect::<Vec<_>>();
-    rows.sort_by_key(|(_, strip)| strip.virtual_index);
-
-    if rows.is_empty() {
-        return;
-    }
-
-    let primary_entity = rows[0].0;
-    let mut next_idx = 0;
-    for (entity, mut strip) in rows {
-        if strip.virtual_index > 0 && strip.len() == 0 {
-            if entity == changed_entity {
-                debug!("moving markers from despawned virtual workspace to primary");
-                commands
-                    .entity(primary_entity)
-                    .try_insert(ActiveWorkspaceMarker)
-                    .try_insert(SelectedVirtualMarker);
-            }
-            commands.entity(entity).despawn();
-            continue;
-        }
-        if strip.virtual_index != next_idx {
-            strip.virtual_index = next_idx;
-        }
-        next_idx += 1;
-    }
-}
-
-#[allow(clippy::needless_pass_by_value)]
 fn handle_virtual_window_moves(
     moved_windows: Populated<(Entity, &VirtualMoveMarker), With<Window>>,
     mut workspaces: Query<(
@@ -730,9 +687,10 @@ fn switch_virtual_workspace_bind(
     workspaces: Query<(Entity, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     mut commands: Commands,
 ) {
-    let Some(Operation::Virtual(direction)) =
-        filter_window_operations(&mut messages, |op| matches!(op, Operation::Virtual(_))).next()
-    else {
+    let Some(operation) = filter_window_operations(&mut messages, |op| {
+        matches!(op, Operation::Virtual(_) | Operation::VirtualNumber(_))
+    })
+    .next() else {
         return;
     };
 
@@ -748,9 +706,30 @@ fn switch_virtual_workspace_bind(
     rows.sort_by_key(|(_, strip, _)| strip.virtual_index);
 
     let current_index = rows.iter().position(|(_, _, active)| *active).unwrap_or(0);
-    let next_index = match direction {
-        Direction::South => (current_index + 1).clamp(0, rows.len() - 1),
-        Direction::North => current_index.saturating_sub(1),
+    let next_index = match operation {
+        Operation::Virtual(Direction::South) => (current_index + 1).clamp(0, rows.len() - 1),
+        Operation::Virtual(Direction::North) => current_index.saturating_sub(1),
+        Operation::VirtualNumber(target_virtual_index) => {
+            let Some(index) = rows
+                .iter()
+                .position(|(_, strip, _)| strip.virtual_index == *target_virtual_index)
+            else {
+                if *target_virtual_index == 0 {
+                    return;
+                }
+                let strip = LayoutStrip::new(workspace_id, *target_virtual_index);
+                commands.spawn((
+                    strip,
+                    Position(active_display.bounds().min),
+                    ChildOf(active_display.entity()),
+                    SelectedVirtualMarker,
+                    ActiveWorkspaceMarker,
+                ));
+                flash_message(format!("{}", *target_virtual_index + 1), 1.0, &mut commands);
+                return;
+            };
+            index
+        }
         _ => return,
     };
 
@@ -785,12 +764,13 @@ fn move_virtual_workspace_bind(
     active_display: ActiveDisplay,
     mut commands: Commands,
 ) {
-    let Some(Operation::VirtualMove(direction, move_focus)) =
-        filter_window_operations(&mut messages, |op| {
-            matches!(op, Operation::VirtualMove(_, _))
-        })
-        .next()
-    else {
+    let Some(operation) = filter_window_operations(&mut messages, |op| {
+        matches!(
+            op,
+            Operation::VirtualMove(_, _) | Operation::VirtualMoveNumber(_, _)
+        )
+    })
+    .next() else {
         return;
     };
 
@@ -800,23 +780,33 @@ fn move_virtual_workspace_bind(
 
     let current_virtual_index = active_display.active_strip().virtual_index;
 
-    let target_virtual_index = match direction {
-        Direction::South if active_display.active_strip().len() > 1 => current_virtual_index + 1,
-        Direction::North => {
+    let (target_virtual_index, move_focus) = match operation {
+        Operation::VirtualMove(Direction::South, move_focus)
+            if active_display.active_strip().len() > 1 =>
+        {
+            (current_virtual_index + 1, *move_focus)
+        }
+        Operation::VirtualMove(Direction::North, move_focus) => {
             if current_virtual_index == 0 {
                 return;
             }
-            current_virtual_index - 1
+            (current_virtual_index - 1, *move_focus)
+        }
+        Operation::VirtualMoveNumber(target_virtual_index, move_focus) => {
+            if *target_virtual_index == current_virtual_index {
+                return;
+            }
+            (*target_virtual_index, *move_focus)
         }
         _ => return,
     };
 
     commands.entity(focused_entity).insert(VirtualMoveMarker {
         target_virtual_index,
-        move_focus: *move_focus,
+        move_focus,
     });
 
-    if *move_focus == MoveFocus::Follow {
+    if move_focus == MoveFocus::Follow {
         flash_message(format!("{}", target_virtual_index + 1), 1.0, &mut commands);
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,10 +2,13 @@ use bevy::ecs::message::Message;
 use objc2::rc::Retained;
 use objc2_core_foundation::{CFRetained, CGPoint};
 use objc2_core_graphics::CGDirectDisplayID;
+use std::os::unix::net::UnixStream;
 use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::{Arc, Mutex};
 
 use crate::commands::Command;
 use crate::config::Config;
+use crate::ecs::state::StateQueryKind;
 use crate::errors::Result;
 use crate::platform::{Modifiers, ProcessSerialNumber, WinID, WorkspaceId, WorkspaceObserver};
 use crate::util::AXUIWrapper;
@@ -147,6 +150,15 @@ pub enum Event {
 
     /// A command has been issued to the window manager.
     Command { command: Command },
+
+    /// A structured state query has been issued by a socket client.
+    StateQuery {
+        kind: StateQueryKind,
+        respond_to: Sender<String>,
+    },
+
+    /// A socket client has subscribed to line-delimited state events.
+    StateSubscribe { stream: Arc<Mutex<UnixStream>> },
 }
 
 /// `EventSender` is a thin wrapper around a `std::sync::mpsc::Sender` for `Event`s.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ embed_plist::embed_info_plist!("../assets/Info.plist");
 
 use events::EventSender;
 
+use ecs::state::StateQueryKind;
 use errors::Result;
 use platform::service;
 use reader::CommandReader;
@@ -74,6 +75,37 @@ pub enum SubCmd {
     SendCmd {
         #[arg(trailing_var_arg = true)]
         cmd: Vec<String>,
+    },
+
+    /// Queries structured state from the running daemon.
+    Query {
+        #[clap(subcommand)]
+        query: QueryCmd,
+    },
+
+    /// Subscribes to structured state events from the running daemon.
+    Subscribe {
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum QueryCmd {
+    /// Prints the complete state document.
+    State {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Prints the virtual workspace list.
+    VirtualWorkspaces {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Prints the active focus/workspace state.
+    Active {
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -132,8 +164,23 @@ fn main() -> Result<()> {
         SubCmd::Stop => service()?.stop()?,
         SubCmd::Restart => service()?.restart()?,
         SubCmd::SendCmd { cmd } => CommandReader::send_command(cmd)?,
+        SubCmd::Query { query } => {
+            let output = CommandReader::send_query(query.kind())?;
+            print!("{output}");
+        }
+        SubCmd::Subscribe { json: _ } => CommandReader::subscribe_json()?,
     }
     Ok(())
+}
+
+impl QueryCmd {
+    fn kind(&self) -> StateQueryKind {
+        match self {
+            QueryCmd::State { json: _ } => StateQueryKind::State,
+            QueryCmd::VirtualWorkspaces { json: _ } => StateQueryKind::VirtualWorkspaces,
+            QueryCmd::Active { json: _ } => StateQueryKind::Active,
+        }
+    }
 }
 
 fn should_check_deprecated_options(subcmd: &SubCmd) -> bool {

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -95,6 +95,8 @@ pub trait ApplicationApi: Send + Sync {
     fn is_frontmost(&self) -> bool;
     /// Returns the bundle identifier of the application.
     fn bundle_id(&self) -> Option<&str>;
+    /// Returns the display name of the application.
+    fn name(&self) -> &str;
 }
 
 /// A wrapper struct for `ApplicationApi` trait objects, allowing for dynamic dispatch.
@@ -309,6 +311,10 @@ impl ApplicationApi for ApplicationOS {
     /// An `Option<&str>` containing the bundle ID if available, otherwise `None`.
     fn bundle_id(&self) -> Option<&str> {
         self.bundle_id.as_deref()
+    }
+
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,9 +1,13 @@
 use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use std::{fs, thread};
 use tracing::{debug, error};
 
 use crate::config::parse_command;
+use crate::ecs::state::StateQueryKind;
 use crate::errors::Result;
 use crate::events::{Event, EventSender};
 
@@ -29,6 +33,30 @@ impl CommandReader {
     ///
     /// `Ok(())` if the command is sent successfully, otherwise `Err(Error)` if an I/O error occurs or the connection fails.
     pub fn send_command(params: impl IntoIterator<Item = String>) -> Result<()> {
+        let _stream = Self::send_socket_request(params)?;
+        Ok(())
+    }
+
+    pub fn send_query(kind: StateQueryKind) -> Result<String> {
+        let args = match kind {
+            StateQueryKind::State => ["query", "state", "--json"],
+            StateQueryKind::VirtualWorkspaces => ["query", "virtual-workspaces", "--json"],
+            StateQueryKind::Active => ["query", "active", "--json"],
+        };
+        let mut stream = Self::send_socket_request(args.into_iter().map(str::to_string))?;
+        let mut output = String::new();
+        stream.read_to_string(&mut output)?;
+        Ok(output)
+    }
+
+    pub fn subscribe_json() -> Result<()> {
+        let mut stream =
+            Self::send_socket_request(["subscribe", "--json"].into_iter().map(str::to_string))?;
+        std::io::copy(&mut stream, &mut std::io::stdout())?;
+        Ok(())
+    }
+
+    fn send_socket_request(params: impl IntoIterator<Item = String>) -> Result<UnixStream> {
         let output = params
             .into_iter()
             .flat_map(|param| [param.as_bytes(), &[0]].concat())
@@ -39,7 +67,7 @@ impl CommandReader {
         let mut stream = UnixStream::connect(CommandReader::SOCKET_PATH)?;
         stream.write_all(&size.to_le_bytes())?;
         stream.write_all(&output)?;
-        Ok(())
+        Ok(stream)
     }
 
     /// Creates a new `CommandReader` instance.
@@ -99,6 +127,45 @@ impl CommandReader {
                 .collect::<Vec<_>>();
             let argv_ref = argv.iter().map(String::as_str).collect::<Vec<_>>();
 
+            if let Some(kind) = parse_query_request(&argv_ref) {
+                let (tx, rx) = channel();
+                _ = self
+                    .events
+                    .send(Event::StateQuery {
+                        kind,
+                        respond_to: tx,
+                    })
+                    .inspect_err(|err| {
+                        error!("sending state query: {err}");
+                    });
+
+                match rx.recv_timeout(Duration::from_secs(2)) {
+                    Ok(response) => {
+                        _ = stream.write_all(response.as_bytes());
+                        _ = stream.write_all(b"\n");
+                    }
+                    Err(err) => error!("waiting for state query response: {err}"),
+                }
+                continue;
+            }
+
+            if is_subscribe_request(&argv_ref) {
+                match stream.try_clone() {
+                    Ok(clone) => {
+                        _ = self
+                            .events
+                            .send(Event::StateSubscribe {
+                                stream: Arc::new(Mutex::new(clone)),
+                            })
+                            .inspect_err(|err| {
+                                error!("registering state subscriber: {err}");
+                            });
+                    }
+                    Err(err) => error!("cloning subscriber stream: {err}"),
+                }
+                continue;
+            }
+
             if let Ok(command) =
                 parse_command(&argv_ref).inspect_err(|err| error!("parsing command: {err}"))
             {
@@ -112,6 +179,21 @@ impl CommandReader {
         }
         Ok(())
     }
+}
+
+fn parse_query_request(argv: &[&str]) -> Option<StateQueryKind> {
+    match argv {
+        ["query", "state", "--json"] | ["query", "state"] => Some(StateQueryKind::State),
+        ["query", "virtual-workspaces", "--json"] | ["query", "virtual-workspaces"] => {
+            Some(StateQueryKind::VirtualWorkspaces)
+        }
+        ["query", "active", "--json"] | ["query", "active"] => Some(StateQueryKind::Active),
+        _ => None,
+    }
+}
+
+fn is_subscribe_request(argv: &[&str]) -> bool {
+    matches!(argv, ["subscribe", "--json"] | ["subscribe"])
 }
 
 fn full_read(stream: &mut UnixStream, expected: usize, buffer: &mut [u8]) -> bool {

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -73,6 +73,7 @@ impl ProcessApi for MockProcess {
 #[derive(Clone, Debug)]
 pub(crate) struct MockApplication {
     pub(crate) inner: Arc<RwLock<InnerMockApplication>>,
+    pub(crate) name: String,
 }
 
 /// The inner state of `MockApplication`, containing process serial number, PID, and focused window ID.
@@ -95,6 +96,7 @@ impl MockApplication {
                 focused_id: None,
                 bundle_id,
             })),
+            name: "test".to_string(),
         }
     }
 }
@@ -178,6 +180,10 @@ impl ApplicationApi for MockApplication {
             self.inner.force_read().bundle_id.clone().into_boxed_str(),
         ))
     }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 /// A mock implementation of the `WindowManagerApi` trait for testing purposes.
@@ -205,6 +211,7 @@ impl WindowManagerApi for MockWindowManager {
                 focused_id: None,
                 bundle_id: "test".to_string(),
             })),
+            name: "test".to_string(),
         })))
     }
 
@@ -523,6 +530,7 @@ impl WindowManagerApi for TwoDisplayMock {
                 focused_id: None,
                 bundle_id: "test".to_string(),
             })),
+            name: "test".to_string(),
         })))
     }
 

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 
-use crate::ecs::state::{PaneruState, SavedColumn, SavedStrip, SavedWindow, SavedWorkspace};
+use crate::ecs::state::{
+    PaneruQueryState, PaneruState, SavedColumn, SavedStrip, SavedWindow, SavedWorkspace,
+};
 use crate::platform::ProcessSerialNumber;
 use crate::tests::TEST_WORKSPACE_ID;
 
@@ -98,4 +100,69 @@ fn test_state_extraction() {
     } else {
         panic!("Expected SavedColumn::Single");
     }
+}
+
+#[test]
+#[allow(clippy::type_complexity)]
+fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
+    use crate::ecs::layout::LayoutStrip;
+    use crate::ecs::params::Windows;
+    use crate::manager::{Application, Display};
+    use crate::tests::harness::TestHarness;
+    use bevy::ecs::hierarchy::ChildOf;
+    use bevy::ecs::query::Has;
+    use bevy::ecs::system::SystemState;
+
+    let mut harness = TestHarness::new().with_windows(1);
+
+    harness.app.update();
+
+    let world = harness.app.world_mut();
+    let mut active_display_query =
+        world.query_filtered::<Entity, With<crate::ecs::ActiveDisplayMarker>>();
+    let display_entity = active_display_query
+        .single(world)
+        .expect("active display should exist");
+    world.spawn((
+        LayoutStrip::new(TEST_WORKSPACE_ID, 2),
+        ChildOf(display_entity),
+    ));
+
+    let mut system_state: SystemState<(
+        Query<(
+            &ChildOf,
+            &LayoutStrip,
+            Has<crate::ecs::ActiveWorkspaceMarker>,
+        )>,
+        Query<(&Display, Entity, Has<crate::ecs::ActiveDisplayMarker>)>,
+        Windows,
+        Query<&Application>,
+    )> = SystemState::new(world);
+    let (workspaces, displays, windows, apps) = system_state.get(world);
+
+    let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
+
+    assert_eq!(state.version, 1);
+    assert_eq!(state.active.virtual_workspace_number, Some(1));
+    assert_eq!(state.active.native_workspace_id, Some(TEST_WORKSPACE_ID));
+    assert_eq!(state.active.focused_window_id, Some(0));
+    assert_eq!(state.active.focused_bundle_id.as_deref(), Some("test"));
+    assert_eq!(state.virtual_workspaces.len(), 3);
+    assert_eq!(state.virtual_workspaces[0].number, 1);
+    assert!(state.virtual_workspaces[0].active);
+    assert_eq!(state.virtual_workspaces[0].windows.len(), 1);
+    assert_eq!(state.virtual_workspaces[0].windows[0].window_id, 0);
+    assert_eq!(state.virtual_workspaces[0].windows[0].bundle_id, "test");
+    assert!(state.virtual_workspaces[0].windows[0].focused);
+    assert_eq!(state.virtual_workspaces[1].number, 2);
+    assert!(state.virtual_workspaces[1].windows.is_empty());
+    assert_eq!(state.virtual_workspaces[2].number, 3);
+    assert!(state.virtual_workspaces[2].windows.is_empty());
+
+    let json = serde_json::to_value(&state).expect("query state should serialize");
+    assert_eq!(json["active"]["virtual_workspace_number"], 1);
+    assert_eq!(
+        json["virtual_workspaces"][0]["windows"][0]["bundle_id"],
+        "test"
+    );
 }


### PR DESCRIPTION
- Add `paneru query` and `paneru subscribe` commands for structured JSON state over the Unix socket
- Support absolute virtual workspace switching via `window virtualnum` and related commands
- Preserve empty virtual workspace rows to maintain stable numbered slots


Note: Im not an expert in rust, I used codex for helping me code this.