### PR TITLE
Fix vertical swap logic within stack and unmanaged window bug

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -324,7 +324,13 @@ fn command_swap_focus(
             active_strip.len()
         );
 
-        if index < new_index {
+        if index == new_index {
+            if let Some(Column::Stack(stack)) = active_strip.get_column_mut(index) {
+                let pos_a = stack.iter().position(|i| i.contains(current))?;
+                let pos_b = stack.iter().position(|i| i.contains(other_window))?;
+                stack.swap(pos_a, pos_b);
+            }
+        } else if index < new_index {
             (index..new_index).for_each(|idx| active_strip.swap(idx, idx + 1));
         } else {
             (new_index..index)

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -548,7 +548,7 @@ pub(super) fn window_unmanaged_trigger(
             let h = (f64::from(display_bounds.height()) * rh) as i32;
             reposition_entity(entity, Origin::new(x, y), &mut commands);
             resize_entity(entity, Size::new(w, h), &mut commands);
-        } else {
+        } else if !properties.floating() {
             let max_width = display_bounds.width() * UNMANAGED_MAX_SCREEN_RATIO_NUM
                 / UNMANAGED_MAX_SCREEN_RATIO_DEN;
             let max_height = display_bounds.height() * UNMANAGED_MAX_SCREEN_RATIO_NUM


### PR DESCRIPTION
  - Fix window swap north/south not working in vertical stacks. Both windows shared the same column index, so the swap was a silent no-op. Now swaps StackItems within the column when the source and target are in the same stack.
  - Fix floating windows configured via [windows] rules being repositioned on spawn. The 32px offset nudge now only applies to dynamically-floated windows (toggle/rescue), not config-declared ones.
