### PR TITLE
feat: Restore window sessions on startup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 1.  **Platform Layer:** `src/platform/` uses `objc2` and AppKit to interface with macOS. It runs a native event loop or hooks into OS notifications.
 2.  **Event Channel:** macOS events (mouse moves, window creations, space changes) are sent via a thread-safe `mpsc` channel.
 3.  **Pump System:** The `pump_events` system (in `src/ecs/systems.rs`) reads from this channel during the `PreUpdate` phase and writes Bevy `Message`s or triggers `Observer`s.
-4.  **Observers:** Bevy Observers (in `src/ecs/triggers.rs`) react to these events to update the ECS World (e.g., spawning new `Window` entities or updating `FocusedMarker`).
+4.  **Observers:** Bevy Observers (primarily in `src/ecs/triggers.rs`, with focused domains such as session restore in `src/ecs/restore.rs`) react to these events to update the ECS World (e.g., spawning new `Window` entities or updating `FocusedMarker`).
 
 ### State Synchronization (ECS -> macOS)
 1.  **Systems:** Bevy systems (like `layout::position_layout_windows`) calculate the intended positions and sizes of windows based on the tiling logic.
@@ -36,6 +36,7 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 | `src/ecs/systems.rs` | Bevy systems for lifecycle management, event pumping, and state syncing. |
 | `src/ecs/params.rs` | High-level Bevy `SystemParam` abstractions for querying the World. |
 | `src/ecs/triggers.rs` | Reactive event handlers (Observers) for OS and internal events. |
+| `src/ecs/restore.rs` | Startup session restore planning and application, including window matching, layout rebuilding, and restore grace-period handling. |
 | `src/ecs/workspace.rs` | Management of virtual workspaces, display changes, and window movement between spaces. |
 | `src/ecs/scroll.rs` | Input handling for trackpad swipe gestures, inertia, and snapping. |
 | `src/ecs/focus.rs` | Focus management logic, including focus-follows-mouse and mouse-follows-focus. |
@@ -64,7 +65,8 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 ### Resources
 - **`WindowManager`:** A wrapper for the global window management state and OS bridge.
 - **`Config`:** The current user configuration.
-- **`PaneruState`**: The persisted state of the window manager, used for recovery after restarts.
+- **`PaneruState`**: The durable snapshot of managed layout, display, native workspace, and virtual workspace state used for recovery after restarts.
+- **`SessionRestore`**: A short-lived startup resource that keeps loaded state and restore timing active until the startup grace period expires.
 - **`MissionControlActive`:** A flag indicating if macOS Mission Control is visible (disabling tiling).
 - **`FocusFollowsMouse`:** Tracks which window should gain focus based on mouse position.
 
@@ -73,9 +75,37 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 - **Main Thread Only:** Any interaction with `objc2`, `AppKit`, or `Accessibility` APIs **must** occur on the main thread.
 - **ECS as Source of Truth:** Tiling logic must operate on ECS components (`WidthRatio`, `LayoutStrip`). The physical macOS window state should be a reflection of the ECS state, not the other way around.
 - **Pure Layout:** Layout math (in `layout.rs`) should remain as pure as possible, operating on coordinates and ratios rather than directly calling OS APIs.
+- **Bounded Restore:** Saved session state is only consulted during startup restore. After `SessionRestore` expires, normal config and window-rule placement owns newly discovered windows.
 - **Reactive Power Saving:** Systems should use Bevy's reactive scheduling to avoid CPU usage when no windows are moving or events are occurring.
 
-## 6. Data Flow Diagram
+## 6. Session Restore
+
+`src/ecs/state.rs` extracts and persists the restart snapshot. The state file is
+written atomically to `paneru/state.json` in the XDG state directory
+(`~/.local/state/paneru/state.json` on a default macOS setup) and is loaded
+during Bevy app setup.
+
+`src/ecs/restore.rs` owns startup restore. It keeps the loaded `PaneruState`
+alive in `SessionRestore` for the configured grace period so applications have
+time to reopen their windows. As windows arrive, `restore_window_state` builds a
+restore plan from the saved state and the currently managed ECS windows.
+
+Window matching prefers stable identity (`window_id`, `pid`, and `bundle_id`)
+and uses the conservative fallback identity only when it can do so
+unambiguously. The fallback includes `bundle_id`, window title when available,
+window identifier, role, and subrole. Saved windows that are missing at startup
+are ignored by default, and the restored layout is compacted around the matched
+windows.
+
+Restore rebuilds `LayoutStrip`s, virtual workspace rows, selected virtual
+workspace markers, and display associations. When the current macOS workspace
+to display mapping conflicts with saved display data, the current mapping is
+preferred; otherwise restore falls back to the saved display, then the active
+display, then any available display. Matched startup windows skip static
+`[windows]` placement so the saved session wins, while unmatched windows and
+post-grace windows follow normal config behavior.
+
+## 7. Data Flow Diagram
 
 ```mermaid
 graph TD
@@ -88,11 +118,15 @@ graph TD
     E -->|PostUpdate| G(commit_window_position)
     G -->|FFI Call| A
     H[CommandReader] -->|Unix Socket| C
+    S[PaneruState file] -->|Startup load| R(session restore)
+    R -->|Rebuild saved strips| E
+    E -->|Periodic / exit save| S
 ```
 
-## 7. Testing Strategy
+## 8. Testing Strategy
 
 1.  **Pure Unit Tests:** Located in `src/tests.rs` and alongside modules. These test layout math and configuration parsing without requiring a macOS environment.
 2.  **ECS Integration Tests:** Use Bevy's `App` or `World` to drive systems in isolation. macOS APIs are typically mocked via the `WindowApi` and `WindowManagerApi` traits.
-3.  **FFI Verification:** Manual or semi-automated tests on macOS to ensure the Accessibility API calls behave as expected with native windows.
-4.  **Agent Support:** The `AGENTS.md` file provides project-specific guidance for AI agents to ensure contributions follow these architectural patterns.
+3.  **Session Restore Tests:** `src/tests/session_restore.rs` covers restore planning, missing-window compaction, startup grace behavior, config precedence, virtual workspace restoration, and multi-display fallback.
+4.  **FFI Verification:** Manual or semi-automated tests on macOS to ensure the Accessibility API calls behave as expected with native windows.
+5.  **Agent Support:** The `AGENTS.md` file provides project-specific guidance for AI agents to ensure contributions follow these architectural patterns.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -219,6 +219,73 @@ horizontal_padding = 5
 bindings_passthrough = ["ctrl-h", "ctrl-l"]
 ```
 
+### Session Restore
+
+Paneru saves its managed window layout and can restore it the next time it
+starts. Restore is a startup-only phase: Paneru loads the saved session, applies
+it after initial window discovery, keeps matching open for a short grace period,
+then stops consulting the saved state until the next Paneru process start.
+
+The saved session includes:
+
+- native workspace ids
+- virtual workspace rows and the selected row per native workspace
+- layout structure: singles, stacks, tabs, and fullscreen strips
+- display/screen association
+- window identity for matching across restarts
+
+Matched startup windows use the saved session before static `[windows]` rules.
+That means saved layout, virtual workspace, display, and managed/floating state
+win over configured `index`, `floating`, `width`, and `grid` rules during
+restore. Unmatched startup windows, and all windows created after the restore
+grace period ends, keep normal `[windows]` behavior.
+
+| Option | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `enabled` | Boolean | `true` | Enables session restore on startup. |
+| `startup_grace_ms` | Integer (ms) | `2000` | How long Paneru keeps restore matching active after startup. This gives apps a chance to create windows shortly after Paneru starts. |
+| `missing_windows` | String | `"ignore"` | Behavior when a saved window is not present during restore. Currently only `"ignore"` is supported, which drops the missing window and compacts the restored layout. |
+
+**Example:**
+```toml
+[restore]
+enabled = true
+startup_grace_ms = 2000
+missing_windows = "ignore"
+```
+
+Restore matches windows first by stable startup identity:
+
+- window id
+- process id
+- bundle id
+
+If an application has restarted and those ids changed, Paneru can use a
+conservative fallback match:
+
+- bundle id
+- non-empty window title
+- window identifier
+- accessibility role
+- accessibility subrole
+
+Fallback matching is only used when it is unambiguous. If multiple current
+windows could match the same saved window, Paneru skips that saved window rather
+than moving the wrong one.
+
+If a saved app or window is missing, the default `"ignore"` policy simply drops
+it from the restored layout. Empty stacks, tab groups, columns, and virtual rows
+are removed. If the previously selected virtual row is removed because all of
+its windows are missing, Paneru selects the nearest remaining restored row for
+that native workspace. If no restored row remains, the normal startup workspace
+selection is kept.
+
+For screens, Paneru prefers the current macOS workspace-to-display mapping when
+the workspace is already present on a display. Otherwise it restores to the
+saved display id when that screen is still connected, then falls back to the
+current active display, then the first available display by id. Paneru does not
+create placeholder displays or off-screen state for disconnected monitors.
+
 ---
 
 ## 7. Experimental Features

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ adjacent monitors.
   workspaces to stay organized within each context.
 - **Menu bar workspace indicator:** Shows the currently active virtual
   workspace in the macOS menu bar.
+- **Startup session restore:** Restores managed window layouts, virtual
+  workspaces, and display assignments from the last saved state when Paneru
+  starts.
 - **Focus follows mouse on MacOS:** Very useful for people who would like to
   avoid an extra click.
 - **Sliding windows with touchpad:** Using a touchpad is quite natural for
@@ -159,6 +162,23 @@ quit = "ctrl + alt - q"
 Configuration changes made to your `~/.paneru` file are automatically reloaded
 while Paneru is running. This is useful for tweaking keyboard bindings and
 other settings without restarting the application.
+
+### Startup session restore
+
+Paneru saves managed window layout state to the user state directory
+(`$XDG_STATE_HOME/paneru/state.json`, usually
+`~/.local/state/paneru/state.json`) and loads it when Paneru starts. During the
+startup restore window, Paneru matches reopened windows to the saved session and
+restores their layout placement, virtual workspace row, and display assignment
+where possible.
+
+Restore is startup-only. After the configured startup grace period expires, new
+or unmatched windows follow the normal configuration and window-rule behavior.
+Saved windows that are not present are ignored by default and the restored
+layout is compacted around the windows that were found. The behavior is
+configured with `[restore]`; see the
+**[Session Restore](./CONFIGURATION.md#session-restore)** section in the
+configuration guide.
 
 ### Running as a service
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use std::{
     path::{Path, PathBuf},
     ptr::NonNull,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 use stdext::function_name;
 use tracing::{error, info, warn};
@@ -632,6 +633,32 @@ impl Config {
         self.options().mouse_resize_modifier
     }
 
+    pub fn restore_enabled(&self) -> bool {
+        self.inner()
+            .restore
+            .as_ref()
+            .and_then(|restore| restore.enabled)
+            .unwrap_or(true)
+    }
+
+    pub fn restore_startup_grace(&self) -> Duration {
+        Duration::from_millis(
+            self.inner()
+                .restore
+                .as_ref()
+                .and_then(|restore| restore.startup_grace_ms)
+                .unwrap_or(2000),
+        )
+    }
+
+    pub fn restore_missing_windows(&self) -> MissingWindowBehavior {
+        self.inner()
+            .restore
+            .as_ref()
+            .and_then(|restore| restore.missing_windows)
+            .unwrap_or(MissingWindowBehavior::Ignore)
+    }
+
     pub fn swipe_scroll_modifier(&self) -> Modifiers {
         let config = self.inner();
         config
@@ -806,6 +833,7 @@ struct InnerConfig {
     decorations: Option<decorations::DecorationsOptions>,
     swipe: Option<swipe::SwipeOptions>,
     padding: Option<padding::PaddingOptions>,
+    restore: Option<RestoreOptions>,
 }
 
 impl InnerConfig {
@@ -833,6 +861,11 @@ impl InnerConfig {
     ///
     /// `Ok(InnerConfig)` if the parsing is successful, otherwise `Err(Error)` with an error message.
     fn parse_config(input: &str) -> Result<InnerConfig> {
+        let config: InnerConfig = toml::from_str(input)?;
+        if !config.needs_virtual_keys() {
+            return Ok(config);
+        }
+
         let virtual_keys = generate_virtual_keymap();
         Self::parse_config_with_virtual_keys(input, &virtual_keys)
     }
@@ -871,6 +904,28 @@ impl InnerConfig {
 
         Ok(config)
     }
+
+    fn needs_virtual_keys(&self) -> bool {
+        !self.bindings.is_empty()
+            || self.windows.as_ref().is_some_and(|windows| {
+                windows
+                    .values()
+                    .any(|params| !params.bindings_passthrough.is_empty())
+            })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingWindowBehavior {
+    Ignore,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct RestoreOptions {
+    pub enabled: Option<bool>,
+    pub startup_grace_ms: Option<u64>,
+    pub missing_windows: Option<MissingWindowBehavior>,
 }
 
 /// `MainOptions` represents the primary configuration options for the window manager.
@@ -1777,6 +1832,59 @@ fn test_config_defaults() {
     assert_eq!(config.border_width(), 2.0);
     assert_eq!(config.border_radius(), BorderRadiusOption::Auto);
     assert_eq!(config.menubar_height(), None);
+}
+
+#[test]
+fn test_restore_config_defaults() {
+    let config = Config::try_from("[options]\n\n[bindings]\n").expect("config should parse");
+
+    assert!(config.restore_enabled());
+    assert_eq!(config.restore_startup_grace(), Duration::from_millis(2000));
+    assert_eq!(
+        config.restore_missing_windows(),
+        MissingWindowBehavior::Ignore
+    );
+}
+
+#[test]
+fn test_restore_config_explicit_values() {
+    let config = Config::try_from(
+        r#"
+[options]
+
+[restore]
+enabled = false
+startup_grace_ms = 750
+missing_windows = "ignore"
+
+[bindings]
+"#,
+    )
+    .expect("config should parse");
+
+    assert!(!config.restore_enabled());
+    assert_eq!(config.restore_startup_grace(), Duration::from_millis(750));
+    assert_eq!(
+        config.restore_missing_windows(),
+        MissingWindowBehavior::Ignore
+    );
+}
+
+#[test]
+fn test_restore_config_rejects_unsupported_missing_window_policy() {
+    let err = Config::try_from(
+        r#"
+[options]
+
+[restore]
+missing_windows = "reserve"
+
+[bindings]
+"#,
+    )
+    .expect_err("unsupported restore missing-window policy should fail");
+
+    assert!(err.to_string().contains("unknown variant"));
 }
 
 #[test]

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -38,6 +38,7 @@ pub mod focus;
 pub mod layout;
 pub mod mouse;
 pub mod params;
+pub(crate) mod restore;
 pub mod scroll;
 pub mod state;
 mod systems;
@@ -101,6 +102,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 .chain()
                 .run_if(not_swiping),
             systems::cleanup_on_exit,
+            restore::tick_restore_grace,
             state::periodic_state_save.run_if(on_timer(Duration::from_secs(300))),
             state::cleanup_on_exit,
         ),
@@ -165,7 +167,7 @@ pub fn register_triggers(app: &mut bevy::app::App) {
         .add_observer(triggers::send_message_trigger)
         .add_observer(triggers::window_removal_trigger)
         .add_observer(triggers::apply_window_properties)
-        .add_observer(triggers::restore_window_state);
+        .add_observer(restore::restore_window_state);
 }
 
 /// Marker component for the currently focused window.
@@ -476,7 +478,9 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         .insert_non_send_resource(menu_bar_manager)
         .insert_non_send_resource(receiver);
 
-    if let Some(previous_state) = PaneruState::load_from_file(state::STATE_FILE_PATH) {
+    if let Some(previous_state) =
+        PaneruState::load_from_file(&PaneruState::default_state_file_path())
+    {
         app.insert_resource(previous_state);
     }
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -270,6 +270,13 @@ pub enum Unmanaged {
     Hidden,
 }
 
+#[derive(Clone, Component, Copy, Debug)]
+pub struct PreviousManagedStrip {
+    pub workspace_id: WorkspaceId,
+    pub virtual_index: u32,
+    pub index: usize,
+}
+
 /// Wrapper component for a `ProcessApi` trait object, enabling dynamic dispatch for process-related operations within Bevy.
 #[derive(Component, Deref, DerefMut)]
 pub struct BProcess(pub Box<dyn ProcessApi>);

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -277,6 +277,14 @@ impl Windows<'_, '_> {
             .map(|(window, entity, childof, _)| (window, entity, childof))
     }
 
+    pub fn managed_iter(&self) -> impl Iterator<Item = (&Window, Entity, &ChildOf)> {
+        self.all
+            .iter()
+            .filter_map(|(window, entity, childof, unmanaged)| {
+                unmanaged.is_none().then_some((window, entity, childof))
+            })
+    }
+
     pub fn full_width(&self, entity: Entity) -> Option<&FullWidthMarker> {
         self.previous_size
             .get(entity)

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -1,0 +1,667 @@
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::observer::On;
+use bevy::ecs::query::Has;
+use bevy::ecs::resource::Resource;
+use bevy::ecs::system::{Commands, Query, Res, ResMut};
+use bevy::time::{Time, Timer, TimerMode, Virtual};
+use objc2_core_graphics::CGDirectDisplayID;
+use tracing::{Level, info, instrument, warn};
+
+use crate::config::{Config, MissingWindowBehavior};
+use crate::ecs::layout::LayoutStrip;
+use crate::ecs::params::Windows;
+use crate::ecs::state::{
+    PaneruState, SavedColumn, SavedStackItem, SavedStrip, SavedWindow, SavedWorkspace,
+};
+use crate::ecs::workspace::PreviousStripPosition;
+use crate::ecs::{
+    ActiveDisplayMarker, ActiveWorkspaceMarker, Position, RestoreWindowState,
+    SelectedVirtualMarker, Unmanaged,
+};
+use crate::manager::{Application, Display, Window};
+use crate::platform::{Pid, WinID, WorkspaceId};
+
+#[derive(Debug, Resource)]
+pub(crate) struct SessionRestore {
+    state: PaneruState,
+    timer: Timer,
+}
+
+impl SessionRestore {
+    fn new(state: PaneruState, grace: Duration) -> Self {
+        Self {
+            state,
+            timer: Timer::new(grace, TimerMode::Once),
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn tick_restore_grace(
+    time: Res<Time<Virtual>>,
+    mut session: Option<ResMut<SessionRestore>>,
+    mut commands: Commands,
+) {
+    let Some(session) = session.as_mut() else {
+        return;
+    };
+
+    session.timer.tick(time.delta());
+    if session.timer.is_finished() {
+        info!("Session restore grace period ended");
+        commands.remove_resource::<SessionRestore>();
+        commands.remove_resource::<PaneruState>();
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CurrentWindowIdentity {
+    pub entity: Entity,
+    pub window_id: WinID,
+    pub pid: Pid,
+    pub bundle_id: String,
+    pub title: String,
+    pub identifier: String,
+    pub role: String,
+    pub subrole: String,
+}
+
+impl CurrentWindowIdentity {
+    #[cfg(test)]
+    pub(crate) fn fallback_only(entity: Entity, bundle_id: &str, title: &str) -> Self {
+        Self {
+            entity,
+            window_id: -1,
+            pid: -1,
+            bundle_id: bundle_id.to_string(),
+            title: title.to_string(),
+            identifier: "main".to_string(),
+            role: "AXWindow".to_string(),
+            subrole: "AXStandardWindow".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PlannedColumn {
+    Single(Entity),
+    Stack(Vec<PlannedStackItem>),
+    Tabs(Vec<Entity>),
+    Fullscreen(Entity),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PlannedStackItem {
+    Single(Entity),
+    Tabs(Vec<Entity>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PlannedStrip {
+    pub workspace_id: WorkspaceId,
+    pub display_id: Option<CGDirectDisplayID>,
+    pub virtual_index: u32,
+    pub columns: Vec<PlannedColumn>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct RestorePlan {
+    pub strips: Vec<PlannedStrip>,
+    pub active_virtual_by_workspace: HashMap<WorkspaceId, u32>,
+    pub consumed_entities: HashSet<Entity>,
+    pub ignored_missing_windows: usize,
+    pub skipped_ambiguous_matches: usize,
+}
+
+pub(crate) struct RestorePlanner<'a> {
+    state: &'a PaneruState,
+}
+
+impl<'a> RestorePlanner<'a> {
+    pub(crate) fn new(state: &'a PaneruState) -> Self {
+        Self { state }
+    }
+
+    pub(crate) fn plan(&self, current: &[CurrentWindowIdentity]) -> RestorePlan {
+        let mut plan = RestorePlan::default();
+
+        for workspace in &self.state.workspaces {
+            let surviving_strips = self.plan_workspace(workspace, current, &mut plan);
+            Self::record_active_virtual(workspace, &surviving_strips, &mut plan);
+            plan.strips.extend(surviving_strips);
+        }
+
+        plan
+    }
+
+    fn plan_workspace(
+        &self,
+        workspace: &SavedWorkspace,
+        current: &[CurrentWindowIdentity],
+        plan: &mut RestorePlan,
+    ) -> Vec<PlannedStrip> {
+        workspace
+            .strips
+            .iter()
+            .filter_map(|strip| self.plan_strip(workspace, strip, current, plan))
+            .collect()
+    }
+
+    fn plan_strip(
+        &self,
+        workspace: &SavedWorkspace,
+        strip: &SavedStrip,
+        current: &[CurrentWindowIdentity],
+        plan: &mut RestorePlan,
+    ) -> Option<PlannedStrip> {
+        let columns = strip
+            .columns
+            .iter()
+            .filter_map(|column| self.plan_column(column, current, plan))
+            .collect::<Vec<_>>();
+
+        (!columns.is_empty()).then_some(PlannedStrip {
+            workspace_id: workspace.workspace_id,
+            display_id: workspace.display_id,
+            virtual_index: strip.virtual_index,
+            columns,
+        })
+    }
+
+    fn plan_column(
+        &self,
+        column: &SavedColumn,
+        current: &[CurrentWindowIdentity],
+        plan: &mut RestorePlan,
+    ) -> Option<PlannedColumn> {
+        match column {
+            SavedColumn::Single(saved) => self
+                .match_window(saved, current, plan)
+                .map(PlannedColumn::Single),
+            SavedColumn::Fullscreen(saved) => self
+                .match_window(saved, current, plan)
+                .map(PlannedColumn::Fullscreen),
+            SavedColumn::Tabs(tabs) => compact_entities(
+                tabs.iter()
+                    .filter_map(|saved| self.match_window(saved, current, plan))
+                    .collect(),
+            ),
+            SavedColumn::Stack(items) => compact_stack_items(
+                items
+                    .iter()
+                    .filter_map(|item| self.plan_stack_item(item, current, plan))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn plan_stack_item(
+        &self,
+        item: &SavedStackItem,
+        current: &[CurrentWindowIdentity],
+        plan: &mut RestorePlan,
+    ) -> Option<PlannedStackItem> {
+        match item {
+            SavedStackItem::Single(saved) => self
+                .match_window(saved, current, plan)
+                .map(PlannedStackItem::Single),
+            SavedStackItem::Tabs(tabs) => compact_stack_tabs(
+                tabs.iter()
+                    .filter_map(|saved| self.match_window(saved, current, plan))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn match_window(
+        &self,
+        saved: &SavedWindow,
+        current: &[CurrentWindowIdentity],
+        plan: &mut RestorePlan,
+    ) -> Option<Entity> {
+        if let Some(window) = current.iter().find(|window| {
+            !plan.consumed_entities.contains(&window.entity)
+                && saved.hard_match(window.window_id, window.pid, &window.bundle_id)
+        }) {
+            plan.consumed_entities.insert(window.entity);
+            return Some(window.entity);
+        }
+
+        let fallback_matches = current
+            .iter()
+            .filter(|window| {
+                !plan.consumed_entities.contains(&window.entity)
+                    && saved.fallback_match(window)
+                    && !self.current_window_has_saved_hard_match(window)
+            })
+            .collect::<Vec<_>>();
+
+        match fallback_matches.as_slice() {
+            [window] => {
+                plan.consumed_entities.insert(window.entity);
+                Some(window.entity)
+            }
+            [] => {
+                plan.ignored_missing_windows += 1;
+                None
+            }
+            _ => {
+                plan.skipped_ambiguous_matches += 1;
+                None
+            }
+        }
+    }
+
+    fn current_window_has_saved_hard_match(&self, current: &CurrentWindowIdentity) -> bool {
+        self.saved_windows()
+            .any(|saved| saved.hard_match(current.window_id, current.pid, &current.bundle_id))
+    }
+
+    fn saved_windows(&self) -> impl Iterator<Item = &SavedWindow> {
+        self.state
+            .workspaces
+            .iter()
+            .flat_map(|workspace| &workspace.strips)
+            .flat_map(|strip| &strip.columns)
+            .flat_map(saved_windows_in_column)
+    }
+
+    fn record_active_virtual(
+        workspace: &SavedWorkspace,
+        surviving_strips: &[PlannedStrip],
+        plan: &mut RestorePlan,
+    ) {
+        let Some(saved_active) = workspace.active_virtual_index else {
+            if let Some(first_survivor) = surviving_strips
+                .iter()
+                .map(|strip| strip.virtual_index)
+                .min()
+            {
+                plan.active_virtual_by_workspace
+                    .insert(workspace.workspace_id, first_survivor);
+            }
+            return;
+        };
+        let Some(nearest_active) = surviving_strips
+            .iter()
+            .map(|strip| strip.virtual_index)
+            .min_by_key(|virtual_index| (virtual_index.abs_diff(saved_active), *virtual_index))
+        else {
+            return;
+        };
+
+        plan.active_virtual_by_workspace
+            .insert(workspace.workspace_id, nearest_active);
+    }
+}
+
+fn saved_windows_in_column(column: &SavedColumn) -> Box<dyn Iterator<Item = &SavedWindow> + '_> {
+    match column {
+        SavedColumn::Single(saved) | SavedColumn::Fullscreen(saved) => {
+            Box::new(std::iter::once(saved))
+        }
+        SavedColumn::Tabs(tabs) => Box::new(tabs.iter()),
+        SavedColumn::Stack(items) => Box::new(items.iter().flat_map(saved_windows_in_stack_item)),
+    }
+}
+
+fn saved_windows_in_stack_item(
+    item: &SavedStackItem,
+) -> Box<dyn Iterator<Item = &SavedWindow> + '_> {
+    match item {
+        SavedStackItem::Single(saved) => Box::new(std::iter::once(saved)),
+        SavedStackItem::Tabs(tabs) => Box::new(tabs.iter()),
+    }
+}
+
+impl SavedWindow {
+    fn fallback_match(&self, current: &CurrentWindowIdentity) -> bool {
+        !self.title.is_empty()
+            && self.bundle_id == current.bundle_id
+            && self.title == current.title
+            && self.identifier == current.identifier
+            && self.role == current.role
+            && self.subrole == current.subrole
+    }
+}
+
+pub(crate) fn matches_startup_restore_state(
+    window: &Window,
+    app: &Application,
+    session: Option<&SessionRestore>,
+    restoration: Option<&PaneruState>,
+    config: &Config,
+) -> bool {
+    if !config.restore_enabled() {
+        return false;
+    }
+
+    let state = session.map_or(restoration, |session| Some(&session.state));
+    let Some(state) = state else {
+        return false;
+    };
+    let Ok(pid) = window.pid() else {
+        return false;
+    };
+    let bundle_id = app.bundle_id().unwrap_or_default().to_string();
+
+    RestorePlanner::new(state)
+        .saved_windows()
+        .any(|saved| saved.hard_match(window.id(), pid, &bundle_id))
+}
+
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments,
+    clippy::too_many_lines
+)]
+#[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
+pub(super) fn restore_window_state(
+    _: On<RestoreWindowState>,
+    windows: Windows,
+    mut workspaces: Query<(
+        Entity,
+        &mut LayoutStrip,
+        Option<&ChildOf>,
+        Has<ActiveWorkspaceMarker>,
+    )>,
+    displays: Query<(Entity, &Display, Has<ActiveDisplayMarker>)>,
+    apps: Query<&Application>,
+    config: Res<Config>,
+    session: Option<Res<SessionRestore>>,
+    restoration: Option<Res<PaneruState>>,
+    mut commands: Commands,
+) {
+    let restoration = if let Some(session) = session {
+        session.state.clone()
+    } else {
+        let Some(restoration) = restoration else {
+            return;
+        };
+        if !config.restore_enabled() {
+            info!("Session restore disabled by configuration");
+            commands.remove_resource::<PaneruState>();
+            return;
+        }
+        match config.restore_missing_windows() {
+            MissingWindowBehavior::Ignore => {}
+        }
+        let restoration = restoration.as_ref().clone();
+        commands.insert_resource(SessionRestore::new(
+            restoration.clone(),
+            config.restore_startup_grace(),
+        ));
+        restoration
+    };
+
+    let current = current_window_identities(&windows, &apps);
+    let plan = RestorePlanner::new(&restoration).plan(&current);
+
+    if plan.consumed_entities.is_empty() {
+        info!(
+            "Session restore matched 0 windows; missing={}, ambiguous={}",
+            plan.ignored_missing_windows, plan.skipped_ambiguous_matches
+        );
+        return;
+    }
+
+    let mut existing_workspace_parents = HashMap::new();
+    let mut active_workspace_ids = HashSet::new();
+    let mut emptied_existing_strips = HashSet::new();
+    for (entity, mut strip, child, active) in &mut workspaces {
+        if active {
+            active_workspace_ids.insert(strip.id());
+        }
+        if let Some(child) = child {
+            existing_workspace_parents
+                .entry(strip.id())
+                .or_insert_with(|| child.parent());
+        }
+
+        let had_consumed_window = plan
+            .consumed_entities
+            .iter()
+            .any(|entity| strip.contains(*entity));
+        for entity in &plan.consumed_entities {
+            strip.remove(*entity);
+        }
+
+        if had_consumed_window && strip.all_windows().is_empty() {
+            emptied_existing_strips.insert(entity);
+        }
+    }
+
+    for entity in &emptied_existing_strips {
+        commands.entity(*entity).despawn();
+    }
+
+    for entity in &plan.consumed_entities {
+        commands.entity(*entity).try_remove::<Unmanaged>();
+    }
+
+    let mut restored_strips = 0;
+    for planned in &plan.strips {
+        let Some((display_entity, display)) = select_display(
+            planned.workspace_id,
+            planned.display_id,
+            &existing_workspace_parents,
+            &displays,
+        ) else {
+            warn!(
+                "Skipping restore for workspace {} virtual {} because no display exists",
+                planned.workspace_id, planned.virtual_index
+            );
+            continue;
+        };
+
+        let strip = layout_strip_from_plan(planned);
+        if strip.all_windows().is_empty() {
+            continue;
+        }
+
+        let is_active = plan
+            .active_virtual_by_workspace
+            .get(&planned.workspace_id)
+            .is_some_and(|active| *active == planned.virtual_index);
+        let is_global_active = is_active && active_workspace_ids.contains(&planned.workspace_id);
+        if is_active {
+            for (entity, strip, _, _) in &mut workspaces {
+                if strip.id() == planned.workspace_id && !emptied_existing_strips.contains(&entity)
+                {
+                    if is_global_active {
+                        commands
+                            .entity(entity)
+                            .remove::<(ActiveWorkspaceMarker, SelectedVirtualMarker)>();
+                    } else {
+                        commands.entity(entity).remove::<SelectedVirtualMarker>();
+                    }
+                }
+            }
+        }
+
+        let origin = if is_global_active {
+            display.bounds().min
+        } else {
+            display.bounds().max - 10
+        };
+        let previous = PreviousStripPosition {
+            origin: display.bounds().min,
+            focus: strip.all_windows().first().copied(),
+        };
+
+        let mut spawned = commands.spawn((strip, Position(origin), ChildOf(display_entity)));
+        if is_global_active {
+            spawned.insert((ActiveWorkspaceMarker, SelectedVirtualMarker));
+        } else if is_active {
+            spawned.insert((SelectedVirtualMarker, previous));
+        } else {
+            spawned.insert(previous);
+        }
+        restored_strips += 1;
+    }
+
+    info!(
+        "Session restore applied: matched={}, strips={}, missing={}, ambiguous={}",
+        plan.consumed_entities.len(),
+        restored_strips,
+        plan.ignored_missing_windows,
+        plan.skipped_ambiguous_matches
+    );
+}
+
+fn layout_strip_from_plan(planned: &PlannedStrip) -> LayoutStrip {
+    if let [PlannedColumn::Fullscreen(entity)] = planned.columns.as_slice() {
+        let mut strip = LayoutStrip::fullscreen(planned.workspace_id, *entity);
+        strip.virtual_index = planned.virtual_index;
+        return strip;
+    }
+
+    let mut strip = LayoutStrip::new(planned.workspace_id, planned.virtual_index);
+    apply_planned_columns(&mut strip, &planned.columns);
+    strip
+}
+
+fn current_window_identities(
+    windows: &Windows,
+    apps: &Query<&Application>,
+) -> Vec<CurrentWindowIdentity> {
+    windows
+        .managed_iter()
+        .filter_map(|(window, entity, child)| {
+            let app = apps.get(child.parent()).ok()?;
+            Some(CurrentWindowIdentity {
+                entity,
+                window_id: window.id(),
+                pid: window.pid().ok()?,
+                bundle_id: app.bundle_id().unwrap_or_default().to_string(),
+                title: window.title().unwrap_or_default(),
+                identifier: window.identifier().unwrap_or_default(),
+                role: window.role().unwrap_or_default(),
+                subrole: window.subrole().unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
+fn select_display<'a>(
+    workspace_id: WorkspaceId,
+    planned_display_id: Option<CGDirectDisplayID>,
+    existing_workspace_parents: &HashMap<WorkspaceId, Entity>,
+    displays: &'a Query<(Entity, &Display, Has<ActiveDisplayMarker>)>,
+) -> Option<(Entity, &'a Display)> {
+    if let Some(display_entity) = existing_workspace_parents.get(&workspace_id)
+        && let Ok((entity, display, _)) = displays.get(*display_entity)
+    {
+        let current_display_id = display.id();
+        if planned_display_id.is_some_and(|display_id| display_id != current_display_id) {
+            info!(
+                "Session restore remapping workspace {} from saved display {:?} to current display {}",
+                workspace_id, planned_display_id, current_display_id
+            );
+            return Some((entity, display));
+        }
+    }
+
+    if let Some(display_id) = planned_display_id {
+        if let Some((entity, display, _)) = displays
+            .iter()
+            .find(|(_, display, _)| display.id() == display_id)
+        {
+            return Some((entity, display));
+        }
+        info!(
+            "Session restore remapping workspace {} from missing display {}",
+            workspace_id, display_id
+        );
+    }
+
+    if let Some(display_entity) = existing_workspace_parents.get(&workspace_id)
+        && let Ok((entity, display, _)) = displays.get(*display_entity)
+    {
+        return Some((entity, display));
+    }
+
+    displays
+        .iter()
+        .find(|(_, _, active)| *active)
+        .or_else(|| displays.iter().min_by_key(|(_, display, _)| display.id()))
+        .map(|(entity, display, _)| (entity, display))
+}
+
+fn apply_planned_columns(strip: &mut LayoutStrip, columns: &[PlannedColumn]) {
+    for column in columns {
+        match column {
+            PlannedColumn::Single(entity) | PlannedColumn::Fullscreen(entity) => {
+                strip.append(*entity);
+            }
+            PlannedColumn::Tabs(entities) => {
+                append_tabs(strip, entities);
+            }
+            PlannedColumn::Stack(items) => {
+                append_stack(strip, items);
+            }
+        }
+    }
+}
+
+fn append_tabs(strip: &mut LayoutStrip, entities: &[Entity]) -> Option<Entity> {
+    let leader = *entities.first()?;
+    strip.append(leader);
+    for follower in &entities[1..] {
+        _ = strip.convert_to_tabs(leader, *follower);
+    }
+    Some(leader)
+}
+
+fn append_stack(strip: &mut LayoutStrip, items: &[PlannedStackItem]) {
+    let mut first = true;
+    for item in items {
+        let Some(leader) = append_stack_item(strip, item) else {
+            continue;
+        };
+        if first {
+            first = false;
+        } else {
+            _ = strip.stack(leader);
+        }
+    }
+}
+
+fn append_stack_item(strip: &mut LayoutStrip, item: &PlannedStackItem) -> Option<Entity> {
+    match item {
+        PlannedStackItem::Single(entity) => {
+            strip.append(*entity);
+            Some(*entity)
+        }
+        PlannedStackItem::Tabs(entities) => append_tabs(strip, entities),
+    }
+}
+
+fn compact_entities(entities: Vec<Entity>) -> Option<PlannedColumn> {
+    match entities.as_slice() {
+        [] => None,
+        [entity] => Some(PlannedColumn::Single(*entity)),
+        _ => Some(PlannedColumn::Tabs(entities)),
+    }
+}
+
+fn compact_stack_tabs(entities: Vec<Entity>) -> Option<PlannedStackItem> {
+    match entities.as_slice() {
+        [] => None,
+        [entity] => Some(PlannedStackItem::Single(*entity)),
+        _ => Some(PlannedStackItem::Tabs(entities)),
+    }
+}
+
+fn compact_stack_items(items: Vec<PlannedStackItem>) -> Option<PlannedColumn> {
+    match items.as_slice() {
+        [] => None,
+        [PlannedStackItem::Single(entity)] => Some(PlannedColumn::Single(*entity)),
+        [PlannedStackItem::Tabs(entities)] => Some(PlannedColumn::Tabs(entities.clone())),
+        _ => Some(PlannedColumn::Stack(items)),
+    }
+}

--- a/src/ecs/state.rs
+++ b/src/ecs/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bevy::app::AppExit;
@@ -9,6 +10,7 @@ use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::Has;
 use bevy::ecs::resource::Resource;
 use bevy::ecs::system::Query;
+use bevy::math::IRect;
 use objc2_core_graphics::CGDirectDisplayID;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
@@ -16,22 +18,44 @@ use tracing::{debug, error, info, warn};
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::Windows;
 use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::manager::Application;
 use crate::manager::Display;
-use crate::manager::{Application, Window};
 use crate::platform::{Pid, ProcessSerialNumber, WinID, WorkspaceId};
 
-pub const STATE_FILE_PATH: &str = "/tmp/paneru-state.json";
+pub const STATE_FILE_NAME: &str = "state.json";
+const SUPPORTED_STATE_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Resource)]
 pub struct PaneruState {
     pub version: u32,
     pub timestamp: u64,
+    pub active_display_id: Option<CGDirectDisplayID>,
+    #[serde(default)]
+    pub displays: Vec<SavedDisplay>,
     pub workspaces: Vec<SavedWorkspace>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SavedDisplay {
+    pub display_id: CGDirectDisplayID,
+    pub bounds: SavedRect,
+    pub active: bool,
+    pub workspace_ids: Vec<WorkspaceId>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SavedRect {
+    pub min_x: i32,
+    pub min_y: i32,
+    pub max_x: i32,
+    pub max_y: i32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SavedWorkspace {
     pub workspace_id: WorkspaceId,
+    pub display_id: Option<CGDirectDisplayID>,
+    pub active_virtual_index: Option<u32>,
     pub strips: Vec<SavedStrip>,
 }
 
@@ -64,6 +88,7 @@ pub struct SavedWindow {
 
     // Heuristic matching (if IDs change or apps restarted)
     pub bundle_id: String,
+    pub title: String,
     pub identifier: String,
     pub role: String,
     pub subrole: String,
@@ -113,6 +138,17 @@ pub struct PaneruWindowState {
     pub floating: bool,
 }
 
+impl From<IRect> for SavedRect {
+    fn from(rect: IRect) -> Self {
+        Self {
+            min_x: rect.min.x,
+            min_y: rect.min.y,
+            max_x: rect.max.x,
+            max_y: rect.max.y,
+        }
+    }
+}
+
 impl SavedWindow {
     pub fn from_entity(
         entity: Entity,
@@ -128,6 +164,7 @@ impl SavedWindow {
             pid: window.pid().ok()?,
             psn: app.psn(),
             bundle_id: app.bundle_id().unwrap_or_default().to_string(),
+            title: window.title().unwrap_or_default(),
             identifier: window.identifier().unwrap_or_default(),
             role: window.role().unwrap_or_default(),
             subrole: window.subrole().unwrap_or_default(),
@@ -141,14 +178,37 @@ impl SavedWindow {
 }
 
 impl PaneruState {
+    #[allow(clippy::type_complexity, clippy::too_many_lines)]
     pub fn extract(
-        workspaces: &Query<&LayoutStrip>,
+        workspaces: &Query<(Option<&ChildOf>, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+        displays: &Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
         windows: &Windows,
         apps: &Query<&Application>,
     ) -> Self {
-        let mut workspace_map: HashMap<WorkspaceId, Vec<SavedStrip>> = HashMap::new();
+        let mut display_entity_ids = HashMap::new();
+        let mut display_workspace_ids: HashMap<Entity, Vec<WorkspaceId>> = HashMap::new();
+        let mut workspace_map: HashMap<WorkspaceId, SavedWorkspaceBuilder> = HashMap::new();
+        let active_display_id = displays
+            .iter()
+            .find(|(_, _, active)| *active)
+            .map(|(display, _, _)| display.id());
 
-        for strip in workspaces {
+        for (display, entity, _) in displays {
+            display_entity_ids.insert(entity, display.id());
+            display_workspace_ids.insert(entity, Vec::new());
+        }
+
+        for (child, strip, active_workspace) in workspaces {
+            let display_entity = child.map(ChildOf::parent);
+            let display_id =
+                display_entity.and_then(|entity| display_entity_ids.get(&entity).copied());
+            if let Some(entity) = display_entity
+                && let Some(workspace_ids) = display_workspace_ids.get_mut(&entity)
+                && !workspace_ids.contains(&strip.id())
+            {
+                workspace_ids.push(strip.id());
+            }
+
             let mut saved_columns = Vec::new();
             for col in strip.columns() {
                 let saved_col = match col {
@@ -202,47 +262,84 @@ impl PaneruState {
                 }
             }
 
-            workspace_map
-                .entry(strip.id())
-                .or_default()
-                .push(SavedStrip {
-                    virtual_index: strip.virtual_index,
-                    columns: saved_columns,
-                });
+            let workspace =
+                workspace_map
+                    .entry(strip.id())
+                    .or_insert_with(|| SavedWorkspaceBuilder {
+                        display_id,
+                        active_virtual_index: None,
+                        strips: Vec::new(),
+                    });
+            if workspace.display_id.is_none() {
+                workspace.display_id = display_id;
+            }
+            if active_workspace {
+                workspace.active_virtual_index = Some(strip.virtual_index);
+            }
+            workspace.strips.push(SavedStrip {
+                virtual_index: strip.virtual_index,
+                columns: saved_columns,
+            });
         }
 
         let workspaces = workspace_map
             .into_iter()
-            .map(|(workspace_id, mut strips)| {
-                strips.sort_by_key(|s| s.virtual_index);
+            .map(|(workspace_id, mut workspace)| {
+                workspace.strips.sort_by_key(|s| s.virtual_index);
                 SavedWorkspace {
                     workspace_id,
-                    strips,
+                    display_id: workspace.display_id,
+                    active_virtual_index: workspace.active_virtual_index,
+                    strips: workspace.strips,
                 }
+            })
+            .collect();
+        let displays = displays
+            .iter()
+            .map(|(display, entity, active)| SavedDisplay {
+                display_id: display.id(),
+                bounds: display.bounds().into(),
+                active,
+                workspace_ids: display_workspace_ids.remove(&entity).unwrap_or_default(),
             })
             .collect();
 
         Self {
-            version: 1,
+            version: SUPPORTED_STATE_VERSION,
             timestamp: now_timestamp(),
+            active_display_id,
+            displays,
             workspaces,
         }
     }
 
-    pub fn save_to_file(&self, path: &str) -> Result<(), std::io::Error> {
+    pub fn save_to_file(&self, path: &Path) -> Result<(), std::io::Error> {
         let json = serde_json::to_string_pretty(self).map_err(|e| {
             error!("Failed to serialize state: {e}");
             std::io::Error::other(e)
         })?;
-        fs::write(path, json)?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp_path = path.with_extension("json.tmp");
+        fs::write(&tmp_path, json)?;
+        fs::rename(tmp_path, path)?;
         Ok(())
     }
 
-    pub fn load_from_file(path: &str) -> Option<Self> {
+    pub fn load_from_file(path: &Path) -> Option<Self> {
         let data = fs::read_to_string(path).ok()?;
-        serde_json::from_str(&data).ok()
+        let state: Self = serde_json::from_str(&data).ok()?;
+        (state.version == SUPPORTED_STATE_VERSION).then_some(state)
     }
 
+    pub fn default_state_file_path() -> PathBuf {
+        xdg::BaseDirectories::with_prefix("paneru")
+            .get_state_file(STATE_FILE_NAME)
+            .expect("XDG state directory should be available")
+    }
+
+    #[cfg(test)]
     pub fn find_match(
         &self,
         window_id: WinID,
@@ -316,16 +413,13 @@ impl PaneruState {
         }
         None
     }
+}
 
-    pub fn match_window(
-        &self,
-        window: &Window,
-        bundle_id: &str,
-    ) -> Option<(WorkspaceId, u32, usize)> {
-        let (workspace_id, virtual_index, col_idx, _) =
-            self.find_match(window.id(), window.pid().ok()?, bundle_id)?;
-        Some((workspace_id, virtual_index, col_idx))
-    }
+#[derive(Default)]
+struct SavedWorkspaceBuilder {
+    display_id: Option<CGDirectDisplayID>,
+    active_virtual_index: Option<u32>,
+    strips: Vec<SavedStrip>,
 }
 
 impl PaneruQueryState {
@@ -453,29 +547,33 @@ fn now_timestamp() -> u64 {
 
 #[allow(clippy::needless_pass_by_value)]
 pub fn periodic_state_save(
-    workspaces: Query<&LayoutStrip>,
+    workspaces: Query<(Option<&ChildOf>, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
     windows: Windows,
     apps: Query<&Application>,
 ) {
-    let state = PaneruState::extract(&workspaces, &windows, &apps);
-    if let Err(e) = state.save_to_file(STATE_FILE_PATH) {
+    let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
+    let path = PaneruState::default_state_file_path();
+    if let Err(e) = state.save_to_file(&path) {
         warn!("Failed to save state: {e}");
     } else {
-        debug!("State saved to {STATE_FILE_PATH}");
+        debug!("State saved to {}", path.display());
     }
 }
 
 #[allow(clippy::needless_pass_by_value)]
 pub fn cleanup_on_exit(
     mut exit_events: MessageReader<AppExit>,
-    workspaces: Query<&LayoutStrip>,
+    workspaces: Query<(Option<&ChildOf>, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
     windows: Windows,
     apps: Query<&Application>,
 ) {
     if exit_events.read().next().is_some() {
         info!("Exiting, saving state...");
-        let state = PaneruState::extract(&workspaces, &windows, &apps);
-        if let Err(e) = state.save_to_file(STATE_FILE_PATH) {
+        let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
+        let path = PaneruState::default_state_file_path();
+        if let Err(e) = state.save_to_file(&path) {
             error!("Failed to save state on exit: {e}");
         }
     }

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -16,7 +16,8 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
     ActiveDisplayMarker, BProcess, FocusedMarker, FreshMarker, MissionControlActive,
-    RetryFrontSwitch, SpawnWindowTrigger, StrayFocusEvent, SystemTheme, Timeout, Unmanaged,
+    PreviousManagedStrip, RetryFrontSwitch, SelectedVirtualMarker, SpawnWindowTrigger,
+    StrayFocusEvent, SystemTheme, Timeout, Unmanaged,
 };
 use crate::config::{Config, WindowParams};
 use crate::ecs::layout::LayoutStrip;
@@ -179,7 +180,7 @@ pub(super) fn window_focused_trigger(
     mut messages: MessageReader<Event>,
     applications: Query<&Application>,
     windows: Windows,
-    mut active_display: ActiveDisplayMut,
+    mut workspaces: Query<(Entity, &mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     config: Res<Config>,
     mut commands: Commands,
 ) {
@@ -210,11 +211,9 @@ pub(super) fn window_focused_trigger(
         // remain stale from a previously focused window.
         update_passthrough(window, app, &config);
 
-        if let Some((focused, _)) = windows.focused()
-            && focused.id() == window_id
-        {
-            continue;
-        }
+        let already_focused = windows
+            .focused()
+            .is_some_and(|(focused, _)| focused.id() == window_id);
 
         // Guard against stale focus events. Without these checks, delayed
         // events (e.g. from RetryFrontSwitch or dont_focus re-assertions)
@@ -231,11 +230,33 @@ pub(super) fn window_focused_trigger(
         }
 
         // Handle tab switching: if the focused window is a tab, make it the leader.
-        let layout_strip = active_display.active_strip();
-        if let Ok(index) = layout_strip.index_of(entity)
-            && let Some(column) = layout_strip.get_column_mut(index)
+        // Also reactivate the owning virtual strip before treating duplicate
+        // focus as a no-op; the focus marker can be stale on a hidden strip.
+        let mut owner = None;
+        for (strip_entity, mut strip, active) in &mut workspaces {
+            if !strip.contains(entity) {
+                continue;
+            }
+            if let Ok(index) = strip.index_of(entity)
+                && let Some(column) = strip.get_column_mut(index)
+            {
+                column.move_to_front(entity);
+            }
+            owner = Some((strip_entity, active));
+            break;
+        }
+
+        if let Some((strip_entity, active)) = owner
+            && !active
+            && let Ok(mut entity_commands) = commands.get_entity(strip_entity)
         {
-            column.move_to_front(entity);
+            entity_commands
+                .try_insert(ActiveWorkspaceMarker)
+                .try_insert(SelectedVirtualMarker);
+        }
+
+        if already_focused {
+            continue;
         }
 
         if let Ok(mut entity_commands) = commands.get_entity(entity) {
@@ -576,19 +597,28 @@ pub(super) fn window_minimized_trigger(
                 );
             }
             if strip.contains(entity) {
+                if let Ok(index) = strip.index_of(entity) {
+                    commands.entity(entity).try_insert(PreviousManagedStrip {
+                        workspace_id: strip.id(),
+                        virtual_index: strip.virtual_index,
+                        index,
+                    });
+                }
                 strip.remove(entity);
             }
         }
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 pub(super) fn window_managed_trigger(
     trigger: On<Remove, Unmanaged>,
-    mut active_display: ActiveDisplayMut,
+    active_display: Single<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
     windows: Windows,
     apps: Query<(Entity, &Application)>,
+    mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    previous_strips: Query<&PreviousManagedStrip>,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
     mut commands: Commands,
@@ -600,10 +630,12 @@ pub(super) fn window_managed_trigger(
     let entity = trigger.event().entity;
 
     debug!("Entity {entity} is managed again.");
-    let display_bounds = active_display
-        .display()
-        .actual_display_bounds(active_display.dock(), &config);
-    let active_strip = active_display.active_strip();
+    let (display, dock) = *active_display;
+    let display_bounds = display.actual_display_bounds(dock, &config);
+    let mut insert_at = previous_strips
+        .get(entity)
+        .ok()
+        .map(|previous| previous.index);
 
     if let Some(window) = windows.get(entity)
         && let Some((_, app)) = windows
@@ -621,26 +653,52 @@ pub(super) fn window_managed_trigger(
         }
 
         if properties.floating() {
+            commands.entity(entity).try_remove::<PreviousManagedStrip>();
             return;
         }
-        if let Some(index) = properties.insertion() {
-            active_strip.insert_at(index, entity);
-            reshuffle_around(entity, &mut commands);
-            return;
+
+        insert_at = properties.insertion().or(insert_at);
+    }
+
+    let previous = previous_strips.get(entity).ok().copied();
+    for (mut strip, _) in &mut workspaces {
+        strip.remove(entity);
+    }
+
+    let mut restored = false;
+    if let Some(previous) = previous {
+        for (mut strip, _) in &mut workspaces {
+            if strip.id() == previous.workspace_id && strip.virtual_index == previous.virtual_index
+            {
+                strip.insert_at(insert_at.unwrap_or(previous.index), entity);
+                restored = true;
+                break;
+            }
         }
     }
 
-    // Insert at the column the floating window visually overlaps so the
-    // strip doesn't have to scroll to the end to expose the new column.
-    let insertion = windows.frame(entity).and_then(|frame| {
-        let center_x = frame.center().x;
-        active_strip.all_columns().into_iter().position(|top| {
-            windows
-                .frame(top)
-                .is_some_and(|col| col.center().x > center_x)
-        })
-    });
-    active_strip.insert_at(insertion.unwrap_or(active_strip.len()), entity);
+    if !restored
+        && let Some((mut active_strip, _)) = workspaces.iter_mut().find(|(_, active)| *active)
+    {
+        if let Some(index) = insert_at {
+            active_strip.insert_at(index, entity);
+        } else {
+            // Insert at the column the floating window visually overlaps so the
+            // strip doesn't have to scroll to the end to expose the new column.
+            let insertion = windows.frame(entity).and_then(|frame| {
+                let center_x = frame.center().x;
+                active_strip.all_columns().into_iter().position(|top| {
+                    windows
+                        .frame(top)
+                        .is_some_and(|col| col.center().x > center_x)
+                })
+            });
+            let insertion = insertion.unwrap_or(active_strip.len());
+            active_strip.insert_at(insertion, entity);
+        }
+    }
+
+    commands.entity(entity).try_remove::<PreviousManagedStrip>();
     reshuffle_around(entity, &mut commands);
 }
 

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -22,7 +22,6 @@ use crate::config::{Config, WindowParams};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
-use crate::ecs::workspace::PreviousStripPosition;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, LocateDockTrigger,
     Position, RestoreWindowState, Scrolling, SendMessageTrigger, WidthRatio, WindowProperties,
@@ -762,7 +761,7 @@ fn give_away_focus(
 /// * `active_display` - A query for the active display.
 /// * `main_cid` - The main connection ID resource.
 /// * `commands` - Bevy commands to manage components and trigger events.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn spawn_window_trigger(
     mut trigger: On<SpawnWindowTrigger>,
@@ -771,6 +770,8 @@ pub(super) fn spawn_window_trigger(
     mut active_display: ActiveDisplayMut,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
+    restore: Option<Res<crate::ecs::restore::SessionRestore>>,
+    restoration: Option<Res<PaneruState>>,
     mut commands: Commands,
 ) {
     let new_windows = &mut trigger.event_mut().0;
@@ -819,9 +820,12 @@ pub(super) fn spawn_window_trigger(
 
         apply_window_defaults(
             &mut window,
+            &app,
             &mut active_display,
             &properties.params,
             &config,
+            restore.as_deref(),
+            restoration.as_deref(),
             initializing.is_some(),
         );
 
@@ -868,16 +872,28 @@ pub(super) fn spawn_window_trigger(
                 .inspect_err(|err| error!("Failed to convert to tabs: {err}"));
         }
     }
+
+    if initializing.is_none() && restore.is_some() {
+        commands.trigger(RestoreWindowState);
+    }
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation, clippy::too_many_arguments)]
 fn apply_window_defaults(
     window: &mut Window,
+    app: &Application,
     active_display: &mut ActiveDisplayMut,
     properties: &[WindowParams],
     config: &Config,
+    restore: Option<&crate::ecs::restore::SessionRestore>,
+    restoration: Option<&PaneruState>,
     initializing: bool,
 ) {
+    if crate::ecs::restore::matches_startup_restore_state(window, app, restore, restoration, config)
+    {
+        return;
+    }
+
     let floating = properties
         .iter()
         .find_map(|props| props.floating)
@@ -928,7 +944,7 @@ fn apply_window_defaults(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 pub(super) fn apply_window_properties(
     trigger: On<Add, Window>,
@@ -937,6 +953,8 @@ pub(super) fn apply_window_properties(
     apps: Query<&Application>,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
+    restore: Option<Res<crate::ecs::restore::SessionRestore>>,
+    restoration: Option<Res<PaneruState>>,
     mut commands: Commands,
 ) {
     let entity = trigger.event().entity;
@@ -955,6 +973,17 @@ pub(super) fn apply_window_properties(
     let Ok(app) = apps.get(parent) else {
         return;
     };
+
+    if crate::ecs::restore::matches_startup_restore_state(
+        window,
+        app,
+        restore.as_deref(),
+        restoration.as_deref(),
+        &config,
+    ) {
+        return;
+    }
+
     let properties = WindowProperties::new(app, window, &config);
 
     if properties.floating() {
@@ -1132,105 +1161,4 @@ pub(super) fn send_message_trigger(
 ) {
     let event = &trigger.event().0;
     messages.write(event.clone());
-}
-
-#[allow(clippy::needless_pass_by_value)]
-#[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
-pub(super) fn restore_window_state(
-    _: On<RestoreWindowState>,
-    windows: Windows,
-    mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>, &ChildOf)>,
-    displays: Query<(Entity, &Display)>,
-    apps: Query<&Application>,
-    restoration: Option<Res<PaneruState>>,
-    mut commands: Commands,
-) {
-    let Some(restore) = restoration else {
-        return;
-    };
-
-    let mut new_strips: Vec<(LayoutStrip, Entity)> = Vec::new();
-    for (mut strip, _, child) in &mut workspaces {
-        let restore = strip
-            .all_windows()
-            .into_iter()
-            .filter_map(|entity| {
-                let window = windows.get(entity)?;
-                let bundle_id = windows
-                    .find_parent(window.id())
-                    .and_then(|(_, _, parent)| apps.get(parent).ok())
-                    .map(|app| app.bundle_id().unwrap_or_default().to_string())?;
-                Some(entity).zip(restore.match_window(window, &bundle_id))
-            })
-            .collect::<Vec<_>>();
-
-        for index in 0u32..restore.len() as u32 {
-            let mut entities = restore
-                .iter()
-                .filter(|(_, (_, previous_virt_id, _))| *previous_virt_id == index)
-                .collect::<Vec<_>>();
-            if entities.is_empty() {
-                break;
-            }
-            entities.sort_by_key(|(_, (_, _, previous_idx))| *previous_idx);
-
-            if index == 0 {
-                let mut last_idx = 1000;
-
-                for (entity, (_, _, previous_idx)) in entities {
-                    strip.remove(*entity);
-
-                    if last_idx == *previous_idx {
-                        debug!("Stacking window {entity}");
-                        strip.insert_at(last_idx + 1, *entity);
-                        _ = strip.stack(*entity);
-                    } else {
-                        strip.insert_at(*previous_idx, *entity);
-                    }
-                    last_idx = *previous_idx;
-                }
-            } else {
-                let mut new_strip = new_strips.iter_mut().find_map(|(new_strip, _)| {
-                    (new_strip.id() == strip.id() && new_strip.virtual_index == index)
-                        .then_some(new_strip)
-                });
-                if new_strip.is_none() {
-                    debug!("Creating new virtual strip {index}");
-                    new_strips.push((LayoutStrip::new(strip.id(), index), child.parent()));
-                    new_strip = new_strips.last_mut().map(|(strip, _)| strip);
-                }
-
-                if let Some(new_strip) = new_strip {
-                    let mut last_idx = 1000;
-
-                    for (entity, (_, _, previous_idx)) in entities {
-                        strip.remove(*entity);
-                        debug!("Inserting {} into new strip", *entity);
-
-                        if last_idx == *previous_idx {
-                            debug!("Stacking window {entity}");
-                            new_strip.insert_at(last_idx + 1, *entity);
-                            _ = new_strip.stack(*entity);
-                        } else {
-                            new_strip.insert_at(*previous_idx, *entity);
-                        }
-                        last_idx = *previous_idx;
-                    }
-                }
-            }
-        }
-    }
-
-    for (strip, parent) in new_strips {
-        let Ok(bounds) = displays.get(parent).map(|(_, display)| display.bounds()) else {
-            continue;
-        };
-
-        let previous = PreviousStripPosition {
-            origin: bounds.min,
-            focus: strip.all_windows().first().copied(),
-        };
-        let hidden_origin = Position(bounds.max - 10);
-        commands.spawn((strip, hidden_origin, previous, ChildOf(parent)));
-    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,7 @@ mod display;
 mod harness;
 mod interaction;
 mod mocks;
+mod session_restore;
 mod state;
 mod tiling;
 

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use crate::commands::{Command, Direction, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::SpawnWindowTrigger;
+use crate::ecs::{ActiveWorkspaceMarker, layout::LayoutStrip};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
 use crate::{assert_focused, assert_window_at, assert_window_size};
@@ -339,6 +340,89 @@ fn test_stale_focus_event_ignored() {
         })
         .on_iteration(3, |world| {
             assert_focused!(world, 3);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_external_focus_reactivates_hidden_virtual_strip_when_marker_is_stale() {
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        Event::WindowFocused { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(1, |world| {
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip.virtual_index))
+                .expect("an active virtual strip");
+            assert_eq!(active, 1);
+            assert_focused!(world, 0);
+        })
+        .on_iteration(3, |world| {
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip.virtual_index))
+                .expect("an active virtual strip");
+            assert_eq!(active, 0);
+            assert_window_at!(world, 0, 0, TEST_MENUBAR_HEIGHT);
+            assert_focused!(world, 0);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_external_focus_restores_app_hidden_window_to_original_virtual_strip() {
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::ApplicationHidden {
+            pid: TEST_PROCESS_ID,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        Event::ApplicationVisible {
+            pid: TEST_PROCESS_ID,
+        },
+        Event::WindowFocused { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(2, |world| {
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip.virtual_index))
+                .expect("an active virtual strip");
+            assert_eq!(active, 1);
+        })
+        .on_iteration(5, |world| {
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip.virtual_index))
+                .expect("an active virtual strip");
+            assert_eq!(active, 0);
+            assert_window_at!(world, 0, 0, TEST_MENUBAR_HEIGHT);
+            assert_focused!(world, 0);
         })
         .run(commands);
 }

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -1,0 +1,737 @@
+use bevy::ecs::query::Has;
+use bevy::prelude::*;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
+
+use crate::config::{Config, MainOptions, WindowParams};
+use crate::ecs::layout::{Column, LayoutStrip};
+use crate::ecs::state::{
+    PaneruState, SavedColumn, SavedDisplay, SavedRect, SavedStrip, SavedWindow, SavedWorkspace,
+};
+use crate::ecs::workspace::PreviousStripPosition;
+use crate::ecs::{SpawnWindowTrigger, Unmanaged};
+use crate::manager::{Display, Origin, Size, Window};
+use crate::platform::{ProcessSerialNumber, WorkspaceId};
+use crate::tests::{
+    EXT_DISPLAY_ID, EXT_WORKSPACE_ID, MockWindow, MockWindowManager, TEST_DISPLAY_HEIGHT,
+    TEST_DISPLAY_ID, TEST_DISPLAY_WIDTH, TEST_MENUBAR_HEIGHT, TEST_PROCESS_ID, TEST_WINDOW_HEIGHT,
+    TEST_WINDOW_WIDTH, TEST_WORKSPACE_ID, TestHarness, TestWindowSpawner, TwoDisplayMock,
+    setup_process,
+};
+
+#[test]
+fn test_startup_restore_rebuilds_virtual_workspace_layout() {
+    let mut harness = TestHarness::new().with_windows(2);
+
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![SavedDisplay {
+            display_id: TEST_DISPLAY_ID,
+            bounds: SavedRect {
+                min_x: 0,
+                min_y: TEST_MENUBAR_HEIGHT,
+                max_x: TEST_DISPLAY_WIDTH,
+                max_y: TEST_DISPLAY_HEIGHT,
+            },
+            active: true,
+            workspace_ids: vec![TEST_WORKSPACE_ID],
+        }],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(1),
+            strips: vec![SavedStrip {
+                virtual_index: 1,
+                columns: vec![
+                    SavedColumn::Single(saved_window(0)),
+                    SavedColumn::Single(saved_window(1)),
+                ],
+            }],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<(&LayoutStrip, Has<crate::ecs::ActiveWorkspaceMarker>)>();
+    let active_strips = query
+        .iter(world)
+        .filter(|(strip, active)| strip.id() == TEST_WORKSPACE_ID && *active)
+        .map(|(strip, _)| strip)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        active_strips.len(),
+        1,
+        "exactly one virtual row should be active for the restored workspace"
+    );
+
+    let restored = active_strips[0];
+    assert_eq!(restored.virtual_index, 1);
+
+    let columns = restored.columns().collect::<Vec<_>>();
+    assert_eq!(columns.len(), 2);
+    assert!(matches!(columns[0], Column::Single(_)));
+    assert!(matches!(columns[1], Column::Single(_)));
+}
+
+#[test]
+fn test_startup_restore_replaces_consumed_empty_virtual_zero_strip() {
+    let mut harness = TestHarness::new().with_windows(2);
+
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![saved_display(TEST_DISPLAY_ID, true)],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips: vec![SavedStrip {
+                virtual_index: 0,
+                columns: vec![
+                    SavedColumn::Single(saved_window(0)),
+                    SavedColumn::Single(saved_window(1)),
+                ],
+            }],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<&LayoutStrip>();
+    let matching = query
+        .iter(world)
+        .filter(|strip| strip.id() == TEST_WORKSPACE_ID && strip.virtual_index == 0)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        matching.len(),
+        1,
+        "restore should replace the emptied startup row 0 instead of leaving a duplicate"
+    );
+
+    let windows = matching[0].all_windows();
+    assert_eq!(windows.len(), 2);
+    assert!(
+        windows.contains(&crate::tests::harness::find_window_entity(0, world)),
+        "restored row should contain window 0"
+    );
+    assert!(
+        windows.contains(&crate::tests::harness::find_window_entity(1, world)),
+        "restored row should contain window 1"
+    );
+}
+
+#[test]
+fn test_startup_restore_preserves_fullscreen_strip() {
+    let mut harness = TestHarness::new().with_windows(1);
+
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![saved_display(TEST_DISPLAY_ID, true)],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips: vec![SavedStrip {
+                virtual_index: 0,
+                columns: vec![SavedColumn::Fullscreen(saved_window(0))],
+            }],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<&LayoutStrip>();
+    let matching = query
+        .iter(world)
+        .filter(|strip| strip.id() == TEST_WORKSPACE_ID && strip.virtual_index == 0)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        matching.len(),
+        1,
+        "restore should replace the emptied startup row 0 instead of leaving a duplicate"
+    );
+    assert!(
+        matching[0].is_fullscreen(),
+        "fullscreen restore should rebuild a fullscreen strip"
+    );
+}
+
+#[test]
+fn test_startup_restore_prefers_existing_workspace_parent_before_saved_or_active_display() {
+    let active_display = Arc::new(AtomicU32::new(EXT_DISPLAY_ID));
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+    let windows: TestWindowSpawner = Box::new(move |workspace_id: WorkspaceId| {
+        if workspace_id == TEST_WORKSPACE_ID {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            vec![Window::new(Box::new(crate::tests::MockWindow::new(
+                200,
+                IRect::from_corners(origin, origin + size),
+                internal_queue.clone(),
+                mock_app.clone(),
+            )))]
+        } else {
+            vec![]
+        }
+    });
+
+    harness = harness.with_wm(TwoDisplayMock {
+        windows,
+        active_display,
+    });
+
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(EXT_DISPLAY_ID),
+        displays: vec![
+            saved_display(EXT_DISPLAY_ID, true),
+            saved_display(TEST_DISPLAY_ID, false),
+        ],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(EXT_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips: vec![SavedStrip {
+                virtual_index: 0,
+                columns: vec![SavedColumn::Single(saved_window(200))],
+            }],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let restored_window = crate::tests::harness::find_window_entity(200, world);
+    let restored_entity = {
+        let mut query = world.query::<(Entity, &LayoutStrip)>();
+        query
+            .iter(world)
+            .find(|(_, strip)| {
+                strip.id() == TEST_WORKSPACE_ID
+                    && strip.virtual_index == 0
+                    && strip.contains(restored_window)
+            })
+            .map(|(entity, _)| entity)
+            .expect("restored strip should exist")
+    };
+    let parent = world
+        .entity(restored_entity)
+        .get::<ChildOf>()
+        .expect("restored strip should have a display parent")
+        .parent();
+    let display = world
+        .entity(parent)
+        .get::<Display>()
+        .expect("parent should be a display");
+
+    assert_eq!(
+        display.id(),
+        TEST_DISPLAY_ID,
+        "stale saved display id should fall back to the display that already owns the native workspace"
+    );
+}
+
+#[test]
+fn test_startup_restore_preserves_saved_display_when_present() {
+    let active_display = Arc::new(AtomicU32::new(TEST_DISPLAY_ID));
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+    let windows: TestWindowSpawner = Box::new(move |workspace_id: WorkspaceId| {
+        if workspace_id == EXT_WORKSPACE_ID {
+            let origin = Origin::new(0, -TEST_WINDOW_HEIGHT);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            vec![Window::new(Box::new(MockWindow::new(
+                300,
+                IRect::from_corners(origin, origin + size),
+                internal_queue.clone(),
+                mock_app.clone(),
+            )))]
+        } else {
+            vec![]
+        }
+    });
+
+    harness = harness.with_wm(TwoDisplayMock {
+        windows,
+        active_display,
+    });
+
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(EXT_DISPLAY_ID),
+        displays: vec![
+            saved_display(EXT_DISPLAY_ID, true),
+            saved_display(TEST_DISPLAY_ID, false),
+        ],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: EXT_WORKSPACE_ID,
+            display_id: Some(EXT_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips: vec![SavedStrip {
+                virtual_index: 0,
+                columns: vec![SavedColumn::Single(saved_window(300))],
+            }],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let restored_window = crate::tests::harness::find_window_entity(300, world);
+    let parent = restored_strip_display_parent(world, EXT_WORKSPACE_ID, 0, restored_window);
+    let display = world
+        .entity(parent)
+        .get::<Display>()
+        .expect("parent should be a display");
+
+    assert_eq!(
+        display.id(),
+        EXT_DISPLAY_ID,
+        "restore should keep the exact saved display when it is present"
+    );
+}
+
+#[test]
+fn test_startup_restore_keeps_current_native_workspace_active_across_multiple_workspaces() {
+    let active_display = Arc::new(AtomicU32::new(TEST_DISPLAY_ID));
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+    let windows: TestWindowSpawner = Box::new(move |workspace_id: WorkspaceId| {
+        let (window_id, origin) = match workspace_id {
+            TEST_WORKSPACE_ID => (100, Origin::new(0, 0)),
+            EXT_WORKSPACE_ID => (300, Origin::new(0, -TEST_WINDOW_HEIGHT)),
+            _ => return vec![],
+        };
+        let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+        vec![Window::new(Box::new(MockWindow::new(
+            window_id,
+            IRect::from_corners(origin, origin + size),
+            internal_queue.clone(),
+            mock_app.clone(),
+        )))]
+    });
+
+    harness = harness.with_wm(TwoDisplayMock {
+        windows,
+        active_display,
+    });
+
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![
+            saved_display(TEST_DISPLAY_ID, true),
+            saved_display(EXT_DISPLAY_ID, false),
+        ],
+        workspaces: vec![
+            SavedWorkspace {
+                workspace_id: TEST_WORKSPACE_ID,
+                display_id: Some(TEST_DISPLAY_ID),
+                active_virtual_index: Some(0),
+                strips: vec![SavedStrip {
+                    virtual_index: 0,
+                    columns: vec![SavedColumn::Single(saved_window(100))],
+                }],
+            },
+            SavedWorkspace {
+                workspace_id: EXT_WORKSPACE_ID,
+                display_id: Some(EXT_DISPLAY_ID),
+                active_virtual_index: Some(0),
+                strips: vec![SavedStrip {
+                    virtual_index: 0,
+                    columns: vec![SavedColumn::Single(saved_window(300))],
+                }],
+            },
+        ],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<(
+        &LayoutStrip,
+        Has<crate::ecs::ActiveWorkspaceMarker>,
+        Has<crate::ecs::SelectedVirtualMarker>,
+    )>();
+    let restored = query
+        .iter(world)
+        .filter(|(strip, _, _)| {
+            (strip.id() == TEST_WORKSPACE_ID || strip.id() == EXT_WORKSPACE_ID)
+                && strip.virtual_index == 0
+                && !strip.all_windows().is_empty()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        restored.iter().filter(|(_, active, _)| *active).count(),
+        1,
+        "restore should keep one global active native workspace"
+    );
+    assert!(
+        restored
+            .iter()
+            .any(|(strip, active, selected)| strip.id() == TEST_WORKSPACE_ID
+                && *active
+                && *selected)
+    );
+    assert!(
+        restored
+            .iter()
+            .any(|(strip, active, selected)| strip.id() == EXT_WORKSPACE_ID
+                && !*active
+                && *selected)
+    );
+}
+
+#[test]
+fn test_restore_resource_is_removed_after_grace_period() {
+    let mut harness = TestHarness::new().with_windows(1);
+    harness
+        .app
+        .world_mut()
+        .insert_resource(state_with_strips(vec![SavedStrip {
+            virtual_index: 0,
+            columns: vec![SavedColumn::Single(saved_window(0))],
+        }]));
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    assert!(
+        harness
+            .app
+            .world()
+            .contains_resource::<crate::ecs::restore::SessionRestore>()
+    );
+
+    for _ in 0..30 {
+        harness.app.update();
+    }
+
+    assert!(
+        !harness
+            .app
+            .world()
+            .contains_resource::<crate::ecs::restore::SessionRestore>()
+    );
+    assert!(!harness.app.world().contains_resource::<PaneruState>());
+}
+
+#[test]
+fn test_startup_restore_disabled_by_config_keeps_normal_layout() {
+    let config = Config::try_from(
+        r"
+[options]
+
+[restore]
+enabled = false
+
+[bindings]
+",
+    )
+    .expect("config should parse");
+    let mut harness = TestHarness::new().with_config(config).with_windows(1);
+    harness
+        .app
+        .world_mut()
+        .insert_resource(state_with_strips(vec![SavedStrip {
+            virtual_index: 1,
+            columns: vec![SavedColumn::Single(saved_window(0))],
+        }]));
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    assert!(
+        !harness
+            .app
+            .world()
+            .contains_resource::<crate::ecs::restore::SessionRestore>()
+    );
+    assert!(!harness.app.world().contains_resource::<PaneruState>());
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<&LayoutStrip>();
+    assert!(
+        query
+            .iter(world)
+            .any(|strip| strip.id() == TEST_WORKSPACE_ID && strip.virtual_index == 0)
+    );
+    assert!(
+        !query
+            .iter(world)
+            .any(|strip| strip.id() == TEST_WORKSPACE_ID && strip.virtual_index == 1)
+    );
+}
+
+#[test]
+fn test_startup_restore_uses_first_restored_row_when_active_metadata_is_missing() {
+    let mut harness = TestHarness::new().with_windows(1);
+    let mut state = state_with_strips(vec![SavedStrip {
+        virtual_index: 2,
+        columns: vec![SavedColumn::Single(saved_window(0))],
+    }]);
+    state.workspaces[0].active_virtual_index = None;
+    harness.app.world_mut().insert_resource(state);
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<(&LayoutStrip, Has<crate::ecs::ActiveWorkspaceMarker>)>();
+    let active_strips = query
+        .iter(world)
+        .filter(|(strip, active)| strip.id() == TEST_WORKSPACE_ID && *active)
+        .map(|(strip, _)| strip)
+        .collect::<Vec<_>>();
+
+    assert_eq!(active_strips.len(), 1);
+    assert_eq!(active_strips[0].virtual_index, 2);
+}
+
+#[test]
+fn test_startup_restore_overrides_floating_config_for_matched_window() {
+    let mut params = WindowParams::new(".*", Some("test".to_string()));
+    params.floating = Some(true);
+    let config: Config = (MainOptions::default(), vec![params]).into();
+    let mut harness = TestHarness::new().with_config(config).with_windows(1);
+    harness
+        .app
+        .world_mut()
+        .insert_resource(state_with_strips(vec![SavedStrip {
+            virtual_index: 0,
+            columns: vec![SavedColumn::Single(saved_window(0))],
+        }]));
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let restored_window = crate::tests::harness::find_window_entity(0, world);
+    assert!(
+        world.entity(restored_window).get::<Unmanaged>().is_none(),
+        "matched restore windows should not inherit floating config"
+    );
+}
+
+#[test]
+fn test_late_startup_window_restores_during_grace_period() {
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let windows: TestWindowSpawner = Box::new(|_| vec![]);
+    harness = harness.with_wm(MockWindowManager {
+        windows,
+        workspaces: vec![TEST_WORKSPACE_ID],
+    });
+    harness
+        .app
+        .world_mut()
+        .insert_resource(state_with_strips(vec![SavedStrip {
+            virtual_index: 1,
+            columns: vec![SavedColumn::Single(saved_window(99))],
+        }]));
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+    assert!(
+        harness
+            .app
+            .world()
+            .contains_resource::<crate::ecs::restore::SessionRestore>()
+    );
+
+    let origin = Origin::new(0, 0);
+    let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+    let window = Window::new(Box::new(MockWindow::new(
+        99,
+        IRect::from_corners(origin, origin + size),
+        harness.internal_queue.clone(),
+        mock_app,
+    )));
+    harness
+        .app
+        .world_mut()
+        .trigger(SpawnWindowTrigger(vec![window]));
+
+    for _ in 0..3 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let restored_window = crate::tests::harness::find_window_entity(99, world);
+    let mut query = world.query::<(&LayoutStrip, Has<crate::ecs::ActiveWorkspaceMarker>)>();
+    let restored = query
+        .iter(world)
+        .find(|(strip, active)| {
+            strip.id() == TEST_WORKSPACE_ID
+                && strip.virtual_index == 1
+                && *active
+                && strip.contains(restored_window)
+        })
+        .map(|(strip, _)| strip);
+
+    assert!(
+        restored.is_some(),
+        "late startup window should restore into saved row"
+    );
+}
+
+#[test]
+fn test_startup_restore_keeps_one_selected_row_and_hides_inactive_rows() {
+    let mut harness = TestHarness::new().with_windows(2);
+    harness.app.world_mut().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![saved_display(TEST_DISPLAY_ID, true)],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(1),
+            strips: vec![
+                SavedStrip {
+                    virtual_index: 0,
+                    columns: vec![SavedColumn::Single(saved_window(0))],
+                },
+                SavedStrip {
+                    virtual_index: 1,
+                    columns: vec![SavedColumn::Single(saved_window(1))],
+                },
+            ],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.app.world_mut();
+    let mut query = world.query::<(
+        &LayoutStrip,
+        Has<crate::ecs::ActiveWorkspaceMarker>,
+        Has<crate::ecs::SelectedVirtualMarker>,
+        Option<&PreviousStripPosition>,
+    )>();
+    let restored = query
+        .iter(world)
+        .filter(|(strip, _, _, _)| strip.id() == TEST_WORKSPACE_ID)
+        .collect::<Vec<_>>();
+    let active = restored
+        .iter()
+        .filter(|(strip, active, _, _)| *active && strip.virtual_index == 1)
+        .count();
+    let selected = restored
+        .iter()
+        .filter(|(_, _, selected, _)| *selected)
+        .count();
+    let inactive = restored.iter().find(|(strip, active, _, previous)| {
+        strip.virtual_index == 0 && !*active && previous.is_some()
+    });
+
+    assert_eq!(active, 1);
+    assert_eq!(selected, 1);
+    assert!(
+        inactive.is_some(),
+        "inactive restored rows should be hidden with previous position"
+    );
+}
+
+fn saved_display(display_id: u32, active: bool) -> SavedDisplay {
+    SavedDisplay {
+        display_id,
+        bounds: SavedRect {
+            min_x: 0,
+            min_y: TEST_MENUBAR_HEIGHT,
+            max_x: TEST_DISPLAY_WIDTH,
+            max_y: TEST_DISPLAY_HEIGHT,
+        },
+        active,
+        workspace_ids: vec![TEST_WORKSPACE_ID],
+    }
+}
+
+fn state_with_strips(strips: Vec<SavedStrip>) -> PaneruState {
+    PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![saved_display(TEST_DISPLAY_ID, true)],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips,
+        }],
+    }
+}
+
+fn restored_strip_display_parent(
+    world: &mut World,
+    workspace_id: WorkspaceId,
+    virtual_index: u32,
+    window: Entity,
+) -> Entity {
+    let mut query = world.query::<(Entity, &LayoutStrip)>();
+    let restored_entity = query
+        .iter(world)
+        .find(|(_, strip)| {
+            strip.id() == workspace_id
+                && strip.virtual_index == virtual_index
+                && strip.contains(window)
+        })
+        .map(|(entity, _)| entity)
+        .expect("restored strip should exist");
+    world
+        .entity(restored_entity)
+        .get::<ChildOf>()
+        .expect("restored strip should have a display parent")
+        .parent()
+}
+
+fn saved_window(window_id: i32) -> SavedWindow {
+    SavedWindow {
+        window_id,
+        pid: TEST_PROCESS_ID,
+        psn: ProcessSerialNumber { high: 1, low: 2 },
+        bundle_id: "test".to_string(),
+        title: String::new(),
+        identifier: String::new(),
+        role: "AXWindow".to_string(),
+        subrole: "AXStandardWindow".to_string(),
+    }
+}

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -1,10 +1,52 @@
 use bevy::prelude::*;
 
+use crate::ecs::layout::LayoutStrip;
+use crate::ecs::params::Windows;
+use crate::ecs::restore::CurrentWindowIdentity;
 use crate::ecs::state::{
-    PaneruQueryState, PaneruState, SavedColumn, SavedStrip, SavedWindow, SavedWorkspace,
+    PaneruQueryState, PaneruState, SavedColumn, SavedDisplay, SavedRect, SavedStackItem,
+    SavedStrip, SavedWindow, SavedWorkspace,
 };
-use crate::platform::ProcessSerialNumber;
-use crate::tests::TEST_WORKSPACE_ID;
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::manager::{Application, Display};
+use crate::platform::{Pid, ProcessSerialNumber, WinID};
+use crate::tests::{
+    TEST_DISPLAY_HEIGHT, TEST_DISPLAY_ID, TEST_DISPLAY_WIDTH, TEST_MENUBAR_HEIGHT,
+    TEST_WORKSPACE_ID,
+};
+use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::query::Has;
+use bevy::ecs::system::SystemState;
+
+type StateExtractionState<'w, 's> = SystemState<(
+    Query<
+        'w,
+        's,
+        (
+            Option<&'static ChildOf>,
+            &'static LayoutStrip,
+            Has<ActiveWorkspaceMarker>,
+        ),
+    >,
+    Query<'w, 's, (&'static Display, Entity, Has<ActiveDisplayMarker>)>,
+    Windows<'w, 's>,
+    Query<'w, 's, &'static Application>,
+)>;
+
+type QueryStateExtractionState<'w, 's> = SystemState<(
+    Query<
+        'w,
+        's,
+        (
+            &'static ChildOf,
+            &'static LayoutStrip,
+            Has<ActiveWorkspaceMarker>,
+        ),
+    >,
+    Query<'w, 's, (&'static Display, Entity, Has<ActiveDisplayMarker>)>,
+    Windows<'w, 's>,
+    Query<'w, 's, &'static Application>,
+)>;
 
 #[test]
 fn test_state_serialization() {
@@ -13,16 +55,31 @@ fn test_state_serialization() {
         pid: 123,
         psn: ProcessSerialNumber { high: 0, low: 1 },
         bundle_id: "com.apple.Finder".to_string(),
+        title: "Finder".to_string(),
         identifier: "finder-main".to_string(),
         role: "AXWindow".to_string(),
         subrole: "AXStandardWindow".to_string(),
     };
 
     let state = PaneruState {
-        version: 1,
+        version: 2,
         timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![SavedDisplay {
+            display_id: TEST_DISPLAY_ID,
+            bounds: SavedRect {
+                min_x: 0,
+                min_y: TEST_MENUBAR_HEIGHT,
+                max_x: TEST_DISPLAY_WIDTH,
+                max_y: TEST_DISPLAY_HEIGHT,
+            },
+            active: true,
+            workspace_ids: vec![TEST_WORKSPACE_ID],
+        }],
         workspaces: vec![SavedWorkspace {
             workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(0),
             strips: vec![SavedStrip {
                 virtual_index: 0,
                 columns: vec![SavedColumn::Single(window)],
@@ -43,16 +100,21 @@ fn test_state_restoration() {
         pid: 123,
         psn: ProcessSerialNumber { high: 0, low: 1 },
         bundle_id: "com.apple.Finder".to_string(),
+        title: "Finder".to_string(),
         identifier: "finder-main".to_string(),
         role: "AXWindow".to_string(),
         subrole: "AXStandardWindow".to_string(),
     };
 
     let state = PaneruState {
-        version: 1,
+        version: 2,
         timestamp: 123_456_789,
+        active_display_id: None,
+        displays: Vec::new(),
         workspaces: vec![SavedWorkspace {
             workspace_id: TEST_WORKSPACE_ID,
+            display_id: None,
+            active_virtual_index: Some(1),
             strips: vec![SavedStrip {
                 virtual_index: 1,
                 columns: vec![SavedColumn::Single(window)],
@@ -71,12 +133,8 @@ fn test_state_restoration() {
 
 #[test]
 fn test_state_extraction() {
-    use crate::ecs::layout::LayoutStrip;
-    use crate::ecs::params::Windows;
     use crate::ecs::state::SavedColumn;
-    use crate::manager::Application;
     use crate::tests::harness::TestHarness;
-    use bevy::ecs::system::SystemState;
 
     let mut harness = TestHarness::new().with_windows(1);
 
@@ -84,13 +142,19 @@ fn test_state_extraction() {
     harness.app.update();
 
     let world = harness.app.world_mut();
-    let mut system_state: SystemState<(Query<&LayoutStrip>, Windows, Query<&Application>)> =
-        SystemState::new(world);
-    let (query, windows, apps) = system_state.get(world);
+    let mut system_state: StateExtractionState<'_, '_> = SystemState::new(world);
+    let (workspaces, displays, windows, apps) = system_state.get(world);
 
-    let state = PaneruState::extract(&query, &windows, &apps);
+    let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
 
     assert_eq!(state.workspaces.len(), 1);
+    assert_eq!(state.active_display_id, Some(TEST_DISPLAY_ID));
+    assert_eq!(state.displays.len(), 1);
+    assert_eq!(state.displays[0].display_id, TEST_DISPLAY_ID);
+    assert_eq!(state.displays[0].workspace_ids, vec![TEST_WORKSPACE_ID]);
+    assert!(state.displays[0].active);
+    assert_eq!(state.workspaces[0].display_id, Some(TEST_DISPLAY_ID));
+    assert_eq!(state.workspaces[0].active_virtual_index, Some(0));
     assert_eq!(state.workspaces[0].strips.len(), 1);
     assert_eq!(state.workspaces[0].strips[0].columns.len(), 1);
 
@@ -103,15 +167,8 @@ fn test_state_extraction() {
 }
 
 #[test]
-#[allow(clippy::type_complexity)]
-fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
-    use crate::ecs::layout::LayoutStrip;
-    use crate::ecs::params::Windows;
-    use crate::manager::{Application, Display};
+fn test_state_serializes_display_and_active_virtual_workspace() {
     use crate::tests::harness::TestHarness;
-    use bevy::ecs::hierarchy::ChildOf;
-    use bevy::ecs::query::Has;
-    use bevy::ecs::system::SystemState;
 
     let mut harness = TestHarness::new().with_windows(1);
 
@@ -128,16 +185,358 @@ fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
         ChildOf(display_entity),
     ));
 
-    let mut system_state: SystemState<(
-        Query<(
-            &ChildOf,
-            &LayoutStrip,
-            Has<crate::ecs::ActiveWorkspaceMarker>,
-        )>,
-        Query<(&Display, Entity, Has<crate::ecs::ActiveDisplayMarker>)>,
-        Windows,
-        Query<&Application>,
-    )> = SystemState::new(world);
+    let mut system_state: StateExtractionState<'_, '_> = SystemState::new(world);
+    let (workspaces, displays, windows, apps) = system_state.get(world);
+
+    let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
+
+    assert_eq!(state.version, 2);
+    assert_eq!(state.active_display_id, Some(TEST_DISPLAY_ID));
+    assert_eq!(
+        state.displays,
+        vec![SavedDisplay {
+            display_id: TEST_DISPLAY_ID,
+            bounds: SavedRect {
+                min_x: 0,
+                min_y: TEST_MENUBAR_HEIGHT,
+                max_x: TEST_DISPLAY_WIDTH,
+                max_y: TEST_DISPLAY_HEIGHT,
+            },
+            active: true,
+            workspace_ids: vec![TEST_WORKSPACE_ID],
+        }]
+    );
+    assert_eq!(state.workspaces.len(), 1);
+    assert_eq!(state.workspaces[0].display_id, Some(TEST_DISPLAY_ID));
+    assert_eq!(state.workspaces[0].active_virtual_index, Some(0));
+    assert_eq!(state.workspaces[0].strips.len(), 2);
+
+    let json = serde_json::to_value(&state).expect("state should serialize");
+    assert_eq!(json["active_display_id"], TEST_DISPLAY_ID);
+    assert_eq!(json["displays"][0]["display_id"], TEST_DISPLAY_ID);
+    assert_eq!(
+        json["displays"][0]["workspace_ids"],
+        serde_json::json!([TEST_WORKSPACE_ID])
+    );
+    assert_eq!(json["workspaces"][0]["display_id"], TEST_DISPLAY_ID);
+    assert_eq!(json["workspaces"][0]["active_virtual_index"], 0);
+}
+
+#[test]
+fn test_state_extraction_includes_parentless_layout_strips() {
+    use crate::tests::harness::TestHarness;
+
+    let mut harness = TestHarness::new().with_windows(0);
+
+    harness.app.update();
+
+    let world = harness.app.world_mut();
+    let parentless_workspace_id = TEST_WORKSPACE_ID + 1;
+    world.spawn(LayoutStrip::new(parentless_workspace_id, 0));
+
+    let mut system_state: StateExtractionState<'_, '_> = SystemState::new(world);
+    let (workspaces, displays, windows, apps) = system_state.get(world);
+
+    let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
+
+    let parentless_workspace = state
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.workspace_id == parentless_workspace_id)
+        .expect("parentless layout strip should be saved");
+    assert_eq!(parentless_workspace.display_id, None);
+    assert_eq!(parentless_workspace.active_virtual_index, None);
+    assert_eq!(parentless_workspace.strips.len(), 1);
+    assert_eq!(parentless_workspace.strips[0].virtual_index, 0);
+
+    assert!(
+        state
+            .displays
+            .iter()
+            .all(|display| !display.workspace_ids.contains(&parentless_workspace_id)),
+        "parentless layout strip should not be associated with any display"
+    );
+}
+
+#[test]
+fn test_state_load_rejects_unsupported_version() {
+    let path = unique_state_path("unsupported-version");
+    std::fs::write(
+        &path,
+        r#"{"version":1,"timestamp":123456789,"workspaces":[]}"#,
+    )
+    .expect("state fixture should write");
+
+    assert!(PaneruState::load_from_file(&path).is_none());
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn test_state_save_is_loadable_from_path() {
+    let state = PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![SavedDisplay {
+            display_id: TEST_DISPLAY_ID,
+            bounds: SavedRect {
+                min_x: 0,
+                min_y: TEST_MENUBAR_HEIGHT,
+                max_x: TEST_DISPLAY_WIDTH,
+                max_y: TEST_DISPLAY_HEIGHT,
+            },
+            active: true,
+            workspace_ids: vec![TEST_WORKSPACE_ID],
+        }],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips: Vec::new(),
+        }],
+    };
+    let path = unique_state_path("save-load");
+
+    state
+        .save_to_file(&path)
+        .expect("state should save to requested path");
+
+    let loaded = PaneruState::load_from_file(&path).expect("state should load from saved path");
+    assert_eq!(loaded, state);
+
+    let _ = std::fs::remove_file(path);
+}
+
+fn unique_state_path(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "paneru-{name}-{}-{}.json",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    ))
+}
+
+#[test]
+fn restore_plan_compacts_missing_windows_and_preserves_active_virtual_row() {
+    use crate::ecs::restore::{PlannedColumn, RestorePlanner};
+
+    let mut world = World::new();
+    let present_tab = world.spawn_empty().id();
+    let present_stack_tab = world.spawn_empty().id();
+
+    let state = restore_state(vec![SavedWorkspace {
+        workspace_id: TEST_WORKSPACE_ID,
+        display_id: Some(TEST_DISPLAY_ID),
+        active_virtual_index: Some(1),
+        strips: vec![
+            SavedStrip {
+                virtual_index: 0,
+                columns: vec![SavedColumn::Single(saved_window(
+                    10,
+                    110,
+                    "com.example.missing",
+                    "Missing",
+                ))],
+            },
+            SavedStrip {
+                virtual_index: 1,
+                columns: vec![
+                    SavedColumn::Tabs(vec![
+                        saved_window(11, 111, "com.example.missing", "Missing Tab"),
+                        saved_window(12, 112, "com.example.editor", "Editor"),
+                    ]),
+                    SavedColumn::Stack(vec![
+                        SavedStackItem::Single(saved_window(
+                            13,
+                            113,
+                            "com.example.missing",
+                            "Missing Stack",
+                        )),
+                        SavedStackItem::Tabs(vec![
+                            saved_window(14, 114, "com.example.terminal", "Terminal"),
+                            saved_window(15, 115, "com.example.missing", "Missing Stack Tab"),
+                        ]),
+                    ]),
+                ],
+            },
+        ],
+    }]);
+    let current = vec![
+        current_window(present_tab, 12, 112, "com.example.editor", "Editor"),
+        current_window(
+            present_stack_tab,
+            14,
+            114,
+            "com.example.terminal",
+            "Terminal",
+        ),
+    ];
+
+    let plan = RestorePlanner::new(&state).plan(&current);
+
+    assert_eq!(plan.strips.len(), 1);
+    assert_eq!(plan.strips[0].workspace_id, TEST_WORKSPACE_ID);
+    assert_eq!(plan.strips[0].display_id, Some(TEST_DISPLAY_ID));
+    assert_eq!(plan.strips[0].virtual_index, 1);
+    assert_eq!(
+        plan.active_virtual_by_workspace.get(&TEST_WORKSPACE_ID),
+        Some(&1)
+    );
+    assert_eq!(
+        plan.strips[0].columns,
+        vec![
+            PlannedColumn::Single(present_tab),
+            PlannedColumn::Single(present_stack_tab),
+        ]
+    );
+    assert_eq!(
+        plan.consumed_entities,
+        [present_tab, present_stack_tab].into_iter().collect()
+    );
+    assert_eq!(plan.ignored_missing_windows, 4);
+    assert_eq!(plan.skipped_ambiguous_matches, 0);
+}
+
+#[test]
+fn restore_plan_prefers_later_hard_match_over_earlier_fallback_match() {
+    use crate::ecs::restore::{PlannedColumn, RestorePlanner};
+
+    let mut world = World::new();
+    let current_x = world.spawn_empty().id();
+    let saved_a = saved_window(20, 120, "com.example.notes", "Daily Notes");
+    let saved_b = saved_window(21, 121, "com.example.notes", "Daily Notes");
+    let state = restore_state(vec![SavedWorkspace {
+        workspace_id: TEST_WORKSPACE_ID,
+        display_id: Some(TEST_DISPLAY_ID),
+        active_virtual_index: Some(0),
+        strips: vec![
+            SavedStrip {
+                virtual_index: 0,
+                columns: vec![SavedColumn::Single(saved_a)],
+            },
+            SavedStrip {
+                virtual_index: 1,
+                columns: vec![SavedColumn::Single(saved_b)],
+            },
+        ],
+    }]);
+    let current = vec![current_window(
+        current_x,
+        21,
+        121,
+        "com.example.notes",
+        "Daily Notes",
+    )];
+
+    let plan = RestorePlanner::new(&state).plan(&current);
+
+    assert_eq!(plan.strips.len(), 1);
+    assert_eq!(plan.strips[0].virtual_index, 1);
+    assert_eq!(
+        plan.strips[0].columns,
+        vec![PlannedColumn::Single(current_x)]
+    );
+    assert_eq!(plan.consumed_entities, [current_x].into_iter().collect());
+    assert_eq!(plan.ignored_missing_windows, 1);
+    assert_eq!(plan.skipped_ambiguous_matches, 0);
+}
+
+#[test]
+fn restore_plan_skips_ambiguous_fallback_match() {
+    use crate::ecs::restore::{CurrentWindowIdentity, RestorePlanner};
+
+    let mut world = World::new();
+    let first = world.spawn_empty().id();
+    let second = world.spawn_empty().id();
+    let saved = saved_window(20, 120, "com.example.notes", "Daily Notes");
+    let state = restore_state(vec![SavedWorkspace {
+        workspace_id: TEST_WORKSPACE_ID,
+        display_id: None,
+        active_virtual_index: Some(0),
+        strips: vec![SavedStrip {
+            virtual_index: 0,
+            columns: vec![SavedColumn::Single(saved)],
+        }],
+    }]);
+    let current = vec![
+        CurrentWindowIdentity::fallback_only(first, "com.example.notes", "Daily Notes"),
+        CurrentWindowIdentity::fallback_only(second, "com.example.notes", "Daily Notes"),
+    ];
+
+    let plan = RestorePlanner::new(&state).plan(&current);
+
+    assert!(plan.strips.is_empty());
+    assert!(plan.active_virtual_by_workspace.is_empty());
+    assert!(plan.consumed_entities.is_empty());
+    assert_eq!(plan.ignored_missing_windows, 0);
+    assert_eq!(plan.skipped_ambiguous_matches, 1);
+}
+
+fn restore_state(workspaces: Vec<SavedWorkspace>) -> PaneruState {
+    PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: Vec::new(),
+        workspaces,
+    }
+}
+
+fn saved_window(window_id: WinID, pid: Pid, bundle_id: &str, title: &str) -> SavedWindow {
+    SavedWindow {
+        window_id,
+        pid,
+        psn: ProcessSerialNumber { high: 0, low: 1 },
+        bundle_id: bundle_id.to_string(),
+        title: title.to_string(),
+        identifier: "main".to_string(),
+        role: "AXWindow".to_string(),
+        subrole: "AXStandardWindow".to_string(),
+    }
+}
+
+fn current_window(
+    entity: Entity,
+    window_id: WinID,
+    pid: Pid,
+    bundle_id: &str,
+    title: &str,
+) -> CurrentWindowIdentity {
+    CurrentWindowIdentity {
+        entity,
+        window_id,
+        pid,
+        bundle_id: bundle_id.to_string(),
+        title: title.to_string(),
+        identifier: "main".to_string(),
+        role: "AXWindow".to_string(),
+        subrole: "AXStandardWindow".to_string(),
+    }
+}
+
+#[test]
+fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
+    use crate::tests::harness::TestHarness;
+
+    let mut harness = TestHarness::new().with_windows(1);
+
+    harness.app.update();
+
+    let world = harness.app.world_mut();
+    let mut active_display_query =
+        world.query_filtered::<Entity, With<crate::ecs::ActiveDisplayMarker>>();
+    let display_entity = active_display_query
+        .single(world)
+        .expect("active display should exist");
+    world.spawn((
+        LayoutStrip::new(TEST_WORKSPACE_ID, 2),
+        ChildOf(display_entity),
+    ));
+
+    let mut system_state: QueryStateExtractionState<'_, '_> = SystemState::new(world);
     let (workspaces, displays, windows, apps) = system_state.get(world);
 
     let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);


### PR DESCRIPTION
Save managed window state to the user state directory and restore it during a
bounded startup phase. Restore now rebuilds saved layouts, virtual workspace
rows, active virtual selection, and display associations for matched windows.

Add restore configuration for enabling startup restore, setting the startup
grace period, and choosing the missing-window policy. Missing saved windows are
ignored by default and restored layouts are compacted.

Matched startup windows use saved session placement before static window rules,
while unmatched windows and post-restore windows keep normal config behavior.