### PR TITLE
fix: Full-width mode fights layout pipeline, breaking stacked windows

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,9 +12,9 @@ use crate::config::Config;
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
-    ActiveDisplayMarker, ActiveWorkspaceMarker, FocusFollowsMouse, FocusedMarker, FullWidthMarker,
-    NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger, Unmanaged, WMEventTrigger,
-    focus_entity, reposition_entity, reshuffle_around, resize_entity,
+    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, FocusFollowsMouse, FocusedMarker,
+    FullWidthMarker, NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger, Unmanaged,
+    WMEventTrigger, focus_entity, reposition_entity, reshuffle_around, resize_entity,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Origin, Size, Window, WindowManager, origin_to};
@@ -514,6 +514,18 @@ fn resize_window(
 /// * `windows` - A mutable query for all `Window` components.
 /// * `commands` - Bevy commands to trigger events.
 /// * `config` - The `Config` resource.
+fn exit_full_width(
+    entity: Entity,
+    marker: &FullWidthMarker,
+    viewport: IRect,
+    commands: &mut Commands,
+) {
+    let w = (marker.width_ratio * f64::from(viewport.width())).round() as i32;
+    let h = (marker.height_ratio * f64::from(viewport.height())).round() as i32;
+    commands.entity(entity).try_remove::<FullWidthMarker>();
+    commands.entity(entity).try_insert(Bounds(Size::new(w, h)));
+}
+
 #[allow(clippy::needless_pass_by_value)]
 fn full_width_window(
     mut messages: MessageReader<Event>,
@@ -539,41 +551,29 @@ fn full_width_window(
     let viewport = active_display
         .display()
         .actual_display_bounds(active_display.dock(), &config);
-    let height = frame.height();
-    let y = frame.min.y;
 
-    let (width, x) = if let Some(marker) = windows.full_width(entity) {
-        let previous_ratio = marker.width_ratio;
-        let was_stacked = marker.was_stacked;
-        commands.entity(entity).try_remove::<FullWidthMarker>();
-        if was_stacked {
-            _ = active_display.active_strip().stack(entity);
-        }
-        let w = (previous_ratio * f64::from(viewport.width())).round() as i32;
-        (w, viewport.center().x - w / 2)
+    if let Some(marker) = windows.full_width(entity) {
+        exit_full_width(entity, marker, viewport, &mut commands);
+        reshuffle_around(entity, &mut commands);
     } else {
         let strip = active_display.active_strip();
-        let was_stacked = strip
+        if strip
             .index_of(entity)
             .ok()
             .and_then(|idx| strip.get(idx).ok())
-            .is_some_and(|col| matches!(col, Column::Stack(_)));
-        if was_stacked {
+            .is_some_and(|col| matches!(col, Column::Stack(_)))
+        {
             _ = strip.unstack(entity);
         }
         let width_ratio = windows.width_ratio(entity).unwrap_or(0.5);
-        commands.entity(entity).try_insert(FullWidthMarker {
-            width_ratio,
-            was_stacked,
-        });
-        // Logical frame spans the full viewport; reposition() and
-        // resize() handle h_pad conversion to CG coordinates.
-        (viewport.width(), viewport.min.x)
-    };
-
-    reposition_entity(entity, Origin::new(x, y), &mut commands);
-    resize_entity(entity, Size::new(width, height), &mut commands);
-    reshuffle_around(entity, &mut commands);
+        let height_ratio = f64::from(frame.height()) / f64::from(viewport.height());
+        commands
+            .entity(entity)
+            .try_insert(FullWidthMarker { width_ratio, height_ratio });
+        reposition_entity(entity, Origin::new(viewport.min.x, viewport.min.y), &mut commands);
+        resize_entity(entity, Size::new(viewport.width(), viewport.height()), &mut commands);
+        reshuffle_around(entity, &mut commands);
+    }
 }
 
 /// Toggles the managed state of the focused window.
@@ -860,6 +860,8 @@ pub fn stack_windows_handler(
     mut messages: MessageReader<Event>,
     windows: Windows,
     mut active_display: ActiveDisplayMut,
+    config: Res<Config>,
+    mut commands: Commands,
 ) {
     let Some(Operation::Stack(stack)) =
         filter_window_operations(&mut messages, |op| matches!(op, Operation::Stack(_))).next()
@@ -872,11 +874,23 @@ pub fn stack_windows_handler(
         .and_then(|(_, entity)| windows.get_managed(entity))
         && unmanaged.is_none()
     {
+        let was_full_width = if let Some(marker) = windows.full_width(entity) {
+            let viewport = active_display
+                .display()
+                .actual_display_bounds(active_display.dock(), &config);
+            exit_full_width(entity, marker, viewport, &mut commands);
+            true
+        } else {
+            false
+        };
         let strip = active_display.active_strip();
         if *stack {
             _ = strip.stack(entity);
         } else {
             _ = strip.unstack(entity);
+        }
+        if was_full_width {
+            reshuffle_around(entity, &mut commands);
         }
     }
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -251,13 +251,10 @@ pub struct NativeFullscreenMarker {
     pub previous_index: usize,
 }
 
-/// Stores the width ratio of a window before it was made full-width.
-/// When a stacked window goes full-width, it is unstacked first;
-/// `was_stacked` records whether to restack on exit.
 #[derive(Component)]
 pub struct FullWidthMarker {
     pub width_ratio: f64,
-    pub was_stacked: bool,
+    pub height_ratio: f64,
 }
 
 /// Enum component indicating the unmanaged state of a window.

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -15,8 +15,8 @@ use tracing::{Level, instrument, trace};
 use crate::config::Config;
 use crate::ecs::params::Windows;
 use crate::ecs::{
-    Bounds, DockPosition, Initializing, LayoutPosition, Position, ReshuffleAroundMarker, Scrolling,
-    reposition_entity,
+    Bounds, DockPosition, FullWidthMarker, Initializing, LayoutPosition, Position,
+    ReshuffleAroundMarker, Scrolling, reposition_entity,
 };
 use crate::errors::{Error, Result};
 use crate::manager::{Display, Window};
@@ -748,7 +748,7 @@ fn layout_sizes_changed(
 fn layout_strip_changed(
     changed_strips: Populated<(&LayoutStrip, &ChildOf), Changed<LayoutStrip>>,
     mut windows: Query<
-        (&Position, &mut Bounds, &mut LayoutPosition),
+        (&Position, &mut Bounds, &mut LayoutPosition, Has<FullWidthMarker>),
         (Without<LayoutStrip>, With<Window>),
     >,
     displays: Query<(&Display, Option<&DockPosition>)>,
@@ -757,7 +757,7 @@ fn layout_strip_changed(
     let get_window_frame = |entity| {
         windows
             .get(entity)
-            .map(|(position, bounds, _)| IRect::from_corners(position.0, position.0 + bounds.0))
+            .map(|(position, bounds, _, _)| IRect::from_corners(position.0, position.0 + bounds.0))
             .ok()
     };
 
@@ -776,7 +776,10 @@ fn layout_strip_changed(
         .collect::<Vec<_>>();
 
     for (entity, frame) in changed {
-        if let Ok((_, mut bounds, mut layout_position)) = windows.get_mut(entity) {
+        if let Ok((_, mut bounds, mut layout_position, full_width)) = windows.get_mut(entity) {
+            if full_width {
+                continue;
+            }
             if layout_position.0 != frame.min {
                 layout_position.0 = frame.min;
             }
@@ -874,7 +877,14 @@ fn position_layout_strips(
 #[instrument(level = Level::DEBUG, skip_all)]
 fn position_layout_windows(
     mut positioned_windows: Populated<
-        (Entity, &Window, &LayoutPosition, &mut Position, &mut Bounds),
+        (
+            Entity,
+            &Window,
+            &LayoutPosition,
+            &mut Position,
+            &mut Bounds,
+            Has<FullWidthMarker>,
+        ),
         (Changed<LayoutPosition>, With<Window>, Without<LayoutStrip>),
     >,
     workspaces: Query<(&LayoutStrip, &Position, Has<Scrolling>, &ChildOf), With<LayoutStrip>>,
@@ -885,7 +895,10 @@ fn position_layout_windows(
     let (_, pad_right, _, pad_left) = config.edge_padding();
 
     positioned_windows.par_iter_mut().for_each(
-        |(entity, window, layout_position, mut position, mut bounds)| {
+        |(entity, window, layout_position, mut position, mut bounds, full_width)| {
+            if full_width {
+                return;
+            }
             let Some((layout_strip, Position(strip_position), swiping, child_of)) =
                 workspaces.iter().find(|strip| strip.0.contains(entity))
             else {


### PR DESCRIPTION
The layout pipeline (layout_strip_changed, position_layout_windows) had no awareness of FullWidthMarker and would overwrite the window's Bounds and Position every frame, causing jitter and half-width rendering.

Additionally, full-width mode only expanded width but kept the stacked height, and exiting full-width would restack the window — causing confusing state transitions.

### Changes:
- Skip FullWidthMarker windows in layout_strip_changed and position_layout_windows so the animation system has sole control
- Expand to full viewport width AND height when entering full-width
- Store height_ratio in FullWidthMarker (replaces was_stacked)
- On exit, set Bounds directly instead of animating to avoid layout pipeline fight on re-entry
- Exit full-width automatically when stacking a full-width window
- Extract exit_full_width helper to deduplicate the restore logic

### Before:

https://github.com/user-attachments/assets/9d0954b0-2c9c-4c59-b9df-0f2ca552f5a6

### After:

https://github.com/user-attachments/assets/34c1aeb7-4803-47e5-932d-90464543834c


