### PR TITLE
fix: Synthesize WindowFocused for newly spawned windows

### DIFF
--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -989,15 +989,21 @@ pub(super) fn apply_window_properties(
 
     // During init, skip per-window reshuffles. finish_setup does a single
     // reshuffle after all windows are added.
-    if initializing.is_none()
-        && properties.dont_focus()
-        && let Some((focus, entity)) = windows.focused()
-    {
-        debug!(
-            "Not focusing new window {entity}, keeping focus on '{}'",
-            focus.title().unwrap_or_default()
-        );
-        focus_entity(entity, true, &mut commands);
+    if initializing.is_none() {
+        if properties.dont_focus() {
+            if let Some((focus, prev)) = windows.focused() {
+                debug!(
+                    "Not focusing new window {entity}, keeping focus on '{}'",
+                    focus.title().unwrap_or_default()
+                );
+                focus_entity(prev, true, &mut commands);
+            }
+        } else {
+            debug!("Synthesizing WindowFocused for newly spawned window {entity}");
+            commands.trigger(SendMessageTrigger(Event::WindowFocused {
+                window_id: window.id(),
+            }));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #219.

In `apply_window_properties` (`src/ecs/triggers.rs`), the non-`dont_focus`
branch now synthesizes `Event::WindowFocused` via `SendMessageTrigger`,
mirroring how the `dont_focus` branch already re-asserts focus on the
previously-focused window. This closes the spawn-time race where the OS
WindowFocused event was being dropped under AX write contention.

`window_focused_trigger` is already idempotent against duplicate events,
so the synthetic message composes harmlessly with any OS-delivered one.

Renamed the inner `entity` (the previously-focused entity) to `prev` to
remove a name shadow with the outer `entity` (the new window).

## Test plan

- [x] `cargo test` (one pre-existing failure unrelated to this change:
      `tests::interaction::test_scrolling` — fails identically on
      unpatched `testing` HEAD with `left: -316, right: -313`)
- [x] Manual verification on macOS 26 Tahoe (Darwin 25.4.0, arm64):
  - Safari: 5/5 auto-focus ✓ (was 5/5 fail on stock `testing`)
  - Chrome: 3/3 auto-focus ✓ (was 3/3 fail)
  - Zed: 1/1 ✓