### PR TITLE
fix: Do not insert Scrolling on bare TouchpadDown.

### DIFF
--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -139,7 +139,7 @@ fn swipe_gesture(
         if touchpad_up {
             scrolling.is_user_swiping = false;
         }
-    } else if has_scroll_event || touchpad_down {
+    } else if has_scroll_event {
         let dt = time.delta_secs_f64();
         let velocity = if dt > 0.0 {
             total_delta * swipe_sensitivity / dt


### PR DESCRIPTION
Thanks for the great work on paneru — it's become a daily driver for me.

I noticed the active-window border flickering every time my finger landed on the trackpad to move the cursor (without swiping). Digging into it, a bare `Event::TouchpadDown` was inserting a zero-velocity `Scrolling` component; `update_overlays` then hid the border for that frame, and the next `swiping_timeout` tick removed the component again — so the border blinked off and back on with every cursor touch.

Looking at git history, this seems to have regressed in c59ccd06 (`fix: Accumulate the scrolling events for swiping.`). Before that commit, `Event::TouchpadDown` only updated an existing `Scrolling` component and then `continue`d, so a bare `TouchpadDown` never created a new one. The refactor unified handling into `else if has_scroll_event || touchpad_down`, which accidentally added an insertion path for `TouchpadDown` alone.

I tried dropping `|| touchpad_down` from the insertion guard. Inertia-stopping still works because when a `Scrolling` already exists (the strip is gliding), `TouchpadDown` is handled in the `if let Some(scrolling)` branch — which zeros velocity and sets `is_user_swiping = true`, matching pre-c59ccd06 behavior. The flicker is gone on my machine and ongoing swipes / inertia behave as before.

Thanks in advance for taking a look!


https://github.com/user-attachments/assets/2fffbe4e-e1ac-4ff4-9b8c-64bdd110d0f1

