### PR TITLE
perf: Improve various performance points

### DIFF
--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -7,7 +7,7 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::{Query, Res, ResMut};
 use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
@@ -76,6 +76,80 @@ struct StateBroadcastSignals {
     window_focused: bool,
 }
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Debug, Default, PartialEq)]
+struct StateBroadcastIntent {
+    virtual_workspace_changed: bool,
+    windows_changed: bool,
+    window_focused: bool,
+    title_changes: BTreeSet<WinID>,
+    display_changes: Vec<Option<u32>>,
+    active_display_changed: bool,
+}
+
+impl StateBroadcastIntent {
+    fn from_events<'a>(
+        events: impl IntoIterator<Item = &'a Event>,
+        signals: StateBroadcastSignals,
+    ) -> Self {
+        let mut intent = Self {
+            virtual_workspace_changed: signals.virtual_workspace_changed,
+            window_focused: signals.window_focused,
+            ..Self::default()
+        };
+
+        for event in events {
+            match event {
+                Event::SpaceChanged
+                | Event::Command {
+                    command: Command::Window(Operation::Virtual(_) | Operation::VirtualNumber(_)),
+                } => intent.virtual_workspace_changed = true,
+                Event::WindowCreated { .. }
+                | Event::WindowDestroyed { .. }
+                | Event::WindowMinimized { .. }
+                | Event::WindowDeminimized { .. }
+                | Event::Command {
+                    command:
+                        Command::Window(
+                            Operation::VirtualMove(_, _) | Operation::VirtualMoveNumber(_, _),
+                        ),
+                } => intent.windows_changed = true,
+                Event::WindowFocused { .. } => intent.window_focused = true,
+                Event::WindowTitleChanged { window_id } => {
+                    intent.title_changes.insert(*window_id);
+                }
+                Event::DisplayAdded { display_id }
+                | Event::DisplayRemoved { display_id }
+                | Event::DisplayMoved { display_id }
+                | Event::DisplayResized { display_id }
+                | Event::DisplayConfigured { display_id } => {
+                    let display_id = Some(*display_id);
+                    if !intent.display_changes.contains(&display_id) {
+                        intent.display_changes.push(display_id);
+                    }
+                }
+                Event::DisplayChanged => {
+                    intent.active_display_changed = true;
+                }
+                _ => {}
+            }
+        }
+
+        intent
+    }
+
+    fn requires_state(&self) -> bool {
+        self.virtual_workspace_changed
+            || self.windows_changed
+            || self.window_focused
+            || self.active_display_changed
+    }
+
+    fn is_empty(&self) -> bool {
+        !self.requires_state() && self.title_changes.is_empty() && self.display_changes.is_empty()
+    }
+}
+
 pub(super) fn register_query_commands(app: &mut App) {
     let active_subscribers = |subscribers: Option<Res<StateSubscribers>>| {
         subscribers.is_some_and(|subscribers| !subscribers.streams.is_empty())
@@ -124,6 +198,7 @@ fn state_subscribe_handler(
     }
 }
 
+#[cfg(test)]
 fn collect_state_broadcast_events<'a>(
     events: impl IntoIterator<Item = &'a Event>,
     state: &PaneruQueryState,
@@ -131,50 +206,54 @@ fn collect_state_broadcast_events<'a>(
     title_for_window: impl Fn(WinID) -> Option<String>,
     signals: StateBroadcastSignals,
 ) -> Vec<Value> {
-    let mut virtual_workspace_changed = signals.virtual_workspace_changed;
-    let mut windows_changed = false;
-    let mut window_focused = signals.window_focused;
-    let mut title_changes = BTreeMap::new();
-    let mut display_changes = Vec::new();
+    let intent = StateBroadcastIntent::from_events(events, signals);
+    collect_state_broadcast_events_for_intent(&intent, Some(state), cache, title_for_window)
+}
 
-    for event in events {
-        match event {
-            Event::SpaceChanged
-            | Event::Command {
-                command: Command::Window(Operation::Virtual(_) | Operation::VirtualNumber(_)),
-            } => virtual_workspace_changed = true,
-            Event::WindowCreated { .. }
-            | Event::WindowDestroyed { .. }
-            | Event::WindowMinimized { .. }
-            | Event::WindowDeminimized { .. }
-            | Event::Command {
-                command:
-                    Command::Window(Operation::VirtualMove(_, _) | Operation::VirtualMoveNumber(_, _)),
-            } => windows_changed = true,
-            Event::WindowFocused { .. } => window_focused = true,
-            Event::WindowTitleChanged { window_id } => {
-                title_changes.insert(*window_id, title_for_window(*window_id).unwrap_or_default());
-            }
-            Event::DisplayAdded { display_id }
-            | Event::DisplayRemoved { display_id }
-            | Event::DisplayMoved { display_id }
-            | Event::DisplayResized { display_id }
-            | Event::DisplayConfigured { display_id } => {
-                let display_id = Some(*display_id);
-                if !display_changes.contains(&display_id) {
-                    display_changes.push(display_id);
-                }
-            }
-            Event::DisplayChanged if !display_changes.contains(&state.active.display_id) => {
-                display_changes.push(state.active.display_id);
-            }
-            _ => {}
-        }
+fn collect_state_broadcast_events_for_intent(
+    intent: &StateBroadcastIntent,
+    state: Option<&PaneruQueryState>,
+    cache: &mut StateBroadcastCache,
+    title_for_window: impl Fn(WinID) -> Option<String>,
+) -> Vec<Value> {
+    let mut display_changes = intent.display_changes.clone();
+    if intent.active_display_changed
+        && let Some(state) = state
+        && !display_changes.contains(&state.active.display_id)
+    {
+        display_changes.push(state.active.display_id);
     }
+
+    let mut title_changes = BTreeMap::new();
+    for window_id in &intent.title_changes {
+        title_changes.insert(*window_id, title_for_window(*window_id).unwrap_or_default());
+    }
+
+    let Some(state) = state else {
+        let mut outgoing = Vec::new();
+        for (window_id, title) in title_changes {
+            if cache.titles.get(&window_id) == Some(&title) {
+                continue;
+            }
+            outgoing.push(json!({
+                "event": "window_title_changed",
+                "window_id": window_id,
+                "title": title,
+            }));
+            cache.titles.insert(window_id, title);
+        }
+        for display_id in display_changes {
+            outgoing.push(json!({
+                "event": "display_changed",
+                "display_id": display_id,
+            }));
+        }
+        return outgoing;
+    };
 
     let mut outgoing = Vec::new();
 
-    if virtual_workspace_changed {
+    if intent.virtual_workspace_changed {
         let workspace = WorkspaceBroadcastSnapshot::from(&state.active);
         if cache.workspace.as_ref() != Some(&workspace)
             && (workspace.native_workspace_id.is_some()
@@ -188,7 +267,9 @@ fn collect_state_broadcast_events<'a>(
         }
     }
 
-    if windows_changed && cache.virtual_workspaces.as_ref() != Some(&state.virtual_workspaces) {
+    if intent.windows_changed
+        && cache.virtual_workspaces.as_ref() != Some(&state.virtual_workspaces)
+    {
         outgoing.push(json!({
             "event": "windows_changed",
             "virtual_workspace_number": state.active.virtual_workspace_number,
@@ -197,7 +278,7 @@ fn collect_state_broadcast_events<'a>(
         cache.virtual_workspaces = Some(state.virtual_workspaces.clone());
     }
 
-    if window_focused {
+    if intent.window_focused {
         let focus = FocusBroadcastSnapshot::from(&state.active);
         if focus.window_id.is_some() && cache.focus.as_ref() != Some(&focus) {
             outgoing.push(json!({
@@ -251,21 +332,27 @@ fn state_event_broadcast_handler(
         return;
     }
 
-    let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
     let signals = StateBroadcastSignals {
         virtual_workspace_changed: !active_workspace_changes.is_empty(),
         window_focused: !focused_changes.is_empty(),
     };
-    let outgoing = collect_state_broadcast_events(
-        events,
-        &state,
+    let intent = StateBroadcastIntent::from_events(events, signals);
+    if intent.is_empty() {
+        return;
+    }
+
+    let state = intent
+        .requires_state()
+        .then(|| PaneruQueryState::extract(&workspaces, &displays, &windows, &apps));
+    let outgoing = collect_state_broadcast_events_for_intent(
+        &intent,
+        state.as_ref(),
         &mut cache,
         |window_id| {
             windows
                 .find(window_id)
                 .and_then(|(window, _)| window.title().ok())
         },
-        signals,
     );
 
     if outgoing.is_empty() {
@@ -454,5 +541,50 @@ mod tests {
         assert_eq!(outgoing[0]["window_id"], 26_262);
         assert_eq!(outgoing[0]["bundle_id"], "com.openai.codex");
         assert_eq!(outgoing[0]["title"], "Codex");
+    }
+
+    #[test]
+    fn test_state_broadcast_intent_skips_state_for_empty_or_unrelated_events() {
+        let empty =
+            StateBroadcastIntent::from_events(std::iter::empty(), StateBroadcastSignals::default());
+        assert!(empty.is_empty());
+        assert!(!empty.requires_state());
+
+        let unrelated = StateBroadcastIntent::from_events(
+            [
+                PaneruEvent::ThemeChanged,
+                PaneruEvent::MouseUp {
+                    point: Default::default(),
+                    modifiers: crate::platform::Modifiers::empty(),
+                },
+            ]
+            .iter(),
+            StateBroadcastSignals::default(),
+        );
+        assert!(unrelated.is_empty());
+        assert!(!unrelated.requires_state());
+    }
+
+    #[test]
+    fn test_state_broadcast_intent_classifies_relevant_events() {
+        let intent = StateBroadcastIntent::from_events(
+            [
+                PaneruEvent::SpaceChanged,
+                PaneruEvent::WindowMinimized { window_id: 10 },
+                PaneruEvent::WindowFocused { window_id: 11 },
+                PaneruEvent::WindowTitleChanged { window_id: 12 },
+                PaneruEvent::DisplayResized { display_id: 2 },
+            ]
+            .iter(),
+            StateBroadcastSignals::default(),
+        );
+
+        assert!(intent.virtual_workspace_changed);
+        assert!(intent.windows_changed);
+        assert!(intent.window_focused);
+        assert_eq!(intent.title_changes, [12].into());
+        assert_eq!(intent.display_changes, vec![Some(2)]);
+        assert!(intent.requires_state());
+        assert!(!intent.is_empty());
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -554,7 +554,7 @@ mod tests {
             [
                 PaneruEvent::ThemeChanged,
                 PaneruEvent::MouseUp {
-                    point: Default::default(),
+                    point: objc2_core_foundation::CGPoint::default(),
                     modifiers: crate::platform::Modifiers::empty(),
                 },
             ]

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -73,7 +73,11 @@ pub fn register_systems(app: &mut bevy::app::App) {
     );
     app.add_systems(
         PreUpdate,
-        (systems::window_creation_event, systems::pump_events),
+        (
+            systems::window_creation_event,
+            systems::detect_tabbed_windows,
+            systems::pump_events,
+        ),
     );
     app.add_systems(
         Update,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -157,6 +157,8 @@ pub fn register_triggers(app: &mut bevy::app::App) {
         .add_observer(triggers::send_message_trigger)
         .add_observer(triggers::window_removal_trigger)
         .add_observer(systems::cleanup_timeout)
+        .add_observer(systems::release_frame_commit_after_reposition)
+        .add_observer(systems::release_frame_commit_after_resize)
         .add_observer(restore::restore_window_state);
 }
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -156,7 +156,7 @@ pub fn register_triggers(app: &mut bevy::app::App) {
         .add_observer(triggers::locate_dock_trigger)
         .add_observer(triggers::send_message_trigger)
         .add_observer(triggers::window_removal_trigger)
-        .add_observer(triggers::cleanup_timeout_trigger)
+        .add_observer(systems::cleanup_timeout)
         .add_observer(restore::restore_window_state);
 }
 
@@ -463,6 +463,18 @@ pub fn flash_message(message: String, duration: f32, commands: &mut Commands) {
     commands.spawn((timeout, FlashMessage(message)));
 }
 
+pub fn remove_timeout(entity: Entity, commands: &mut Commands) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+        entity_commands.try_remove::<Timeout>();
+    }
+}
+
+pub fn despawn_timeout_entity(entity: Entity, commands: &mut Commands) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+        entity_commands.try_despawn();
+    }
+}
+
 pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<BevyApp> {
     let window_manager: Box<dyn WindowManagerApi> = Box::new(WindowManagerOS::new(sender.clone()));
     let watcher = window_manager.setup_config_watcher(CONFIGURATION_FILE.as_path())?;
@@ -574,5 +586,64 @@ impl WindowProperties {
             .iter()
             .find_map(|props| props.horizontal_padding)
             .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bevy::app::App;
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::system::ResMut;
+    use bevy::time::TimerMode;
+
+    #[derive(Default, Resource)]
+    struct TimeoutTestRuns(u32);
+
+    fn count_timeout_run(mut runs: ResMut<TimeoutTestRuns>) {
+        runs.0 += 1;
+    }
+
+    fn registered_timeout(app: &mut App) -> (Entity, SystemId) {
+        let system_id = app.world_mut().register_system(count_timeout_run);
+        let timer = Timer::from_seconds(1.0, TimerMode::Once);
+        let entity = app
+            .world_mut()
+            .spawn(Timeout {
+                timer,
+                system_id: Some(system_id),
+            })
+            .id();
+        (entity, system_id)
+    }
+
+    fn timeout_cleanup_app() -> App {
+        let mut app = App::new();
+        app.init_resource::<TimeoutTestRuns>()
+            .add_observer(systems::cleanup_timeout);
+        app
+    }
+
+    #[test]
+    fn timeout_unregisters_system_when_removed() {
+        let mut app = timeout_cleanup_app();
+        let (entity, system_id) = registered_timeout(&mut app);
+
+        app.world_mut().entity_mut(entity).remove::<Timeout>();
+        app.world_mut().flush();
+
+        assert!(app.world_mut().run_system(system_id).is_err());
+    }
+
+    #[test]
+    fn timeout_unregisters_system_when_despawned() {
+        let mut app = timeout_cleanup_app();
+        let (entity, system_id) = registered_timeout(&mut app);
+
+        app.world_mut().entity_mut(entity).despawn();
+        app.world_mut().flush();
+
+        assert!(app.world_mut().run_system(system_id).is_err());
     }
 }

--- a/src/ecs/display.rs
+++ b/src/ecs/display.rs
@@ -16,7 +16,7 @@ use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::{
     ActiveDisplayMarker, Position, RefreshWindowSizes, SelectedVirtualMarker, SendMessageTrigger,
-    Timeout,
+    Timeout, remove_timeout,
 };
 use crate::events::Event;
 use crate::manager::{Display, WindowManager};
@@ -88,7 +88,7 @@ fn display_change_trigger(
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn displays_rearranged(
     mut messages: MessageReader<Event>,
-    workspaces: Query<(&LayoutStrip, Entity, Option<&ChildOf>)>,
+    workspaces: Query<(&LayoutStrip, Entity, Option<&ChildOf>, Has<Timeout>)>,
     mut displays: Query<(&mut Display, Entity)>,
     window_manager: Res<WindowManager>,
     config: Res<Config>,
@@ -129,7 +129,7 @@ pub(crate) fn displays_rearranged(
 #[instrument(level = Level::DEBUG, skip_all, fields(display_id))]
 fn add_display(
     display_id: CGDirectDisplayID,
-    existing_strips: &Query<(&LayoutStrip, Entity, Option<&ChildOf>)>,
+    existing_strips: &Query<(&LayoutStrip, Entity, Option<&ChildOf>, Has<Timeout>)>,
     window_manager: &WindowManager,
     config: &Config,
     retries: &mut HashSet<CGDirectDisplayID>,
@@ -172,7 +172,7 @@ fn add_display(
 #[instrument(level = Level::DEBUG, skip_all, fields(display_id))]
 fn remove_display(
     display_id: CGDirectDisplayID,
-    workspaces: &Query<(&LayoutStrip, Entity, Option<&ChildOf>)>,
+    workspaces: &Query<(&LayoutStrip, Entity, Option<&ChildOf>, Has<Timeout>)>,
     displays: &mut Query<(&mut Display, Entity)>,
     commands: &mut Commands,
 ) {
@@ -185,9 +185,9 @@ fn remove_display(
         return;
     };
 
-    for (strip, entity, _) in workspaces
+    for (strip, entity, _, _) in workspaces
         .into_iter()
-        .filter(|(_, _, child)| child.is_some_and(|child| child.parent() == display_entity))
+        .filter(|(_, _, child, _)| child.is_some_and(|child| child.parent() == display_entity))
     {
         let display_id = display.id();
         debug!(
@@ -220,7 +220,7 @@ fn move_display(
     display_id: CGDirectDisplayID,
     displays: &mut Query<(&mut Display, Entity)>,
     window_manager: &Res<WindowManager>,
-    existing_strips: &Query<(&LayoutStrip, Entity, Option<&ChildOf>)>,
+    existing_strips: &Query<(&LayoutStrip, Entity, Option<&ChildOf>, Has<Timeout>)>,
     config: &Config,
     commands: &mut Commands,
 ) {
@@ -256,24 +256,25 @@ fn reparent_existing_workspaces(
     workspace_ids: &[WorkspaceId],
     display_entity: Entity,
     display_bounds: &IRect,
-    existing_strips: &Query<(&LayoutStrip, Entity, Option<&ChildOf>)>,
+    existing_strips: &Query<(&LayoutStrip, Entity, Option<&ChildOf>, Has<Timeout>)>,
     commands: &mut Commands,
 ) {
     // Verifies that a moved display has all the workspaces which it owns.
     for &id in workspace_ids {
         let mut found = false;
-        for (strip, entity, child) in existing_strips {
+        for (strip, entity, child, has_timeout) in existing_strips {
             if strip.id() == id {
                 found = true;
                 if child.is_none_or(|child| child.parent() != display_entity) {
                     // Re-parent this workspace
                     if let Ok(mut cmd) = commands.get_entity(entity) {
                         debug!("reparenting workspace {id} to display {display_entity}");
-                        cmd.try_remove::<Timeout>()
-                            .try_remove::<ChildOf>()
-                            .insert(ChildOf(display_entity));
+                        cmd.try_remove::<ChildOf>().insert(ChildOf(display_entity));
 
                         cmd.insert(RefreshWindowSizes::default());
+                    }
+                    if has_timeout {
+                        remove_timeout(entity, commands);
                     }
                 }
             }

--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -18,7 +18,7 @@ use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Scrolling, SelectedVirtualMarker, SendMessageTrigger, StrayFocusEvent,
-    focus_entity, reposition_entity, reshuffle_around,
+    Timeout, despawn_timeout_entity, focus_entity, reposition_entity, reshuffle_around,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Window, WindowManager};
@@ -267,7 +267,7 @@ fn recover_lost_focus(
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn stray_focus_observer(
     trigger: On<Add, Window>,
-    focus_events: Populated<(Entity, &StrayFocusEvent)>,
+    focus_events: Populated<(Entity, &StrayFocusEvent), With<Timeout>>,
     windows: Windows,
     mut commands: Commands,
 ) {
@@ -282,6 +282,6 @@ pub(super) fn stray_focus_observer(
         .for_each(|(timeout_entity, _)| {
             debug!("Re-queueing lost focus event for window id {window_id}.");
             commands.trigger(SendMessageTrigger(Event::WindowFocused { window_id }));
-            commands.entity(timeout_entity).despawn();
+            despawn_timeout_entity(timeout_entity, &mut commands);
         });
 }

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -525,6 +525,10 @@ impl LayoutStrip {
         self.columns.iter().filter_map(Column::top).collect()
     }
 
+    pub fn column_tops(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.columns.iter().filter_map(Column::top)
+    }
+
     pub fn id(&self) -> WorkspaceId {
         self.id
     }

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -243,6 +243,7 @@ impl LayoutStrip {
     pub fn convert_to_tabs(&mut self, leader: Entity, follower: Entity) -> Result<()> {
         let index = self.index_of(leader)?;
         let column = self.columns.remove(index).unwrap();
+        self.remove(follower);
         match column {
             Column::Single(id) | Column::Fullscren(id) => {
                 self.columns.insert(index, Column::Tabs(vec![id, follower]));

--- a/src/ecs/mouse.rs
+++ b/src/ecs/mouse.rs
@@ -392,7 +392,7 @@ fn horizontal_warp_mouse_trigger(
             return;
         }
 
-        let mut target_displays = displays
+        let Some(warp_to) = displays
             .iter()
             .filter(|display| {
                 let above = display.bounds().min.y < current_display.bounds().min.y;
@@ -405,11 +405,8 @@ fn horizontal_warp_mouse_trigger(
                     below
                 }
             })
-            .collect::<Vec<_>>();
-
-        target_displays
-            .sort_by_key(|display| (display.bounds().min.y - current_display.bounds().min.y).abs());
-        let Some(warp_to) = target_displays.first() else {
+            .min_by_key(|display| (display.bounds().min.y - current_display.bounds().min.y).abs())
+        else {
             return;
         };
         let target = warp_to.bounds();

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -24,6 +24,18 @@ use crate::platform::Modifiers;
 
 pub struct ScrollEventsPlugin;
 
+const FINGER_LIFT_THRESHOLD: Duration = Duration::from_millis(50);
+const MIN_VELOCITY_PX: f64 = 5.0;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SwipeTimeoutAction {
+    Pending,
+    KeepScrolling,
+    RefreshMouse,
+    RemoveScrolling,
+    RemoveScrollingAndRefreshMouse,
+}
+
 impl Plugin for ScrollEventsPlugin {
     fn build(&self, app: &mut App) {
         let mission_control_inactive = |mission_control: Option<Res<MissionControlActive>>| {
@@ -151,25 +163,54 @@ pub(super) fn swiping_timeout(
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
-    const FINGER_LIFT_THRESHOLD: Duration = Duration::from_millis(50);
-    const MIN_VELOCITY_PX: f64 = 5.0;
     let dt = time.delta_secs_f64();
     let viewport_width = f64::from(active_display.bounds().width());
 
     for (entity, mut scroll) in strips {
-        if scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD {
-            scroll.is_user_swiping = false;
-
-            if scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX {
+        match swiping_timeout_step(&mut scroll, dt, viewport_width) {
+            SwipeTimeoutAction::Pending | SwipeTimeoutAction::KeepScrolling => {}
+            SwipeTimeoutAction::RefreshMouse => {
+                if let Some(point) = window_manager.cursor_position() {
+                    commands.trigger(SendMessageTrigger(Event::MouseMoved {
+                        point,
+                        modifiers: Modifiers::empty(),
+                    }));
+                }
+            }
+            SwipeTimeoutAction::RemoveScrolling => {
                 commands.entity(entity).remove::<Scrolling>();
             }
-            if let Some(point) = window_manager.cursor_position() {
-                commands.trigger(SendMessageTrigger(Event::MouseMoved {
-                    point,
-                    modifiers: Modifiers::empty(),
-                }));
+            SwipeTimeoutAction::RemoveScrollingAndRefreshMouse => {
+                commands.entity(entity).remove::<Scrolling>();
+                if let Some(point) = window_manager.cursor_position() {
+                    commands.trigger(SendMessageTrigger(Event::MouseMoved {
+                        point,
+                        modifiers: Modifiers::empty(),
+                    }));
+                }
             }
         }
+    }
+}
+
+fn swiping_timeout_step(
+    scroll: &mut Scrolling,
+    dt: f64,
+    viewport_width: f64,
+) -> SwipeTimeoutAction {
+    if scroll.last_event.elapsed() <= FINGER_LIFT_THRESHOLD {
+        return SwipeTimeoutAction::Pending;
+    }
+
+    let was_user_swiping = scroll.is_user_swiping;
+    scroll.is_user_swiping = false;
+
+    let slow_enough_to_stop = scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX;
+    match (slow_enough_to_stop, was_user_swiping) {
+        (true, true) => SwipeTimeoutAction::RemoveScrollingAndRefreshMouse,
+        (true, false) => SwipeTimeoutAction::RemoveScrolling,
+        (false, true) => SwipeTimeoutAction::RefreshMouse,
+        (false, false) => SwipeTimeoutAction::KeepScrolling,
     }
 }
 
@@ -223,8 +264,7 @@ fn apply_snap_force(
     }
 
     let target_offset = strip
-        .all_columns()
-        .into_iter()
+        .column_tops()
         .filter_map(|entity| {
             windows
                 .layout_position(entity)
@@ -437,5 +477,30 @@ fn vertical_swipe_gesture(
             state.accumulated = 0.0;
             state.fired = true;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn swipe_timeout_requests_mouse_refresh_only_on_lift_transition() {
+        let now = Instant::now();
+        let mut scroll = Scrolling {
+            velocity: 100.0,
+            position: 0.0,
+            is_user_swiping: true,
+            last_event: now.checked_sub(Duration::from_millis(100)).unwrap_or(now),
+        };
+
+        assert_eq!(
+            swiping_timeout_step(&mut scroll, 1.0 / 60.0, 1440.0),
+            SwipeTimeoutAction::RefreshMouse
+        );
+        assert_eq!(
+            swiping_timeout_step(&mut scroll, 1.0 / 60.0, 1440.0),
+            SwipeTimeoutAction::KeepScrolling
+        );
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -899,16 +899,53 @@ pub(super) fn verify_window_position(
 pub(super) fn commit_window_frames(
     active_display: ActiveDisplay,
     mut framed_windows: Populated<
-        (&mut Window, Ref<Position>, Ref<Bounds>, &mut WidthRatio),
+        (
+            &mut Window,
+            Ref<Position>,
+            Ref<Bounds>,
+            &mut WidthRatio,
+            Option<&RepositionMarker>,
+            Option<&ResizeMarker>,
+        ),
         Or<(Changed<Position>, Changed<Bounds>)>,
     >,
 ) {
     let display_bounds = active_display.bounds();
-    for (mut window, position, bounds, mut width_ratio) in &mut framed_windows {
+    for (mut window, position, bounds, mut width_ratio, reposition, resize) in &mut framed_windows {
         if bounds.is_changed() {
             width_ratio.0 = f64::from(bounds.0.x) / f64::from(display_bounds.width());
         }
-        window.set_frame(position.0, bounds.0);
+        window.set_frame_for_commit(
+            position.0,
+            bounds.0,
+            reposition.is_some() || resize.is_some(),
+        );
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn release_frame_commit_after_reposition(
+    trigger: On<Remove, RepositionMarker>,
+    mut windows: Query<(&mut Window, Option<&ResizeMarker>)>,
+) {
+    let Ok((mut window, resize)) = windows.get_mut(trigger.entity) else {
+        return;
+    };
+    if resize.is_none() {
+        window.release_frame_commit();
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn release_frame_commit_after_resize(
+    trigger: On<Remove, ResizeMarker>,
+    mut windows: Query<(&mut Window, Option<&RepositionMarker>)>,
+) {
+    let Ok((mut window, reposition)) = windows.get_mut(trigger.entity) else {
+        return;
+    };
+    if reposition.is_none() {
+        window.release_frame_commit();
     }
 }
 
@@ -1082,9 +1119,7 @@ pub(crate) fn detect_tabbed_windows(
 }
 
 const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
-
-const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
-
+const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 50;
 const LOOP_MAX_TIMEOUT_MS: u32 = 50;
 
 const LOOP_TIMEOUT_STEP: u32 = 1;

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -557,25 +557,27 @@ pub(super) fn animate_resize_entities(
         });
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub(super) fn pump_events(
     mut exit: MessageWriter<AppExit>,
     mut messages: MessageWriter<Event>,
     low_power_mode: Option<Res<LowPowerMode>>,
     incoming_events: Option<NonSend<Receiver<Event>>>,
     platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
+    repositioning: Query<(), With<RepositionMarker>>,
+    resizing: Query<(), With<ResizeMarker>>,
+    scrolling: Query<(), With<Scrolling>>,
+    flash_messages: Query<(), With<FlashMessage>>,
     mut timeout: Local<u32>,
 ) {
-    const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
-    const LOOP_MAX_TIMEOUT_MS: u32 = 50;
-    const LOOP_TIMEOUT_STEP: u32 = 1;
-
     let Some((ref mut platform, incoming_events)) = platform.zip(incoming_events) else {
         // No platform interface or incoming event pipe - probably executing in a unit test.
         return;
     };
 
     platform.pump_cocoa_event_loop(f64::from(*timeout) / 1000.0);
+    let mut received_events = Vec::new();
+    let mut pending_mouse = None;
     loop {
         // Repeatedly drain the events until timeout.
         match incoming_events.recv_timeout(Duration::from_millis(1)) {
@@ -584,15 +586,25 @@ pub(super) fn pump_events(
                 break;
             }
             Ok(event) => {
-                messages.write(event);
+                if matches!(event, Event::MouseMoved { .. }) {
+                    pending_mouse = Some(event);
+                } else {
+                    received_events.extend(pending_mouse.take());
+                    received_events.push(event);
+                }
                 *timeout = LOOP_TIMEOUT_STEP;
             }
             Err(RecvTimeoutError::Timeout) => {
-                let timeout_limit = if low_power_mode.is_some_and(|low_power| low_power.0) {
-                    LOOP_MAX_TIMEOUT_LOWPOWER_MS
-                } else {
-                    LOOP_MAX_TIMEOUT_MS
-                };
+                received_events.extend(pending_mouse.take());
+                messages.write_batch(received_events);
+                let frame_active = !repositioning.is_empty()
+                    || !resizing.is_empty()
+                    || !scrolling.is_empty()
+                    || !flash_messages.is_empty();
+                let timeout_limit = pump_timeout_limit(
+                    low_power_mode.is_some_and(|low_power| low_power.0),
+                    frame_active,
+                );
                 *timeout = timeout.min(timeout_limit) + LOOP_TIMEOUT_STEP;
                 break;
             }
@@ -1067,5 +1079,50 @@ pub(crate) fn detect_tabbed_windows(
                 reshuffle_around(entity, &mut commands);
             }
         }
+    }
+}
+
+const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
+
+const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
+
+const LOOP_MAX_TIMEOUT_MS: u32 = 50;
+
+const LOOP_TIMEOUT_STEP: u32 = 1;
+
+fn pump_timeout_limit(low_power_active: bool, frame_active: bool) -> u32 {
+    if frame_active {
+        LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+    } else if low_power_active {
+        LOOP_MAX_TIMEOUT_LOWPOWER_MS
+    } else {
+        LOOP_MAX_TIMEOUT_MS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pump_timeout_limit_uses_frame_active_cap_for_visible_work() {
+        assert_eq!(pump_timeout_limit(false, false), LOOP_MAX_TIMEOUT_MS);
+        assert_eq!(
+            pump_timeout_limit(true, false),
+            LOOP_MAX_TIMEOUT_LOWPOWER_MS
+        );
+        assert_eq!(
+            pump_timeout_limit(false, true),
+            LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+        );
+        assert_eq!(
+            pump_timeout_limit(true, true),
+            LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+        );
+    }
+
+    #[test]
+    fn low_power_idle_timeout_stays_below_interactive_latency_budget() {
+        assert!(pump_timeout_limit(true, false) <= 50);
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -2,7 +2,9 @@ use bevy::app::AppExit;
 use bevy::ecs::change_detection::{DetectChanges, Ref};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
+use bevy::ecs::lifecycle::Remove;
 use bevy::ecs::message::{MessageReader, MessageWriter};
+use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::system::{
     Commands, Local, NonSend, NonSendMut, ParallelCommands, Populated, Query, Res, ResMut, Single,
@@ -30,7 +32,7 @@ use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, Initializing,
     LocateDockTrigger, LowPowerMode, MissionControlActive, Position, RestoreWindowState, Scrolling,
     SelectedVirtualMarker, SendMessageTrigger, Unmanaged, WidthRatio, WindowProperties,
-    focus_entity, reposition_entity, reshuffle_around,
+    despawn_timeout_entity, focus_entity, reposition_entity, reshuffle_around, remove_timeout,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -358,20 +360,20 @@ pub(super) fn add_launched_application(
 ///
 /// # Arguments
 ///
-/// * `cleanup` - A `Populated` query for `(Entity, Has<FreshMarker>, &Timeout)` components, targeting `BProcess` or `Application` entities.
+/// * `cleanup` - A `Populated` query for fresh `BProcess` or `Application` entities with timeouts.
 /// * `commands` - Bevy commands to remove components.
 #[allow(clippy::type_complexity)]
 pub(super) fn fresh_marker_cleanup(
     cleanup: Populated<
-        (Entity, Has<FreshMarker>, &Timeout),
-        Or<(With<BProcess>, With<Application>)>,
+        (Entity, Has<FreshMarker>),
+        (Or<(With<BProcess>, With<Application>)>, With<Timeout>),
     >,
     mut commands: Commands,
 ) {
-    for (entity, fresh, _) in cleanup {
+    for (entity, fresh) in cleanup {
         if !fresh {
             // Process was ready before the timer finished.
-            commands.entity(entity).try_remove::<Timeout>();
+            remove_timeout(entity, &mut commands);
         }
     }
 }
@@ -395,7 +397,6 @@ pub(super) fn timeout_ticker(
             trace!("Despawning entity {entity} due to timeout.");
             if let Some(system_id) = timeout.system_id.take() {
                 commands.run_system(system_id);
-                commands.unregister_system(system_id);
             }
             trace!("Removing timer {entity}");
             commands.entity(entity).despawn();
@@ -405,28 +406,38 @@ pub(super) fn timeout_ticker(
     }
 }
 
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn cleanup_timeout(
+    trigger: On<Remove, Timeout>,
+    timeouts: Query<&Timeout>,
+    mut commands: Commands,
+) {
+    let Ok(timeout) = timeouts.get(trigger.event().entity) else {
+        return;
+    };
+    if let Some(system_id) = timeout.system_id {
+        commands.unregister_system(system_id);
+    }
+}
+
 /// Retries querying the focused window for applications that had a transient AX error
 /// during `ApplicationFrontSwitched`. Runs each frame until success or timeout.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn retry_front_switch(
-    retries: Populated<(Entity, &RetryFrontSwitch)>,
+    retries: Populated<(Entity, &RetryFrontSwitch), With<Timeout>>,
     applications: Query<&Application>,
     mut commands: Commands,
 ) {
     for (entity, retry) in retries.iter() {
         let Ok(app) = applications.get(retry.0) else {
             // Application entity no longer exists, clean up.
-            if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_despawn();
-            }
+            despawn_timeout_entity(entity, &mut commands);
             continue;
         };
         if !app.is_frontmost() {
             // App is no longer frontmost — this retry is stale.
             debug!("Discarding stale front switch retry (app no longer frontmost).");
-            if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_despawn();
-            }
+            despawn_timeout_entity(entity, &mut commands);
             continue;
         }
         if let Ok(focused_id) = app.focused_window_id() {
@@ -434,9 +445,7 @@ pub(super) fn retry_front_switch(
             commands.trigger(SendMessageTrigger(Event::WindowFocused {
                 window_id: focused_id,
             }));
-            if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_despawn();
-            }
+            despawn_timeout_entity(entity, &mut commands);
         }
         // Otherwise, let timeout_ticker handle expiry.
     }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,5 +1,6 @@
 use bevy::app::AppExit;
 use bevy::ecs::change_detection::{DetectChanges, Ref};
+use bevy::ecs::change_detection::DetectChanges;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::lifecycle::Remove;

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -3,7 +3,7 @@ use bevy::ecs::change_detection::{DetectChanges, Ref};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
-use bevy::ecs::query::{Changed, Has, Or, With, Without};
+use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::system::{
     Commands, Local, NonSend, NonSendMut, ParallelCommands, Populated, Query, Res, ResMut, Single,
 };
@@ -30,7 +30,7 @@ use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, Initializing,
     LocateDockTrigger, LowPowerMode, MissionControlActive, Position, RestoreWindowState, Scrolling,
     SelectedVirtualMarker, SendMessageTrigger, Unmanaged, WidthRatio, WindowProperties,
-    focus_entity,
+    focus_entity, reposition_entity, reshuffle_around,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -994,6 +994,7 @@ pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>
     state.0 = process_info.isLowPowerModeEnabled();
 }
 
+#[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut commands: Commands) {
     for event in messages.read() {
@@ -1008,6 +1009,53 @@ pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut comm
             .map(|window| Window::new(Box::new(window)))
         {
             commands.trigger(SpawnWindowTrigger(vec![window]));
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn detect_tabbed_windows(
+    created: Populated<(Entity, &Bounds, &ChildOf), Added<Window>>,
+    windows: Query<(Entity, &Window, &Position, &Bounds, &ChildOf), With<Window>>,
+    apps: Query<Entity, With<Application>>,
+    mut workspaces: Query<&mut LayoutStrip>,
+    window_manager: Res<WindowManager>,
+    mut commands: Commands,
+) {
+    for (entity, Bounds(bounds), child) in created {
+        let Ok(app_entity) = apps.get(child.parent()) else {
+            continue;
+        };
+
+        // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
+        // window from the same application. If so, it's likely a native tab.
+        let tabbed = windows.iter().find_map(
+            |(leader, window, Position(leader_position), Bounds(leader_bounds), parent)| {
+                (leader != entity && parent.parent() == app_entity && leader_bounds.x == bounds.x)
+                    .then_some((leader, window.id(), leader_position))
+            },
+        );
+
+        // Tab detection heuristics:
+        // If the two windows are overlapping, and the previous window is suddenly not visible on
+        // the scren - it's a tab stack.
+        if let Some((leader, leader_id, leader_position)) = tabbed
+            && window_manager
+                .visible_on_screen(leader_id)
+                .is_some_and(|ids| !ids.contains(&leader_id))
+            && let Some(mut strip) = workspaces.iter_mut().find(|strip| strip.contains(entity))
+        {
+            debug!("Tabbed window detected: adding {entity} to leader {leader}");
+            if strip
+                .convert_to_tabs(leader, entity)
+                .inspect_err(|err| error!("Failed to convert to tabs: {err}"))
+                .is_ok()
+            {
+                // Reposition and reshuffle - otherwise the window will attempt to where the new
+                // tab was previously added.
+                reposition_entity(entity, *leader_position, &mut commands);
+                reshuffle_around(entity, &mut commands);
+            }
         }
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,6 +1,5 @@
 use bevy::app::AppExit;
 use bevy::ecs::change_detection::{DetectChanges, Ref};
-use bevy::ecs::change_detection::DetectChanges;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::lifecycle::Remove;

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -26,7 +26,8 @@ use crate::ecs::state::PaneruState;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, LocateDockTrigger,
     Position, RestoreWindowState, Scrolling, SendMessageTrigger, VerifyWindowPosition, WidthRatio,
-    WindowProperties, focus_entity, reposition_entity, reshuffle_around, resize_entity,
+    WindowProperties, despawn_timeout_entity, focus_entity, reposition_entity, reshuffle_around,
+    resize_entity,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -357,14 +358,14 @@ pub(super) fn mission_control_trigger(
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn application_event_trigger(
     mut messages: MessageReader<Event>,
-    processes: Query<(&BProcess, Entity)>,
+    processes: Query<(&BProcess, Entity, Has<Timeout>)>,
     mut commands: Commands,
 ) {
     const PROCESS_READY_TIMEOUT_SEC: u64 = 5;
     let find_process = |psn| {
         processes
             .iter()
-            .find(|(BProcess(process), _)| process.psn() == psn)
+            .find(|(BProcess(process), _, _)| process.psn() == psn)
     };
 
     for event in messages.read() {
@@ -383,8 +384,12 @@ pub(super) fn application_event_trigger(
             }
 
             Event::ApplicationTerminated { psn } => {
-                if let Some((_, entity)) = find_process(*psn) {
-                    commands.entity(entity).despawn();
+                if let Some((_, entity, has_timeout)) = find_process(*psn) {
+                    if has_timeout {
+                        despawn_timeout_entity(entity, &mut commands);
+                    } else {
+                        commands.entity(entity).despawn();
+                    }
                 }
             }
             _ => (),

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -21,7 +21,7 @@ use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, Initializing, NativeFullscreenMarker, Position,
-    RefreshWindowSizes, SelectedVirtualMarker, Timeout, Unmanaged, flash_message, focus_entity,
+    RefreshWindowSizes, SelectedVirtualMarker, Timeout, Unmanaged, flash_message, focus_entity, remove_timeout,
     reposition_entity, reshuffle_around,
 };
 use crate::errors::Result;
@@ -385,9 +385,9 @@ fn find_orphaned_workspaces(
         if child.is_some() {
             // Was reparented, remove timer.
             if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
-                cmd.try_remove::<Timeout>();
                 cmd.insert(RefreshWindowSizes::default());
             }
+            remove_timeout(orphan_entity, &mut commands);
             debug!(
                 "layout strip {} was re-parented, removing timeout.",
                 orphan.id()
@@ -427,10 +427,10 @@ fn find_orphaned_workspaces(
         );
 
         if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
-            cmd.try_remove::<Timeout>()
-                .insert(ChildOf(target_entity))
+            cmd.insert(ChildOf(target_entity))
                 .insert(RefreshWindowSizes::default());
         }
+        remove_timeout(orphan_entity, &mut commands);
     }
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -10,7 +10,8 @@ use objc2_core_foundation::{
 };
 use objc2_core_graphics::{
     CGAssociateMouseAndMouseCursorPosition, CGDirectDisplayID, CGDisplayBounds,
-    CGGetActiveDisplayList, CGWarpMouseCursorPosition,
+    CGGetActiveDisplayList, CGWarpMouseCursorPosition, CGWindowListCopyWindowInfo,
+    CGWindowListOption, kCGWindowNumber,
 };
 use std::path::Path;
 use std::ptr::null_mut;
@@ -170,6 +171,8 @@ pub trait WindowManagerApi: Send + Sync {
     fn cursor_position(&self) -> Option<CGPoint>;
 
     fn dim_windows(&self, windows: &[WinID], level: f32);
+
+    fn visible_on_screen(&self, window_id: WinID) -> Option<Vec<WinID>>;
 }
 
 /// `WindowManager` is a Bevy resource that holds a boxed `WindowManagerApi` trait object.
@@ -543,6 +546,21 @@ impl WindowManagerApi for WindowManagerOS {
         }
         .to_result(function_name!())
         .inspect_err(|err| debug!("{err}"));
+    }
+
+    fn visible_on_screen(&self, window_id: WinID) -> Option<Vec<WinID>> {
+        let option = CGWindowListOption::OptionOnScreenOnly;
+        let window_list_info = CGWindowListCopyWindowInfo(option, window_id.cast_unsigned());
+        window_list_info.map(|window_info| {
+            let array = unsafe { window_info.cast_unchecked::<CFDictionary<CFString, CFNumber>>() };
+            array
+                .iter()
+                .filter_map(|dict| {
+                    dict.get(unsafe { kCGWindowNumber })
+                        .and_then(|id| id.as_i32())
+                })
+                .collect::<Vec<_>>()
+        })
     }
 }
 

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -494,43 +494,47 @@ impl AxObserverHandler {
             which,
         });
         let context_ptr = NonNull::from_ref(&*context).as_ptr();
-        self.contexts.push(context);
 
         // TODO: retry re-registering these.
         let mut retry = vec![];
-        let added = notifications
-            .iter()
-            .filter_map(|name| {
-                debug!("adding {name} {element:x?} {observer:?}");
-                let notification = CFString::from_static_str(name);
-                match unsafe {
-                    AXObserverAddNotification(
-                        observer,
-                        element.as_ptr(),
-                        &notification,
-                        context_ptr.cast(),
-                    )
-                } {
-                    accessibility_sys::kAXErrorSuccess
-                    | accessibility_sys::kAXErrorNotificationAlreadyRegistered => Some(*name),
-                    accessibility_sys::kAXErrorCannotComplete => {
-                        retry.push(*name);
-                        None
-                    }
-                    result => {
-                        error!("error adding {name} {element:x?} {observer:?}: {result}");
-                        None
-                    }
+        let mut registered_any = false;
+        let mut context_used = false;
+        for name in notifications {
+            debug!("adding {name} {element:x?} {observer:?}");
+            let notification = CFString::from_static_str(name);
+            match unsafe {
+                AXObserverAddNotification(
+                    observer,
+                    element.as_ptr(),
+                    &notification,
+                    context_ptr.cast(),
+                )
+            } {
+                accessibility_sys::kAXErrorSuccess => {
+                    registered_any = true;
+                    context_used = true;
                 }
-            })
-            .collect::<Vec<_>>();
-        if added.is_empty() {
+                accessibility_sys::kAXErrorNotificationAlreadyRegistered => {
+                    registered_any = true;
+                }
+                accessibility_sys::kAXErrorCannotComplete => {
+                    retry.push(*name);
+                }
+                result => {
+                    error!("error adding {name} {element:x?} {observer:?}: {result}");
+                }
+            }
+        }
+        if context_used {
+            self.contexts.push(context);
+        }
+        if registered_any {
+            Ok(retry)
+        } else {
             Err(Error::PermissionDenied(format!(
                 "{}: unable to register any observers!",
                 function_name!()
             )))
-        } else {
-            Ok(retry)
         }
     }
 

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -59,6 +59,15 @@ pub trait WindowApi: Send + Sync {
         self.reposition(origin);
         self.resize(size);
     }
+    fn set_frame_for_commit(
+        &mut self,
+        origin: Origin,
+        size: Size,
+        _defer_enhanced_ui_restore: bool,
+    ) {
+        self.set_frame(origin, size);
+    }
+    fn release_frame_commit(&mut self) {}
     fn update_frame(&mut self) -> Result<IRect>;
     fn focus_without_raise(
         &self,
@@ -122,6 +131,13 @@ pub struct WindowOS {
     border_radius: OnceLock<Option<f64>>,
     pid: OnceLock<Result<Pid>>,
     app_reference: OnceLock<Option<CFRetained<AXUIWrapper>>>,
+    enhanced_ui_commit_held: bool,
+}
+
+impl Drop for WindowOS {
+    fn drop(&mut self) {
+        self.release_enhanced_ui_commit();
+    }
 }
 
 impl WindowOS {
@@ -146,6 +162,7 @@ impl WindowOS {
             border_radius: OnceLock::new(),
             pid: OnceLock::new(),
             app_reference: OnceLock::new(),
+            enhanced_ui_commit_held: false,
         };
 
         if window.is_unknown() {
@@ -273,6 +290,22 @@ impl WindowOS {
                 );
             }
         }
+    }
+
+    fn hold_enhanced_ui_for_commit(&mut self) {
+        if self.enhanced_ui_commit_held {
+            return;
+        }
+        self.disable_enhanced_ui();
+        self.enhanced_ui_commit_held = true;
+    }
+
+    fn release_enhanced_ui_commit(&mut self) {
+        if !self.enhanced_ui_commit_held {
+            return;
+        }
+        self.enhanced_ui_commit_held = false;
+        self.reenable_enhanced_ui();
     }
 
     /// Makes the window the key window for its application by sending synthesized events.
@@ -474,6 +507,48 @@ impl WindowApi for WindowOS {
             self.set_size_attribute(size);
         }
         self.reenable_enhanced_ui();
+    }
+
+    #[instrument(level = Level::TRACE)]
+    fn set_frame_for_commit(
+        &mut self,
+        origin: Origin,
+        size: Size,
+        defer_enhanced_ui_restore: bool,
+    ) {
+        let position_changed = self.frame.min != origin;
+        let size_changed = self.frame.size() != size;
+        if !position_changed && !size_changed {
+            if !defer_enhanced_ui_restore {
+                self.release_enhanced_ui_commit();
+            }
+            trace!("already correct frame.");
+            return;
+        }
+
+        if defer_enhanced_ui_restore {
+            self.hold_enhanced_ui_for_commit();
+            if position_changed {
+                self.set_position_attribute(origin);
+            }
+            if size_changed {
+                self.set_size_attribute(size);
+            }
+        } else if self.enhanced_ui_commit_held {
+            if position_changed {
+                self.set_position_attribute(origin);
+            }
+            if size_changed {
+                self.set_size_attribute(size);
+            }
+            self.release_enhanced_ui_commit();
+        } else {
+            self.set_frame(origin, size);
+        }
+    }
+
+    fn release_frame_commit(&mut self) {
+        self.release_enhanced_ui_commit();
     }
 
     /// Updates the internal `frame` of the window by querying its current position and size from the Accessibility API.

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -171,7 +171,7 @@ pub(crate) fn window_spawner(
         let mut windows = (0..count)
             .map(|i| {
                 let origin = Origin::new(0, 0);
-                let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+                let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT - i);
                 let window = MockWindow::new(
                     i,
                     IRect {

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -355,6 +355,9 @@ fn test_rapid_focus_not_swallowed() {
         Event::Command {
             command: Command::Window(Operation::Focus(Direction::Last)),
         },
+        Event::Command {
+            command: Command::PrintState,
+        },
     ]);
 
     verify_focused_window(0, harness.app.world_mut());

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -312,6 +312,11 @@ impl WindowManagerApi for MockWindowManager {
 
     #[instrument(level = Level::DEBUG, skip(self))]
     fn dim_windows(&self, windows: &[WinID], level: f32) {}
+
+    #[instrument(level = Level::DEBUG, skip(self))]
+    fn visible_on_screen(&self, window_id: WinID) -> Option<Vec<WinID>> {
+        None
+    }
 }
 
 /// A mock implementation of the `WindowApi` trait for testing purposes.
@@ -632,4 +637,8 @@ impl WindowManagerApi for TwoDisplayMock {
     }
 
     fn dim_windows(&self, _windows: &[WinID], _level: f32) {}
+
+    fn visible_on_screen(&self, _window_id: WinID) -> Option<Vec<WinID>> {
+        None
+    }
 }


### PR DESCRIPTION
Various performance improvements (paneru is more responsive with this changes). I splited it in invididual commits to allow better review and modular changes/acceptance if needed.

- Reduces event loop latency by draining ready events before the Cocoa pump, coalescing `MouseMoved` events, and capping waits while visible work or low-power mode is active.
- Avoids expensive hot-path work: fewer AX reads during spawn logging, nonblocking subscriber sockets, hard-match caching for session restore, and fallback metadata reads only when needed.
- Optimizes layout and window commits by caching `LayoutStrip` membership/context, using `HashSet` lookups for unresolved windows, and combining position/size updates into a single `set_frame` commit.
- Cleans up lifecycle resources by unregistering one-shot timeout systems during early cleanup and avoiding retention of unused AX observer contexts.


Im not an expert in rust or macos-development, i writed this changes with the help of codex