### PR TITLE
fix: stabilize startup window layout assignment (Fix from failing tests)

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -495,7 +495,7 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
 }
 
 struct WindowProperties {
-    pub params: Vec<WindowParams>,
+    params: Vec<WindowParams>,
 }
 
 impl WindowProperties {
@@ -541,5 +541,19 @@ impl WindowProperties {
 
     pub fn width_ratio(&self) -> Option<f64> {
         self.params.iter().find_map(|props| props.width)
+    }
+
+    pub fn vertical_padding(&self) -> i32 {
+        self.params
+            .iter()
+            .find_map(|props| props.vertical_padding)
+            .unwrap_or(0)
+    }
+
+    pub fn horizontal_padding(&self) -> i32 {
+        self.params
+            .iter()
+            .find_map(|props| props.horizontal_padding)
+            .unwrap_or(0)
     }
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -80,6 +80,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
     app.add_systems(
         Update,
         (
+            triggers::apply_window_properties,
             (
                 systems::add_existing_process,
                 systems::add_existing_application,
@@ -166,7 +167,6 @@ pub fn register_triggers(app: &mut bevy::app::App) {
         .add_observer(triggers::locate_dock_trigger)
         .add_observer(triggers::send_message_trigger)
         .add_observer(triggers::window_removal_trigger)
-        .add_observer(triggers::apply_window_properties)
         .add_observer(restore::restore_window_state);
 }
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -80,7 +80,8 @@ pub fn register_systems(app: &mut bevy::app::App) {
     app.add_systems(
         Update,
         (
-            triggers::apply_window_properties,
+            triggers::apply_window_defaults,
+            triggers::apply_window_positions,
             (
                 systems::add_existing_process,
                 systems::add_existing_application,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -94,6 +94,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
             systems::fresh_marker_cleanup,
             systems::timeout_ticker,
             systems::retry_front_switch,
+            systems::detect_tabbed_windows.before(triggers::apply_window_positions),
             systems::update_low_power_state
                 .run_if(resource_exists::<LowPowerMode>)
                 .run_if(on_timer(Duration::from_secs(LOW_POWER_MODE_CHECK_SEC))),

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -239,6 +239,10 @@ impl LayoutStrip {
 
     /// Converts a column containing `leader` to a `Tabs` column and adds `follower`.
     pub fn convert_to_tabs(&mut self, leader: Entity, follower: Entity) -> Result<()> {
+        if leader != follower {
+            self.remove(follower);
+        }
+
         let index = self.index_of(leader)?;
         let column = self.columns.remove(index).unwrap();
         match column {
@@ -1031,6 +1035,25 @@ mod tests {
         assert_eq!(strip.index_of(entities[1]).unwrap(), 0);
         assert_eq!(strip.index_of(entities[0]).unwrap(), 1);
         assert_eq!(strip.index_of(entities[2]).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_convert_to_tabs_removes_existing_follower_column() {
+        let (_world, mut strip, entities) = setup_world_and_strip();
+
+        strip.convert_to_tabs(entities[1], entities[2]).unwrap();
+
+        assert_eq!(strip.len(), 2);
+        assert_eq!(
+            strip.all_windows(),
+            vec![entities[0], entities[1], entities[2]]
+        );
+        assert_eq!(strip.index_of(entities[1]).unwrap(), 1);
+        assert_eq!(strip.index_of(entities[2]).unwrap(), 1);
+        assert!(matches!(
+            strip.get(1).unwrap(),
+            Column::Tabs(tabs) if tabs == vec![entities[1], entities[2]]
+        ));
     }
 
     #[test]

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -271,12 +271,6 @@ impl Windows<'_, '_> {
             .map(|(window, entity, _, _)| (window, entity))
     }
 
-    pub fn all_iter(&self) -> impl Iterator<Item = (&Window, Entity, &ChildOf)> {
-        self.all
-            .iter()
-            .map(|(window, entity, childof, _)| (window, entity, childof))
-    }
-
     pub fn managed_iter(&self) -> impl Iterator<Item = (&Window, Entity, &ChildOf)> {
         self.all
             .iter()

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -2,11 +2,11 @@ use bevy::app::AppExit;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
-use bevy::ecs::query::{Changed, Has, Or, With, Without};
+use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::system::{
     Commands, Local, NonSend, NonSendMut, ParallelCommands, Populated, Query, Res, ResMut, Single,
 };
-use bevy::math::IRect;
+use bevy::math::{IRect, IVec2};
 use bevy::tasks::AsyncComputeTaskPool;
 use bevy::tasks::futures_lite::future;
 use bevy::time::Time;
@@ -1041,4 +1041,57 @@ pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>
     };
     let process_info = objc2_foundation::NSProcessInfo::processInfo();
     state.0 = process_info.isLowPowerModeEnabled();
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn detect_tabbed_windows(
+    created: Populated<(&Window, Entity, &ChildOf), Added<Window>>,
+    windows: Query<(&Window, Entity, &ChildOf)>,
+    mut workspaces: Query<&mut LayoutStrip, With<ActiveWorkspaceMarker>>,
+    apps: Query<(Entity, &Application)>,
+    config: Res<Config>,
+) {
+    for (window, entity, child) in created {
+        let Ok((app_entity, app)) = apps.get(child.parent()) else {
+            continue;
+        };
+
+        // A tabbed window will be inserted with the same size as the leader.
+        // So compensate for the potential frame padding.
+        let properties = WindowProperties::new(app, window, &config);
+        let padding = IVec2::new(
+            properties.horizontal_padding(),
+            properties.vertical_padding(),
+        );
+        let mut frame = window.frame();
+        frame.min -= padding;
+        frame.max += padding;
+
+        // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
+        // window from the same application. If so, it's likely a native tab.
+        let tabbed_entity = windows
+            .iter()
+            .find_map(|(existing_window, leader, parent)| {
+                (leader != entity
+                    && parent.parent() == app_entity
+                    // && strip.contains(leader)
+                    && existing_window.frame() == frame)
+                    .then_some(leader)
+            });
+
+        if let Some(leader) = tabbed_entity {
+            debug!(
+                "Adding window {} as a tab follower for leader {leader:?} (overlapping frame)",
+                window.id()
+            );
+            // strip.remove(entity);
+            let Some(ref mut strip) = workspaces.iter_mut().find(|strip| strip.contains(leader))
+            else {
+                continue;
+            };
+            _ = strip
+                .convert_to_tabs(leader, entity)
+                .inspect_err(|err| error!("Failed to convert to tabs: {err}"));
+        }
+    }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -4,7 +4,8 @@ use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::system::{
-    Commands, Local, NonSend, NonSendMut, ParallelCommands, Populated, Query, Res, ResMut, Single,
+    Commands, Local, NonSend, NonSendMut, ParallelCommands, ParamSet, Populated, Query, Res,
+    ResMut, Single,
 };
 use bevy::math::{IRect, IVec2};
 use bevy::tasks::AsyncComputeTaskPool;
@@ -1043,15 +1044,22 @@ pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>
     state.0 = process_info.isLowPowerModeEnabled();
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 pub(crate) fn detect_tabbed_windows(
     created: Populated<(&Window, Entity, &ChildOf), Added<Window>>,
     windows: Query<(&Window, Entity, &ChildOf)>,
-    mut workspaces: Query<&mut LayoutStrip, With<ActiveWorkspaceMarker>>,
+    mut workspaces: ParamSet<(
+        Query<&LayoutStrip>,
+        Query<&mut LayoutStrip, With<ActiveWorkspaceMarker>>,
+    )>,
     apps: Query<(Entity, &Application)>,
     config: Res<Config>,
 ) {
     for (window, entity, child) in created {
+        if workspaces.p0().iter().any(|strip| strip.contains(entity)) {
+            continue;
+        }
+
         let Ok((app_entity, app)) = apps.get(child.parent()) else {
             continue;
         };
@@ -1085,7 +1093,10 @@ pub(crate) fn detect_tabbed_windows(
                 window.id()
             );
             // strip.remove(entity);
-            let Some(ref mut strip) = workspaces.iter_mut().find(|strip| strip.contains(leader))
+            let mut active_workspaces = workspaces.p1();
+            let Some(ref mut strip) = active_workspaces
+                .iter_mut()
+                .find(|strip| strip.contains(leader))
             else {
                 continue;
             };

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -819,14 +819,13 @@ fn give_away_focus(
 /// * `active_display` - A query for the active display.
 /// * `main_cid` - The main connection ID resource.
 /// * `commands` - Bevy commands to manage components and trigger events.
-#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+#[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn spawn_window_trigger(
     mut trigger: On<SpawnWindowTrigger>,
-    windows: Windows,
+    windows: Query<(&Window, Entity, &ChildOf)>,
     mut apps: Query<(Entity, &mut Application)>,
-    mut active_display: ActiveDisplayMut,
-    config: Res<Config>,
+    active_display: ActiveDisplayMut,
     initializing: Option<Res<Initializing>>,
     restore: Option<Res<crate::ecs::restore::SessionRestore>>,
     mut commands: Commands,
@@ -836,7 +835,7 @@ pub(super) fn spawn_window_trigger(
     while let Some(mut window) = new_windows.pop() {
         let window_id = window.id();
 
-        if windows.find(window_id).is_some() {
+        if windows.iter().any(|window| window.0.id() == window_id) {
             continue;
         }
 
@@ -870,19 +869,6 @@ pub(super) fn spawn_window_trigger(
             window.title().unwrap_or_default()
         );
 
-        let properties = WindowProperties::new(&app, &window, &config);
-        if !properties.params.is_empty() {
-            debug!("Applying window properties for '{}'", window.id());
-        }
-
-        apply_window_defaults(
-            &mut window,
-            &mut active_display,
-            &properties,
-            &config,
-            initializing.is_some(),
-        );
-
         // update_frame expands the OS rect by the per-window padding, so calling it *after*
         // set_padding produces the correct logical frame for the ECS components below.
         let Ok(frame) = window.update_frame().inspect_err(|err| error!("{err}")) else {
@@ -894,37 +880,16 @@ pub(super) fn spawn_window_trigger(
             WidthRatio(f64::from(frame.width()) / f64::from(active_display.bounds().width()));
         let layout_position = LayoutPosition::default();
 
-        // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
-        // window from the same application. If so, it's likely a native tab.
-        let tabbed_entity = windows
-            .all_iter()
-            .find_map(|(existing_window, entity, parent)| {
-                (parent.parent() == app_entity && existing_window.frame() == window.frame())
-                    .then_some(entity)
-            });
-
         // Insert the window into the internal Bevy state.
         // This insertion triggers window attributes observer.
-        let entity = commands
-            .spawn((
-                position,
-                bounds,
-                width_ratio,
-                window,
-                layout_position,
-                ChildOf(app_entity),
-            ))
-            .id();
-
-        if let Some(leader) = tabbed_entity {
-            debug!(
-                "Adding window {window_id} as a tab follower for leader {leader:?} (overlapping frame)"
-            );
-            let layout_strip = active_display.active_strip();
-            _ = layout_strip
-                .convert_to_tabs(leader, entity)
-                .inspect_err(|err| error!("Failed to convert to tabs: {err}"));
-        }
+        commands.spawn((
+            position,
+            bounds,
+            width_ratio,
+            window,
+            layout_position,
+            ChildOf(app_entity),
+        ));
     }
 
     if initializing.is_none() && restore.is_some() {
@@ -932,55 +897,73 @@ pub(super) fn spawn_window_trigger(
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
-fn apply_window_defaults(
-    window: &mut Window,
-    active_display: &mut ActiveDisplayMut,
-    properties: &WindowProperties,
-    config: &Config,
-    initializing: bool,
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn apply_window_defaults(
+    added: Populated<(&mut Window, Entity, &ChildOf), Added<Window>>,
+    apps: Query<(Entity, &Application)>,
+    active_display: ActiveDisplay,
+    config: Res<Config>,
+    initializing: Option<Res<Initializing>>,
 ) {
-    // Do not add padding to floating windows.
-    if properties.floating() {
-        // Skip grid_ratios during init: we don't know this window's display.
-        if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
-            let bounds = active_display.bounds();
-            let x = (f64::from(bounds.width()) * rx) as i32;
-            let y = (f64::from(bounds.height()) * ry) as i32;
-            let w = (f64::from(bounds.width()) * rw) as i32;
-            let h = (f64::from(bounds.height()) * rh) as i32;
-            window.reposition(Origin::new(x, y));
-            window.resize(Size::new(w, h));
+    for (ref mut window, entity, child) in added {
+        if active_display.active_strip().tabbed(entity) {
+            debug!("Ignoring tabbed {entity} attributes.");
+            continue;
         }
-        return;
-    }
 
-    let vpadding = properties.vertical_padding();
-    let hpadding = properties.horizontal_padding();
-    window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
-    window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+        let Ok((_, app)) = apps.get(child.parent()) else {
+            continue;
+        };
 
-    // Apply configured width AFTER update_frame so it isn't overwritten.
-    // Use padded display width (matching window_resize command behavior).
-    // Safe during init: this only resizes, it doesn't reposition, so a
-    // window on an inactive display stays put.
-    if let Some(width) = properties.width_ratio() {
-        _ = window.update_frame().inspect_err(|err| error!("{err}"));
-        let bounds = active_display.bounds();
-        let (_, pad_right, _, pad_left) = config.edge_padding();
-        let padded_width = bounds.width() - pad_left - pad_right;
-        let new_width = (f64::from(padded_width) * width).round() as i32;
-        let height = window.frame().height();
-        window.resize(Size::new(new_width, height));
-        // Re-read the actual OS size: the app may enforce a minimum width
-        // that differs from our request.
-        _ = window.update_frame().inspect_err(|err| error!("{err}"));
+        let properties = WindowProperties::new(app, window, &config);
+        if !properties.params.is_empty() {
+            debug!("Applying window defaults for '{}'", window.id());
+        }
+
+        let initializing = initializing.is_some();
+        let floating = properties.floating();
+
+        // Do not add padding to floating windows.
+        if floating {
+            // Skip grid_ratios during init: we don't know this window's display.
+            if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
+                let bounds = active_display.bounds();
+                let x = (f64::from(bounds.width()) * rx) as i32;
+                let y = (f64::from(bounds.height()) * ry) as i32;
+                let w = (f64::from(bounds.width()) * rw) as i32;
+                let h = (f64::from(bounds.height()) * rh) as i32;
+                window.reposition(Origin::new(x, y));
+                window.resize(Size::new(w, h));
+            }
+            continue;
+        }
+        let vpadding = properties.vertical_padding();
+        let hpadding = properties.horizontal_padding();
+        window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
+        window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+
+        // Apply configured width AFTER update_frame so it isn't overwritten.
+        // Use padded display width (matching window_resize command behavior).
+        // Safe during init: this only resizes, it doesn't reposition, so a
+        // window on an inactive display stays put.
+        if let Some(width) = properties.width_ratio() {
+            _ = window.update_frame().inspect_err(|err| error!("{err}"));
+            let bounds = active_display.bounds();
+            let (_, pad_right, _, pad_left) = config.edge_padding();
+            let padded_width = bounds.width() - pad_left - pad_right;
+            let new_width = (f64::from(padded_width) * width).round() as i32;
+            let height = window.frame().height();
+            window.resize(Size::new(new_width, height));
+            // Re-read the actual OS size: the app may enforce a minimum width
+            // that differs from our request.
+            _ = window.update_frame().inspect_err(|err| error!("{err}"));
+        }
     }
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
-pub(super) fn apply_window_properties(
+pub(super) fn apply_window_positions(
     added: Populated<Entity, Added<Window>>,
     mut active_display: ActiveDisplayMut,
     windows: Windows,

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -19,7 +19,7 @@ use super::{
     PreviousManagedStrip, RetryFrontSwitch, SelectedVirtualMarker, SpawnWindowTrigger,
     StrayFocusEvent, SystemTheme, Timeout, Unmanaged,
 };
-use crate::config::{Config, WindowParams};
+use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
@@ -878,7 +878,7 @@ pub(super) fn spawn_window_trigger(
         apply_window_defaults(
             &mut window,
             &mut active_display,
-            &properties.params,
+            &properties,
             &config,
             initializing.is_some(),
         );
@@ -936,31 +936,14 @@ pub(super) fn spawn_window_trigger(
 fn apply_window_defaults(
     window: &mut Window,
     active_display: &mut ActiveDisplayMut,
-    properties: &[WindowParams],
+    properties: &WindowProperties,
     config: &Config,
     initializing: bool,
 ) {
-    let floating = properties
-        .iter()
-        .find_map(|props| props.floating)
-        .unwrap_or(false);
-
     // Do not add padding to floating windows.
-    if let Some(padding) = properties.iter().find_map(|props| props.vertical_padding)
-        && !floating
-    {
-        window.set_padding(WindowPadding::Vertical(padding.clamp(0, 50)));
-    }
-    if let Some(padding) = properties.iter().find_map(|props| props.horizontal_padding)
-        && !floating
-    {
-        window.set_padding(WindowPadding::Horizontal(padding.clamp(0, 50)));
-    }
-    if floating {
+    if properties.floating() {
         // Skip grid_ratios during init: we don't know this window's display.
-        if !initializing
-            && let Some((rx, ry, rw, rh)) = properties.iter().find_map(WindowParams::grid_ratios)
-        {
+        if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
             let bounds = active_display.bounds();
             let x = (f64::from(bounds.width()) * rx) as i32;
             let y = (f64::from(bounds.height()) * ry) as i32;
@@ -972,11 +955,16 @@ fn apply_window_defaults(
         return;
     }
 
+    let vpadding = properties.vertical_padding();
+    let hpadding = properties.horizontal_padding();
+    window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
+    window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+
     // Apply configured width AFTER update_frame so it isn't overwritten.
     // Use padded display width (matching window_resize command behavior).
     // Safe during init: this only resizes, it doesn't reposition, so a
     // window on an inactive display stays put.
-    if let Some(width) = properties.iter().find_map(|props| props.width) {
+    if let Some(width) = properties.width_ratio() {
         _ = window.update_frame().inspect_err(|err| error!("{err}"));
         let bounds = active_display.bounds();
         let (_, pad_right, _, pad_left) = config.edge_padding();

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -899,18 +899,13 @@ pub(super) fn spawn_window_trigger(
 
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn apply_window_defaults(
-    added: Populated<(&mut Window, Entity, &ChildOf), Added<Window>>,
+    added: Populated<(&mut Window, &ChildOf), Added<Window>>,
     apps: Query<(Entity, &Application)>,
     active_display: ActiveDisplay,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
 ) {
-    for (ref mut window, entity, child) in added {
-        if active_display.active_strip().tabbed(entity) {
-            debug!("Ignoring tabbed {entity} attributes.");
-            continue;
-        }
-
+    for (ref mut window, child) in added {
         let Ok((_, app)) = apps.get(child.parent()) else {
             continue;
         };

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -4,7 +4,9 @@ use bevy::ecs::lifecycle::{Add, Remove};
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With};
-use bevy::ecs::system::{Commands, NonSend, NonSendMut, Populated, Query, Res, ResMut, Single};
+use bevy::ecs::system::{
+    Commands, NonSend, NonSendMut, ParamSet, Populated, Query, Res, ResMut, Single,
+};
 use bevy::math::IRect;
 use notify::event::{DataChange, MetadataKind, ModifyKind};
 use notify::{EventKind, Watcher};
@@ -899,13 +901,13 @@ pub(super) fn spawn_window_trigger(
 
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn apply_window_defaults(
-    added: Populated<(&mut Window, &ChildOf), Added<Window>>,
+    added: Populated<(&mut Window, &ChildOf, &mut Position, &mut Bounds), Added<Window>>,
     apps: Query<(Entity, &Application)>,
     active_display: ActiveDisplay,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
 ) {
-    for (ref mut window, child) in added {
+    for (ref mut window, child, mut position, mut bounds) in added {
         let Ok((_, app)) = apps.get(child.parent()) else {
             continue;
         };
@@ -936,31 +938,44 @@ pub(super) fn apply_window_defaults(
         let hpadding = properties.horizontal_padding();
         window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
         window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+        if let Ok(frame) = window.update_frame().inspect_err(|err| error!("{err}")) {
+            position.0 = frame.min;
+            bounds.0 = frame.size();
+        }
 
         // Apply configured width AFTER update_frame so it isn't overwritten.
         // Use padded display width (matching window_resize command behavior).
         // Safe during init: this only resizes, it doesn't reposition, so a
         // window on an inactive display stays put.
         if let Some(width) = properties.width_ratio() {
-            _ = window.update_frame().inspect_err(|err| error!("{err}"));
-            let bounds = active_display.bounds();
+            let display_bounds = active_display.bounds();
             let (_, pad_right, _, pad_left) = config.edge_padding();
-            let padded_width = bounds.width() - pad_left - pad_right;
+            let padded_width = display_bounds.width() - pad_left - pad_right;
             let new_width = (f64::from(padded_width) * width).round() as i32;
             let height = window.frame().height();
             window.resize(Size::new(new_width, height));
             // Re-read the actual OS size: the app may enforce a minimum width
             // that differs from our request.
-            _ = window.update_frame().inspect_err(|err| error!("{err}"));
+            if let Ok(frame) = window.update_frame().inspect_err(|err| error!("{err}")) {
+                position.0 = frame.min;
+                bounds.0 = frame.size();
+            }
         }
     }
 }
 
-#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments,
+    clippy::type_complexity
+)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn apply_window_positions(
     added: Populated<Entity, Added<Window>>,
-    mut active_display: ActiveDisplayMut,
+    mut workspaces: ParamSet<(
+        Query<&LayoutStrip>,
+        Query<&mut LayoutStrip, With<ActiveWorkspaceMarker>>,
+    )>,
     windows: Windows,
     apps: Query<&Application>,
     config: Res<Config>,
@@ -970,7 +985,7 @@ pub(super) fn apply_window_positions(
     mut commands: Commands,
 ) {
     for entity in added {
-        if active_display.active_strip().tabbed(entity) {
+        if workspaces.p0().iter().any(|strip| strip.tabbed(entity)) {
             debug!("Ignoring tabbed {entity} attributes.");
             continue;
         }
@@ -1003,7 +1018,14 @@ pub(super) fn apply_window_positions(
             continue;
         }
 
-        let strip = active_display.active_strip();
+        if workspaces.p0().iter().any(|strip| strip.contains(entity)) {
+            continue;
+        }
+
+        let mut active_workspaces = workspaces.p1();
+        let Ok(mut strip) = active_workspaces.single_mut() else {
+            continue;
+        };
 
         // Attempt inserting the window at a pre-defined position.
         let insert_at = properties.insertion().map_or_else(
@@ -1018,7 +1040,7 @@ pub(super) fn apply_window_positions(
             Some,
         );
 
-        debug!("New window adding at {strip}");
+        debug!("New window adding at {}", &*strip);
         match insert_at {
             Some(after) => {
                 debug!("New window inserted at {after}");

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -3,8 +3,8 @@ use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::lifecycle::{Add, Remove};
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
-use bevy::ecs::query::{Has, With};
-use bevy::ecs::system::{Commands, NonSend, NonSendMut, Query, Res, ResMut, Single};
+use bevy::ecs::query::{Added, Has, With};
+use bevy::ecs::system::{Commands, NonSend, NonSendMut, Populated, Query, Res, ResMut, Single};
 use bevy::math::IRect;
 use notify::event::{DataChange, MetadataKind, ModifyKind};
 use notify::{EventKind, Watcher};
@@ -991,9 +991,9 @@ fn apply_window_defaults(
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
-#[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
+#[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn apply_window_properties(
-    trigger: On<Add, Window>,
+    added: Populated<Entity, Added<Window>>,
     mut active_display: ActiveDisplayMut,
     windows: Windows,
     apps: Query<&Application>,
@@ -1003,81 +1003,81 @@ pub(super) fn apply_window_properties(
     restoration: Option<Res<PaneruState>>,
     mut commands: Commands,
 ) {
-    let entity = trigger.event().entity;
-
-    if active_display.active_strip().tabbed(entity) {
-        debug!("Ignoring tabbed {entity} attributes.");
-        return;
-    }
-
-    let Some((window, _, parent)) = windows
-        .get(entity)
-        .and_then(|window| windows.find_parent(window.id()))
-    else {
-        return;
-    };
-    let Ok(app) = apps.get(parent) else {
-        return;
-    };
-
-    if crate::ecs::restore::matches_startup_restore_state(
-        window,
-        app,
-        restore.as_deref(),
-        restoration.as_deref(),
-        &config,
-    ) {
-        return;
-    }
-
-    let properties = WindowProperties::new(app, window, &config);
-
-    if properties.floating() {
-        // Avoid managing window if it's floating.
-        commands.entity(entity).try_insert(Unmanaged::Floating);
-        return;
-    }
-
-    let strip = active_display.active_strip();
-
-    // Attempt inserting the window at a pre-defined position.
-    let insert_at = properties.insertion().map_or_else(
-        || {
-            // Otherwise attempt inserting it after the current focus.
-            let focused_window = windows.focused();
-            // Insert to the right of the currently focused window
-            focused_window
-                .and_then(|(_, entity)| strip.index_of(entity).ok())
-                .and_then(|insert_at| (insert_at + 1 < strip.len()).then_some(insert_at + 1))
-        },
-        Some,
-    );
-
-    debug!("New window adding at {strip}");
-    match insert_at {
-        Some(after) => {
-            debug!("New window inserted at {after}");
-            strip.insert_at(after, entity);
+    for entity in added {
+        if active_display.active_strip().tabbed(entity) {
+            debug!("Ignoring tabbed {entity} attributes.");
+            continue;
         }
-        None => strip.append(entity),
-    }
 
-    // During init, skip per-window reshuffles. finish_setup does a single
-    // reshuffle after all windows are added.
-    if initializing.is_none() {
-        if properties.dont_focus() {
-            if let Some((focus, prev)) = windows.focused() {
-                debug!(
-                    "Not focusing new window {entity}, keeping focus on '{}'",
-                    focus.title().unwrap_or_default()
-                );
-                focus_entity(prev, true, &mut commands);
+        let Some((window, _, parent)) = windows
+            .get(entity)
+            .and_then(|window| windows.find_parent(window.id()))
+        else {
+            continue;
+        };
+        let Ok(app) = apps.get(parent) else {
+            continue;
+        };
+
+        if crate::ecs::restore::matches_startup_restore_state(
+            window,
+            app,
+            restore.as_deref(),
+            restoration.as_deref(),
+            &config,
+        ) {
+            continue;
+        }
+
+        let properties = WindowProperties::new(app, window, &config);
+
+        if properties.floating() {
+            // Avoid managing window if it's floating.
+            commands.entity(entity).try_insert(Unmanaged::Floating);
+            continue;
+        }
+
+        let strip = active_display.active_strip();
+
+        // Attempt inserting the window at a pre-defined position.
+        let insert_at = properties.insertion().map_or_else(
+            || {
+                // Otherwise attempt inserting it after the current focus.
+                let focused_window = windows.focused();
+                // Insert to the right of the currently focused window
+                focused_window
+                    .and_then(|(_, entity)| strip.index_of(entity).ok())
+                    .and_then(|insert_at| (insert_at + 1 < strip.len()).then_some(insert_at + 1))
+            },
+            Some,
+        );
+
+        debug!("New window adding at {strip}");
+        match insert_at {
+            Some(after) => {
+                debug!("New window inserted at {after}");
+                strip.insert_at(after, entity);
             }
-        } else {
-            debug!("Synthesizing WindowFocused for newly spawned window {entity}");
-            commands.trigger(SendMessageTrigger(Event::WindowFocused {
-                window_id: window.id(),
-            }));
+            None => strip.append(entity),
+        }
+
+        // During init, skip per-window reshuffles. finish_setup does a single
+        // reshuffle after all windows are added.
+        if initializing.is_none() {
+            if properties.dont_focus() {
+                if let Some((focus, prev)) = windows.focused() {
+                    debug!(
+                        "Not focusing new window {entity}, keeping focus on '{}'",
+                        focus.title().unwrap_or_default()
+                    );
+                    focus_entity(prev, true, &mut commands);
+                }
+            } else {
+                debug!("Synthesizing WindowFocused for newly spawned window {entity}");
+                commands.trigger(SendMessageTrigger(Event::WindowFocused {
+                    window_id: window.id(),
+                }));
+            }
         }
     }
 }

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -232,6 +232,34 @@ macro_rules! assert_window_at {
 }
 
 #[macro_export]
+macro_rules! assert_window_near {
+    ($world:expr, $id:expr, $x:expr, $y:expr, $tolerance:expr) => {{
+        let mut query = $world.query::<&$crate::manager::Window>();
+        let window = query
+            .iter($world)
+            .find(|w| w.id() == $id)
+            .expect("window not found");
+        let frame = window.frame();
+        assert!(
+            (frame.min.x - $x).abs() <= $tolerance,
+            "window {} x position mismatch: got {}, expected {} +/- {}",
+            $id,
+            frame.min.x,
+            $x,
+            $tolerance
+        );
+        assert!(
+            (frame.min.y - $y).abs() <= $tolerance,
+            "window {} y position mismatch: got {}, expected {} +/- {}",
+            $id,
+            frame.min.y,
+            $y,
+            $tolerance
+        );
+    }};
+}
+
+#[macro_export]
 macro_rules! assert_window_size {
     ($world:expr, $id:expr, $w:expr, $h:expr) => {{
         let mut query = $world.query::<&$crate::manager::Window>();

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -6,7 +6,7 @@ use crate::ecs::SpawnWindowTrigger;
 use crate::ecs::{ActiveWorkspaceMarker, layout::LayoutStrip};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
-use crate::{assert_focused, assert_window_at, assert_window_size};
+use crate::{assert_focused, assert_window_at, assert_window_near, assert_window_size};
 
 use super::*;
 
@@ -182,9 +182,9 @@ fn test_scrolling() {
             assert_window_at!(world, 0, 800, TEST_MENUBAR_HEIGHT);
         })
         .on_iteration(5, move |world| {
-            assert_window_at!(world, 2, -316, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 1, 84, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 0, 484, TEST_MENUBAR_HEIGHT);
+            assert_window_near!(world, 2, -316, TEST_MENUBAR_HEIGHT, 1);
+            assert_window_near!(world, 1, 84, TEST_MENUBAR_HEIGHT, 1);
+            assert_window_near!(world, 0, 484, TEST_MENUBAR_HEIGHT, 1);
         })
         .run(commands);
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -289,6 +289,7 @@ impl WindowManagerApi for MockWindowManager {
         debug!("{}:", function_name!());
         let ids = (self.windows)(workspace_id)
             .iter()
+            .rev()
             .map(|window| window.id())
             .collect();
         Ok(ids)
@@ -593,6 +594,7 @@ impl WindowManagerApi for TwoDisplayMock {
     fn windows_in_workspace(&self, workspace_id: WorkspaceId) -> Result<Vec<WinID>> {
         Ok((self.windows)(workspace_id)
             .iter()
+            .rev()
             .map(|w| w.id())
             .collect())
     }


### PR DESCRIPTION
Fix startup layout handling so windows are not duplicated or misplaced during initialization. 

- Skip layout insertion for windows already assigned by startup reconciliation
- Avoid false native-tab detection for windows already present in a strip
- Remove an existing follower column when converting windows to tabs
- Keep ECS Position and Bounds synchronized after applying window padding
- Align test mock workspace ordering with spawned window ordering
- Add regression coverage for tab conversion without duplicate followers

Verified with cargo fmt, cargo check, cargo clippy, and cargo test.

Im not an expert in rust or macos-development, i writed this changes with the help of codex