### PR TITLE
fix: restore notification-focused hidden windows

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -126,6 +126,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
             (
                 systems::animate_entities,
                 systems::commit_window_position.run_if(not(resource_exists::<Initializing>)),
+                systems::verify_window_position.run_if(not(resource_exists::<Initializing>)),
             )
                 .chain(),
             (
@@ -360,6 +361,24 @@ impl RefreshWindowSizes {
     pub fn ready(&self) -> bool {
         const REFRESH_WINDOW_SIZE_DELAY_SEC: u64 = 5;
         self.0.elapsed() > Duration::from_secs(REFRESH_WINDOW_SIZE_DELAY_SEC)
+    }
+}
+
+#[derive(Component)]
+pub struct VerifyWindowPosition {
+    remaining: u8,
+}
+
+impl Default for VerifyWindowPosition {
+    fn default() -> Self {
+        Self { remaining: 3 }
+    }
+}
+
+impl VerifyWindowPosition {
+    pub fn tick(&mut self) -> bool {
+        self.remaining = self.remaining.saturating_sub(1);
+        self.remaining == 0
     }
 }
 

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -20,6 +20,7 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 use super::{
     ActiveDisplayMarker, BProcess, ExistingMarker, FreshMarker, PollForNotifications,
     RepositionMarker, ResizeMarker, RetryFrontSwitch, SpawnWindowTrigger, Timeout,
+    VerifyWindowPosition,
 };
 
 use crate::config::{Config, decorations::BorderRadiusOption};
@@ -687,11 +688,20 @@ pub(super) fn pump_events(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn window_resized_update_frame(
     mut messages: MessageReader<Event>,
-    mut windows: Query<(&mut Window, Entity, &Position, &mut Bounds), Without<LayoutStrip>>,
+    mut windows: Query<
+        (
+            &mut Window,
+            Entity,
+            &Position,
+            &mut Bounds,
+            Option<&Unmanaged>,
+        ),
+        Without<LayoutStrip>,
+    >,
     mut active_workspace: Single<(&LayoutStrip, &mut Position), With<ActiveWorkspaceMarker>>,
 ) {
     for event in messages.read() {
@@ -699,12 +709,15 @@ pub(super) fn window_resized_update_frame(
             continue;
         };
 
-        let Some((mut window, entity, position, mut bounds)) = windows
+        let Some((mut window, entity, position, mut bounds, unmanaged)) = windows
             .iter_mut()
             .find(|window| window.0.id() == *window_id)
         else {
             continue;
         };
+        if matches!(unmanaged, Some(Unmanaged::Minimized | Unmanaged::Hidden)) {
+            continue;
+        }
         let Ok(new_frame) = window.update_frame() else {
             continue;
         };
@@ -732,7 +745,7 @@ pub(super) fn window_resized_update_frame(
         let diff = old_frame.min.y - new_frame.min.y;
         if diff.abs() > 0
             && let Some(above_entity) = active_strip.above(entity)
-            && let Ok((_, _, _, mut above_bounds)) = windows.get_mut(above_entity)
+            && let Ok((_, _, _, mut above_bounds, _)) = windows.get_mut(above_entity)
             && above_bounds.0.y - diff > 200
         {
             above_bounds.0.y -= diff;
@@ -744,19 +757,25 @@ pub(super) fn window_resized_update_frame(
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn window_moved_update_frame(
     mut messages: MessageReader<Event>,
-    mut windows: Query<(&mut Window, &mut Position, &Bounds), Without<LayoutStrip>>,
+    mut windows: Query<
+        (&mut Window, &mut Position, &Bounds, Option<&Unmanaged>),
+        Without<LayoutStrip>,
+    >,
 ) {
     for event in messages.read() {
         let Event::WindowMoved { window_id } = event else {
             continue;
         };
 
-        let Some((mut window, mut position, bounds)) = windows
+        let Some((mut window, mut position, bounds, unmanaged)) = windows
             .iter_mut()
             .find(|window| window.0.id() == *window_id)
         else {
             continue;
         };
+        if matches!(unmanaged, Some(Unmanaged::Minimized | Unmanaged::Hidden)) {
+            continue;
+        }
         let Ok(new_frame) = window.update_frame() else {
             continue;
         };
@@ -923,6 +942,28 @@ pub(super) fn commit_window_position(
     moved_windows
         .par_iter_mut()
         .for_each(|(mut window, position)| window.reposition(position.0));
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[instrument(level = Level::TRACE, skip_all)]
+pub(super) fn verify_window_position(
+    mut windows: Populated<(Entity, &mut Window, &Position, &mut VerifyWindowPosition)>,
+    mut commands: Commands,
+) {
+    for (entity, mut window, position, mut verification) in &mut windows {
+        if window
+            .update_frame()
+            .is_ok_and(|frame| frame.min == position.0)
+        {
+            commands.entity(entity).try_remove::<VerifyWindowPosition>();
+            continue;
+        }
+
+        window.reposition(position.0);
+        if verification.tick() {
+            commands.entity(entity).try_remove::<VerifyWindowPosition>();
+        }
+    }
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -25,8 +25,8 @@ use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, LocateDockTrigger,
-    Position, RestoreWindowState, Scrolling, SendMessageTrigger, WidthRatio, WindowProperties,
-    focus_entity, reposition_entity, reshuffle_around, resize_entity,
+    Position, RestoreWindowState, Scrolling, SendMessageTrigger, VerifyWindowPosition, WidthRatio,
+    WindowProperties, focus_entity, reposition_entity, reshuffle_around, resize_entity,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -182,6 +182,7 @@ pub(super) fn window_focused_trigger(
     windows: Windows,
     mut workspaces: Query<(Entity, &mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     config: Res<Config>,
+    global_state: GlobalState,
     mut commands: Commands,
 ) {
     const STRAY_FOCUS_RETRY_SEC: u64 = 2;
@@ -229,6 +230,17 @@ pub(super) fn window_focused_trigger(
             continue;
         }
 
+        if matches!(
+            windows.get_managed(entity),
+            Some((_, _, Some(Unmanaged::Hidden)))
+        ) {
+            if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                entity_commands.try_remove::<Unmanaged>();
+            }
+            commands.trigger(SendMessageTrigger(Event::WindowFocused { window_id }));
+            continue;
+        }
+
         // Handle tab switching: if the focused window is a tab, make it the leader.
         // Also reactivate the owning virtual strip before treating duplicate
         // focus as a no-op; the focus marker can be stale on a hidden strip.
@@ -256,6 +268,9 @@ pub(super) fn window_focused_trigger(
         }
 
         if already_focused {
+            if !global_state.skip_reshuffle() && !global_state.initializing() {
+                reshuffle_around(entity, &mut commands);
+            }
             continue;
         }
 
@@ -698,7 +713,13 @@ pub(super) fn window_managed_trigger(
         }
     }
 
-    commands.entity(entity).try_remove::<PreviousManagedStrip>();
+    if let Some(origin) = windows.origin(entity) {
+        reposition_entity(entity, origin, &mut commands);
+    }
+    commands
+        .entity(entity)
+        .try_insert(VerifyWindowPosition::default())
+        .try_remove::<PreviousManagedStrip>();
     reshuffle_around(entity, &mut commands);
 }
 

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use bevy::prelude::*;
 
 use crate::commands::{Command, Direction, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::SpawnWindowTrigger;
-use crate::ecs::{ActiveWorkspaceMarker, layout::LayoutStrip};
+use crate::ecs::{ActiveWorkspaceMarker, Position, layout::LayoutStrip};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
 use crate::{assert_focused, assert_window_at, assert_window_size};
@@ -212,7 +214,7 @@ fn test_scrolling_stop() {
     TestHarness::new()
         .with_config(config)
         .with_windows(3)
-        .on_iteration(2, |world| {
+        .on_iteration(3, |world| {
             use crate::ecs::Scrolling;
             let mut query = world.query::<&Scrolling>();
             let scroll = query.single(world).unwrap();
@@ -338,8 +340,52 @@ fn test_stale_focus_event_ignored() {
         .on_iteration(1, |world| {
             assert_focused!(world, 3);
         })
-        .on_iteration(3, |world| {
+        .on_iteration(2, |world| {
             assert_focused!(world, 3);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_repeated_external_focus_reshuffles_already_focused_window() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::WindowFocused { window_id: 0 },
+    ];
+
+    TestHarness::new()
+        .with_windows(5)
+        .on_iteration(5, |world| {
+            assert_focused!(world, 0);
+
+            let mut query =
+                world.query::<(&mut Position, &LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let (mut position, _, _) = query
+                .iter_mut(world)
+                .find(|(_, _, active)| *active)
+                .expect("active strip");
+            position.0.x = TEST_DISPLAY_WIDTH * 2;
+        })
+        .on_iteration(4, |world| {
+            assert_focused!(world, 0);
+            assert_window_at!(
+                world,
+                0,
+                TEST_DISPLAY_WIDTH - TEST_WINDOW_WIDTH,
+                TEST_MENUBAR_HEIGHT
+            );
         })
         .run(commands);
 }
@@ -415,6 +461,73 @@ fn test_external_focus_restores_app_hidden_window_to_original_virtual_strip() {
             assert_eq!(active, 1);
         })
         .on_iteration(5, |world| {
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip.virtual_index))
+                .expect("an active virtual strip");
+            assert_eq!(active, 0);
+            assert_window_at!(world, 0, 0, TEST_MENUBAR_HEIGHT);
+            assert_focused!(world, 0);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_external_focus_restores_hidden_window_without_visible_event() {
+    let ignored_repositions = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ignored_repositions_for_window = ignored_repositions.clone();
+
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::ApplicationHidden {
+            pid: TEST_PROCESS_ID,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        Event::WindowFocused { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                internal_queue.clone(),
+                mock_app.clone(),
+            )
+            .with_ignored_repositions(ignored_repositions_for_window.clone());
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+    };
+
+    harness
+        .with_wm(wm)
+        .on_iteration(1, move |world| {
+            let mut query = world.query::<&mut Window>();
+            let mut window = query
+                .iter_mut(world)
+                .find(|window| window.id() == 0)
+                .expect("window 0");
+            window.reposition(Origin::new(0, TEST_DISPLAY_HEIGHT));
+            ignored_repositions.store(1, std::sync::atomic::Ordering::SeqCst);
+        })
+        .on_iteration(4, |world| {
             let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
             let active = query
                 .iter(world)

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use bevy::prelude::*;
@@ -328,6 +328,7 @@ pub(crate) struct MockWindow {
     pub(crate) identifier: String,
     pub(crate) role: String,
     pub(crate) subrole: String,
+    pub(crate) ignored_repositions: Arc<AtomicUsize>,
 }
 
 impl WindowApi for MockWindow {
@@ -385,6 +386,10 @@ impl WindowApi for MockWindow {
     #[instrument(level = Level::DEBUG, skip(self))]
     fn reposition(&mut self, origin: Origin) {
         debug!("{}: id {} to {origin}", function_name!(), self.id);
+        if self.ignored_repositions.load(Ordering::SeqCst) > 0 {
+            self.ignored_repositions.fetch_sub(1, Ordering::SeqCst);
+            return;
+        }
         let size = self.frame.size();
         self.frame.min = origin;
         self.frame.max = origin + size;
@@ -500,7 +505,16 @@ impl MockWindow {
             identifier: String::new(),
             role: "AXWindow".to_string(),
             subrole: "AXStandardWindow".to_string(),
+            ignored_repositions: Arc::default(),
         }
+    }
+
+    pub(crate) fn with_ignored_repositions(
+        mut self,
+        ignored_repositions: Arc<AtomicUsize>,
+    ) -> Self {
+        self.ignored_repositions = ignored_repositions;
+        self
     }
 }
 


### PR DESCRIPTION
Why: clicking a notification can front an app without producing the same event sequence as a normal unhide or keyboard focus change. If the window was already focused, Paneru skipped reshuffling because FocusedMarker was not added again. If the app was hidden or on another virtual strip, the focused window could also remain Unmanaged::Hidden, outside the strip, or keep a stale off-screen macOS frame. On some notification activations macOS also accepts focus before it accepts the first accessibility reposition, leaving the actual frame below the strip on the Y axis even though Paneru's ECS state points at the strip origin.

How: treat verified WindowFocused events as authoritative. Already-focused windows now request a reshuffle, hidden windows clear Unmanaged and requeue focus after the normal managed-window restore can reinsert them, hidden/minimized move and resize noise is ignored, and restored hidden windows are explicitly repositioned to Paneru's tracked ECS origin. Restored windows are then marked for a bounded post-commit frame verification that compares the actual AX frame with Paneru's Position and retries the reposition if macOS ignored the first move. Regression coverage simulates the ignored first reposition with the window stuck at y=768 and verifies it returns to y=20.


For example it happens if you click on a notification by Whatsapp and whatsapp app is on another workspace.

Im not an expert in rust or macos-development, i writed this changes with the help of codex