### PR TITLE
fix: Suppress mouse focus events in bottom-right corner dead zone (#233)

### DIFF
--- a/src/ecs/mouse.rs
+++ b/src/ecs/mouse.rs
@@ -23,7 +23,6 @@ use crate::platform::WinID;
 /// Sized to a representative macOS title bar height — see karinushka/paneru#233:
 /// macOS prevents windows from being moved further down than a fully visible title bar,
 /// so the parked sliver of a hidden virtual workspace lives within this region.
-#[allow(dead_code)]
 const CORNER_DEAD_ZONE_PX: i32 = 30;
 
 pub struct MouseEventsPlugin;
@@ -52,7 +51,6 @@ impl Plugin for MouseEventsPlugin {
 
 /// True when `point` sits inside the bottom-right `CORNER_DEAD_ZONE_PX`-sized
 /// square of the display's working area (excluding any Dock).
-#[allow(dead_code)]
 fn is_in_corner_dead_zone(
     point: Origin,
     display: &Display,
@@ -60,8 +58,7 @@ fn is_in_corner_dead_zone(
     config: &Config,
 ) -> bool {
     let bounds = display.actual_display_bounds(dock, config);
-    point.x >= bounds.max.x - CORNER_DEAD_ZONE_PX
-        && point.y >= bounds.max.y - CORNER_DEAD_ZONE_PX
+    point.x >= bounds.max.x - CORNER_DEAD_ZONE_PX && point.y >= bounds.max.y - CORNER_DEAD_ZONE_PX
 }
 
 /// Handles mouse moved events.
@@ -81,6 +78,7 @@ fn is_in_corner_dead_zone(
 fn mouse_moved_trigger(
     mut messages: MessageReader<Event>,
     windows: Windows,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     window_manager: Res<WindowManager>,
     config: Res<Config>,
     mut global_state: GlobalState,
@@ -97,6 +95,18 @@ fn mouse_moved_trigger(
         {
             // Resizing is handled by a separate trigger or logic.
             // For now, let's just intercept it here to prevent focus changes during resize.
+            continue;
+        }
+
+        // Corner dead zone: suppress focus events when the cursor sits in
+        // the bottom-right of any display (where hidden virtual workspace
+        // slivers park). See is_in_corner_dead_zone for details.
+        let cursor = origin_from(*point);
+        if displays.iter().any(|(display, dock)| {
+            display.bounds().contains(cursor)
+                && is_in_corner_dead_zone(cursor, display, dock, &config)
+        }) {
+            trace!("mouse moved suppressed in corner dead-zone {point:?}");
             continue;
         }
 
@@ -447,7 +457,14 @@ mod tests {
 
     fn make_display() -> Display {
         // 1024x768 test display with a 20px menubar, mirrors the values in src/tests.rs.
-        Display::new(1, IRect { min: Origin::new(0, 0), max: Origin::new(1024, 768) }, 20)
+        Display::new(
+            1,
+            IRect {
+                min: Origin::new(0, 0),
+                max: Origin::new(1024, 768),
+            },
+            20,
+        )
     }
 
     #[test]
@@ -456,12 +473,32 @@ mod tests {
         let config = Config::default();
 
         // Inside the 30x30 bottom-right corner.
-        assert!(is_in_corner_dead_zone(Origin::new(1000, 750), &display, None, &config));
-        assert!(is_in_corner_dead_zone(Origin::new(1024, 768), &display, None, &config));
+        assert!(is_in_corner_dead_zone(
+            Origin::new(1000, 750),
+            &display,
+            None,
+            &config
+        ));
+        assert!(is_in_corner_dead_zone(
+            Origin::new(1024, 768),
+            &display,
+            None,
+            &config
+        ));
 
         // Just outside the corner (one pixel above/left).
-        assert!(!is_in_corner_dead_zone(Origin::new(993, 750), &display, None, &config));
-        assert!(!is_in_corner_dead_zone(Origin::new(1000, 737), &display, None, &config));
+        assert!(!is_in_corner_dead_zone(
+            Origin::new(993, 750),
+            &display,
+            None,
+            &config
+        ));
+        assert!(!is_in_corner_dead_zone(
+            Origin::new(1000, 737),
+            &display,
+            None,
+            &config
+        ));
     }
 
     #[test]
@@ -472,8 +509,18 @@ mod tests {
 
         // With an 80px dock at the bottom, actual_display_bounds.max.y = 768 - 80 = 688.
         // Corner zone is now y >= 658.
-        assert!(is_in_corner_dead_zone(Origin::new(1000, 680), &display, Some(&dock), &config));
+        assert!(is_in_corner_dead_zone(
+            Origin::new(1000, 680),
+            &display,
+            Some(&dock),
+            &config
+        ));
         // Just outside the corner zone (point within display bounds but outside corner).
-        assert!(!is_in_corner_dead_zone(Origin::new(1000, 657), &display, Some(&dock), &config));
+        assert!(!is_in_corner_dead_zone(
+            Origin::new(1000, 657),
+            &display,
+            Some(&dock),
+            &config
+        ));
     }
 }

--- a/src/ecs/mouse.rs
+++ b/src/ecs/mouse.rs
@@ -12,12 +12,19 @@ use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{GlobalState, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, MissionControlActive, Position, Scrolling, focus_entity,
+    ActiveWorkspaceMarker, DockPosition, MissionControlActive, Position, Scrolling, focus_entity,
     reposition_entity, reshuffle_around, resize_entity,
 };
 use crate::events::Event;
 use crate::manager::{Display, Origin, WindowManager, origin_from};
 use crate::platform::WinID;
+
+/// Bottom-right corner region (`NxN` pixels) where focus events are suppressed.
+/// Sized to a representative macOS title bar height — see karinushka/paneru#233:
+/// macOS prevents windows from being moved further down than a fully visible title bar,
+/// so the parked sliver of a hidden virtual workspace lives within this region.
+#[allow(dead_code)]
+const CORNER_DEAD_ZONE_PX: i32 = 30;
 
 pub struct MouseEventsPlugin;
 
@@ -41,6 +48,20 @@ impl Plugin for MouseEventsPlugin {
             ),
         );
     }
+}
+
+/// True when `point` sits inside the bottom-right `CORNER_DEAD_ZONE_PX`-sized
+/// square of the display's working area (excluding any Dock).
+#[allow(dead_code)]
+fn is_in_corner_dead_zone(
+    point: Origin,
+    display: &Display,
+    dock: Option<&DockPosition>,
+    config: &Config,
+) -> bool {
+    let bounds = display.actual_display_bounds(dock, config);
+    point.x >= bounds.max.x - CORNER_DEAD_ZONE_PX
+        && point.y >= bounds.max.y - CORNER_DEAD_ZONE_PX
 }
 
 /// Handles mouse moved events.
@@ -413,5 +434,46 @@ fn horizontal_warp_mouse_trigger(
         // Reset the velocity sample to the landing point so the next motion
         // event computes velocity from the new position, not the pre-warp one.
         state.last = Some((landing, now));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::ecs::DockPosition;
+    use crate::manager::{Display, Origin};
+    use bevy::math::IRect;
+
+    fn make_display() -> Display {
+        // 1024x768 test display with a 20px menubar, mirrors the values in src/tests.rs.
+        Display::new(1, IRect { min: Origin::new(0, 0), max: Origin::new(1024, 768) }, 20)
+    }
+
+    #[test]
+    fn corner_dead_zone_no_dock() {
+        let display = make_display();
+        let config = Config::default();
+
+        // Inside the 30x30 bottom-right corner.
+        assert!(is_in_corner_dead_zone(Origin::new(1000, 750), &display, None, &config));
+        assert!(is_in_corner_dead_zone(Origin::new(1024, 768), &display, None, &config));
+
+        // Just outside the corner (one pixel above/left).
+        assert!(!is_in_corner_dead_zone(Origin::new(993, 750), &display, None, &config));
+        assert!(!is_in_corner_dead_zone(Origin::new(1000, 737), &display, None, &config));
+    }
+
+    #[test]
+    fn corner_dead_zone_with_bottom_dock() {
+        let display = make_display();
+        let config = Config::default();
+        let dock = DockPosition::Bottom(80);
+
+        // With an 80px dock at the bottom, actual_display_bounds.max.y = 768 - 80 = 688.
+        // Corner zone is now y >= 658.
+        assert!(is_in_corner_dead_zone(Origin::new(1000, 680), &display, Some(&dock), &config));
+        // Just outside the corner zone (point within display bounds but outside corner).
+        assert!(!is_in_corner_dead_zone(Origin::new(1000, 657), &display, Some(&dock), &config));
     }
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -342,3 +342,75 @@ fn test_stale_focus_event_ignored() {
         })
         .run(commands);
 }
+
+#[test]
+fn mouse_in_bottom_right_corner_does_not_change_focus() {
+    use crate::events::Event;
+    use crate::platform::Modifiers;
+    use objc2_core_foundation::CGPoint;
+
+    // Focus window 2 explicitly, then move cursor into the bottom-right 30x30
+    // dead zone. The corner gate should suppress the focus-follow-mouse event,
+    // so focus stays on window 2.
+    //
+    // Test display is 1024x768 with no Dock, so the dead zone is
+    // x >= 994, y >= 738. Cursor at (1010, 750) is inside it. The mock's
+    // find_window_at_point always returns window 0, so without the gate the
+    // FFM event would shift focus to window 0; with the gate it should not.
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::West)),
+        },
+        Event::MouseMoved {
+            point: CGPoint {
+                x: 1010.0,
+                y: 750.0,
+            },
+            modifiers: Modifiers::empty(),
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(2, |world| {
+            // After MouseMoved into corner dead zone: focus should remain on window 2
+            // because the corner gate suppressed the focus-follow-mouse event.
+            assert_focused!(world, 2);
+        })
+        .run(commands);
+}
+
+#[test]
+fn mouse_outside_corner_still_changes_focus() {
+    use crate::events::Event;
+    use crate::platform::Modifiers;
+    use objc2_core_foundation::CGPoint;
+
+    // Cursor at (500, 400), middle of the display, outside the dead zone.
+    // FFM should fire normally and switch focus.
+    //
+    // Focus window 2 first, then move cursor away from the corner. The mock's
+    // find_window_at_point always returns window 0, so FFM lands focus on
+    // window 0.
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::West)),
+        },
+        Event::MouseMoved {
+            point: CGPoint { x: 500.0, y: 400.0 },
+            modifiers: Modifiers::empty(),
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(2, |world| {
+            // After MouseMoved outside corner: FFM should have fired and changed focus.
+            // In the mock, find_window_at_point always returns window 0, so window 0
+            // should now be focused (changed from window 2).
+            assert_focused!(world, 0);
+        })
+        .run(commands);
+}


### PR DESCRIPTION
Fixes #233.

Suppresses `Event::MouseMoved`-driven focus events when the cursor sits
in the bottom-right 30x30 region of a display's working area. That
region is where macOS clamps hidden virtual workspace slivers (title bar
must stay visible), so it's the only spot the cursor can park over a
sliver and trigger the flicker loop.

The gate sits at the top of `mouse_moved_trigger`, after the
resize-modifier check, before the FFM check. It uses
`actual_display_bounds` (not `bounds`), so the zone tracks the sliver's
real coordinate space on Dock-at-bottom setups.

## Verification

Reproduced the bug on v0.4.2 with two virtual workspaces sharing a
Space, cursor parked in the corner: ~10 same-strip workspace
alternations in 1.7s, visible flicker.

Same scenario on this branch: zero workspace alternations while the
cursor sits in the corner, no visible flicker. The gate's `trace!` event
fires for every suppressed mouse move in the corner.

## Tests

- Unit tests for the predicate (`src/ecs/mouse.rs::tests`): no-Dock and
  Dock-at-bottom cases.
- Integration tests for the trigger (`src/tests/interaction.rs`):
  in-corner means no focus change, outside-corner means focus change.
- Full suite: 78 passed, 0 failed.

## Notes

The predicate is geometric only, no check for whether a sliver is
actually parked. Matches the issue's proposed shape: "if cursor is in
lower NxN corner, ignore all focus events." Single-workspace users lose
FFM in a 30x30 pixel region, acceptable trade for not paying a lookup
cost on every mouse event.