### PR TITLE
feat: support native macOS tab handling

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,7 +14,7 @@ use crate::config::Config;
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
-    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, FocusedMarker, FullWidthMarker,
+    ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker, FullWidthMarker,
     NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger, Unmanaged, ensure_visible,
     focus_entity, reposition_entity, reshuffle_around, resize_entity,
 };
@@ -527,7 +527,9 @@ fn resize_window(
     else {
         return;
     };
-    if let Ok(mut cmds) = commands.get_entity(entity) {
+    if windows.full_width(entity).is_some()
+        && let Ok(mut cmds) = commands.get_entity(entity)
+    {
         cmds.try_remove::<FullWidthMarker>();
     }
 
@@ -594,27 +596,6 @@ fn resize_window(
     reshuffle_around(entity, &mut commands);
 }
 
-/// Toggles the focused window between full-width and a preset width.
-///
-/// # Arguments
-///
-/// * `active_display` - A mutable reference to the `Display` resource.
-/// * `focused_entity` - The `Entity` of the currently focused window.
-/// * `windows` - A mutable query for all `Window` components.
-/// * `commands` - Bevy commands to trigger events.
-/// * `config` - The `Config` resource.
-fn exit_full_width(
-    entity: Entity,
-    marker: &FullWidthMarker,
-    viewport: IRect,
-    commands: &mut Commands,
-) {
-    let w = (marker.width_ratio * f64::from(viewport.width())).round() as i32;
-    let h = (marker.height_ratio * f64::from(viewport.height())).round() as i32;
-    commands.entity(entity).try_remove::<FullWidthMarker>();
-    commands.entity(entity).try_insert(Bounds(Size::new(w, h)));
-}
-
 #[allow(clippy::needless_pass_by_value)]
 fn full_width_window(
     mut messages: MessageReader<Event>,
@@ -630,10 +611,7 @@ fn full_width_window(
         return;
     }
 
-    let Some((frame, (_, entity))) = windows
-        .focused()
-        .and_then(|(window, entity)| windows.frame(entity).zip(Some((window, entity))))
-    else {
+    let Some((_, entity)) = windows.focused() else {
         return;
     };
 
@@ -642,8 +620,10 @@ fn full_width_window(
         .actual_display_bounds(active_display.dock(), &config);
 
     if let Some(marker) = windows.full_width(entity) {
-        exit_full_width(entity, marker, viewport, &mut commands);
-        reshuffle_around(entity, &mut commands);
+        commands.entity(entity).try_remove::<FullWidthMarker>();
+        let w = (marker.width_ratio * f64::from(viewport.width())).round() as i32;
+        let bounds = active_display.bounds().size().with_x(w);
+        resize_entity(entity, bounds, &mut commands);
     } else {
         let strip = active_display.active_strip();
         if strip
@@ -655,11 +635,9 @@ fn full_width_window(
             _ = strip.unstack(entity);
         }
         let width_ratio = windows.width_ratio(entity).unwrap_or(0.5);
-        let height_ratio = f64::from(frame.height()) / f64::from(viewport.height());
-        commands.entity(entity).try_insert(FullWidthMarker {
-            width_ratio,
-            height_ratio,
-        });
+        commands
+            .entity(entity)
+            .try_insert(FullWidthMarker { width_ratio });
         reposition_entity(
             entity,
             Origin::new(viewport.min.x, viewport.min.y),
@@ -965,7 +943,7 @@ pub fn stack_windows_handler(
     mut messages: MessageReader<Event>,
     windows: Windows,
     mut active_display: ActiveDisplayMut,
-    config: Res<Config>,
+    // config: Res<Config>,
     mut commands: Commands,
 ) {
     let Some(Operation::Stack(stack)) =
@@ -979,23 +957,14 @@ pub fn stack_windows_handler(
         .and_then(|(_, entity)| windows.get_managed(entity))
         && unmanaged.is_none()
     {
-        let was_full_width = if let Some(marker) = windows.full_width(entity) {
-            let viewport = active_display
-                .display()
-                .actual_display_bounds(active_display.dock(), &config);
-            exit_full_width(entity, marker, viewport, &mut commands);
-            true
-        } else {
-            false
-        };
+        if windows.full_width(entity).is_some() {
+            commands.entity(entity).try_remove::<FullWidthMarker>();
+        }
         let strip = active_display.active_strip();
         if *stack {
             _ = strip.stack(entity);
         } else {
             _ = strip.unstack(entity);
-        }
-        if was_full_width {
-            reshuffle_around(entity, &mut commands);
         }
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,8 +15,8 @@ use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, FocusedMarker, FullWidthMarker,
-    NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger, Unmanaged, focus_entity,
-    reposition_entity, reshuffle_around, resize_entity,
+    NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger, Unmanaged, ensure_visible,
+    focus_entity, reposition_entity, reshuffle_around, resize_entity,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Origin, Size, Window, WindowManager};
@@ -345,8 +345,13 @@ fn command_swap_focus(
         Some(current)
     };
 
+    // Keep the focused window on-screen, but don't anchor it: if its new
+    // layout slot is already visible with the strip where it is, the strip
+    // stays put and per-window animation slides the window into the slot.
+    // Only when the slot would fall off the edge does the strip scroll —
+    // and only by the shortfall.
     if let Some(window) = handler() {
-        reshuffle_around(window, &mut commands);
+        ensure_visible(window, &mut commands);
     } else {
         debug!(
             "swap {direction:?}: handler returned None (focused={:?}, strip_len={})",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -251,6 +251,34 @@ fn switch_native_tab(
     mark_focused_entity(target, commands);
 }
 
+fn current_focus_for_tab_navigation(
+    direction: &Direction,
+    windows: &Windows,
+    apps: &Query<&Application>,
+    strip: &LayoutStrip,
+) -> Option<Entity> {
+    let (_, focused_entity) = windows.focused()?;
+    if !matches!(direction, Direction::West | Direction::East) {
+        return Some(focused_entity);
+    }
+
+    let Some(tabs) = strip.tab_group(focused_entity) else {
+        return Some(focused_entity);
+    };
+    let Some(app_focused_entity) = windows
+        .app(focused_entity, apps)
+        .and_then(|app| app.focused_window_id().ok())
+        .and_then(|window_id| windows.find(window_id).map(|(_, entity)| entity))
+    else {
+        return Some(focused_entity);
+    };
+    if tabs.contains(&app_focused_entity) {
+        Some(app_focused_entity)
+    } else {
+        Some(focused_entity)
+    }
+}
+
 /// Handles the "focus" command, moving focus to a window in a specified direction.
 ///
 /// # Arguments
@@ -293,7 +321,9 @@ fn command_move_focus(
         return;
     }
 
-    let Some((_, focused_entity)) = windows.focused() else {
+    let Some(focused_entity) =
+        current_focus_for_tab_navigation(direction, &windows, &apps, active_strip)
+    else {
         return;
     };
 
@@ -381,7 +411,7 @@ fn command_swap_focus(
 
     let active_strip = active_display.active_strip();
     let mut handler = || {
-        let (_, current) = windows.focused()?;
+        let current = current_focus_for_tab_navigation(direction, &windows, &apps, active_strip)?;
         if let Some(tab) = tab_in_direction(direction, current, active_strip) {
             switch_native_tab(direction, current, tab, &windows, &apps, &mut commands);
             return Some((tab, false));

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,7 +19,9 @@ use crate::ecs::{
     focus_entity, reposition_entity, reshuffle_around, resize_entity,
 };
 use crate::events::Event;
-use crate::manager::{Application, Display, Origin, Size, Window, WindowManager};
+use crate::manager::{
+    Application, Display, NativeTabDirection, Origin, Size, Window, WindowManager,
+};
 
 /// Represents a cardinal or directional choice for window manipulation.
 #[derive(Clone, Debug)]
@@ -151,7 +153,8 @@ pub fn filter_window_operations<'a, F: Fn(&Operation) -> bool>(
     })
 }
 
-/// Retrieves a window `Entity` in a specified direction relative to a `current_window_id` within a `LayoutStrip`.
+/// Retrieves a window `Entity` in a specified direction relative to a
+/// `current_window_id` within a `LayoutStrip`.
 ///
 /// # Arguments
 ///
@@ -204,6 +207,50 @@ fn get_window_in_direction(
     }
 }
 
+fn tab_in_direction(direction: &Direction, entity: Entity, strip: &LayoutStrip) -> Option<Entity> {
+    let tabs = strip.tab_group(entity)?;
+    let index = tabs.iter().position(|tab| *tab == entity)?;
+
+    match direction {
+        Direction::West => index.checked_sub(1).map(|index| tabs[index]),
+        Direction::East => index
+            .checked_add(1)
+            .and_then(|index| tabs.get(index).copied()),
+        Direction::North | Direction::South | Direction::First | Direction::Last => None,
+    }
+}
+
+fn native_tab_direction(direction: &Direction) -> Option<NativeTabDirection> {
+    match direction {
+        Direction::West => Some(NativeTabDirection::Previous),
+        Direction::East => Some(NativeTabDirection::Next),
+        Direction::North | Direction::South | Direction::First | Direction::Last => None,
+    }
+}
+
+fn mark_focused_entity(entity: Entity, commands: &mut Commands) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+        entity_commands.try_insert(FocusedMarker);
+    }
+}
+
+fn switch_native_tab(
+    direction: &Direction,
+    current: Entity,
+    target: Entity,
+    windows: &Windows,
+    apps: &Query<&Application>,
+    commands: &mut Commands,
+) {
+    if let Some(direction) = native_tab_direction(direction)
+        && let Some(app) = windows.app(current, apps)
+        && let Some(window) = windows.get(target)
+    {
+        app.select_native_tab(direction, window.id());
+    }
+    mark_focused_entity(target, commands);
+}
+
 /// Handles the "focus" command, moving focus to a window in a specified direction.
 ///
 /// # Arguments
@@ -220,6 +267,7 @@ fn get_window_in_direction(
 fn command_move_focus(
     mut messages: MessageReader<Event>,
     windows: Windows,
+    apps: Query<&Application>,
     workspaces: Query<(&LayoutStrip, Option<&NativeFullscreenMarker>)>,
     active_display: ActiveDisplay,
     mut commands: Commands,
@@ -248,6 +296,18 @@ fn command_move_focus(
     let Some((_, focused_entity)) = windows.focused() else {
         return;
     };
+
+    if let Some(entity) = tab_in_direction(direction, focused_entity, active_strip) {
+        switch_native_tab(
+            direction,
+            focused_entity,
+            entity,
+            &windows,
+            &apps,
+            &mut commands,
+        );
+        return;
+    }
 
     // At the right edge going East, enter the fullscreen workspaces.
     let candidate =
@@ -309,6 +369,7 @@ fn command_move_focus(
 fn command_swap_focus(
     mut messages: MessageReader<Event>,
     windows: Windows,
+    apps: Query<&Application>,
     mut active_display: ActiveDisplayMut,
     mut commands: Commands,
 ) {
@@ -321,6 +382,11 @@ fn command_swap_focus(
     let active_strip = active_display.active_strip();
     let mut handler = || {
         let (_, current) = windows.focused()?;
+        if let Some(tab) = tab_in_direction(direction, current, active_strip) {
+            switch_native_tab(direction, current, tab, &windows, &apps, &mut commands);
+            return Some((tab, false));
+        }
+
         let index = active_strip.index_of(current).ok()?;
         let other_window = get_window_in_direction(direction, current, active_strip)?;
         let new_index = active_strip.index_of(other_window).ok()?;
@@ -342,7 +408,7 @@ fn command_swap_focus(
                 .rev()
                 .for_each(|idx| active_strip.swap(idx, idx + 1));
         }
-        Some(current)
+        Some((current, true))
     };
 
     // Keep the focused window on-screen, but don't anchor it: if its new
@@ -350,14 +416,21 @@ fn command_swap_focus(
     // stays put and per-window animation slides the window into the slot.
     // Only when the slot would fall off the edge does the strip scroll —
     // and only by the shortfall.
-    if let Some(window) = handler() {
-        ensure_visible(window, &mut commands);
+    let outcome = handler();
+    if let Some((window, should_ensure_visible)) = outcome {
+        if should_ensure_visible {
+            ensure_visible(window, &mut commands);
+        }
     } else {
         debug!(
             "swap {direction:?}: handler returned None (focused={:?}, strip_len={})",
             windows.focused().map(|(_, e)| e),
             active_strip.len()
         );
+    }
+
+    if outcome.is_some_and(|(_, should_ensure_visible)| !should_ensure_visible) {
+        return;
     }
 
     if windows
@@ -689,17 +762,26 @@ fn to_next_display(
         other.id(),
         other.width() / 2,
     );
-    let center = other.bounds().center().x;
+    let other_bounds = other.bounds();
+    let other_center = other_bounds.center();
+    let center = other_center.x;
     let target_display_id = other.id();
+
+    let moving_entities = active_display
+        .active_strip()
+        .tab_group(entity)
+        .unwrap_or_else(|| vec![entity]);
 
     let Some(size) = windows.size(entity) else {
         return;
     };
-    let dest = other.bounds().min.with_x(center - size.x / 2);
-    reposition_entity(entity, dest, &mut commands);
+    let dest = other_bounds.min.with_x(center - size.x / 2);
+    for moving_entity in &moving_entities {
+        reposition_entity(*moving_entity, dest, &mut commands);
+    }
 
     if matches!(move_focus, MoveFocus::Follow) {
-        window_manager.warp_mouse(other.bounds().center());
+        window_manager.warp_mouse(other_center);
     }
 
     // Remove the window from the source strip.
@@ -707,7 +789,9 @@ fn to_next_display(
         .active_strip()
         .left_neighbour(entity)
         .or_else(|| active_display.active_strip().right_neighbour(entity));
-    active_display.active_strip().remove(entity);
+    for moving_entity in &moving_entities {
+        active_display.active_strip().remove(*moving_entity);
+    }
     if let Some(neighbour) = source_neighbour {
         reshuffle_around(neighbour, &mut commands);
     }
@@ -724,7 +808,7 @@ fn to_next_display(
             .iter_mut()
             .find(|(strip, selected)| *selected && strip.id() == target_space_id)
     {
-        target_strip.append(entity);
+        target_strip.append_tab_group(&moving_entities);
         reshuffle_around(entity, &mut commands);
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -7,7 +7,7 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::{Query, Res, ResMut};
 use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
@@ -76,6 +76,80 @@ struct StateBroadcastSignals {
     window_focused: bool,
 }
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Debug, Default, PartialEq)]
+struct StateBroadcastIntent {
+    virtual_workspace_changed: bool,
+    windows_changed: bool,
+    window_focused: bool,
+    title_changes: BTreeSet<WinID>,
+    display_changes: Vec<Option<u32>>,
+    active_display_changed: bool,
+}
+
+impl StateBroadcastIntent {
+    fn from_events<'a>(
+        events: impl IntoIterator<Item = &'a Event>,
+        signals: StateBroadcastSignals,
+    ) -> Self {
+        let mut intent = Self {
+            virtual_workspace_changed: signals.virtual_workspace_changed,
+            window_focused: signals.window_focused,
+            ..Self::default()
+        };
+
+        for event in events {
+            match event {
+                Event::SpaceChanged
+                | Event::Command {
+                    command: Command::Window(Operation::Virtual(_) | Operation::VirtualNumber(_)),
+                } => intent.virtual_workspace_changed = true,
+                Event::WindowCreated { .. }
+                | Event::WindowDestroyed { .. }
+                | Event::WindowMinimized { .. }
+                | Event::WindowDeminimized { .. }
+                | Event::Command {
+                    command:
+                        Command::Window(
+                            Operation::VirtualMove(_, _) | Operation::VirtualMoveNumber(_, _),
+                        ),
+                } => intent.windows_changed = true,
+                Event::WindowFocused { .. } => intent.window_focused = true,
+                Event::WindowTitleChanged { window_id } => {
+                    intent.title_changes.insert(*window_id);
+                }
+                Event::DisplayAdded { display_id }
+                | Event::DisplayRemoved { display_id }
+                | Event::DisplayMoved { display_id }
+                | Event::DisplayResized { display_id }
+                | Event::DisplayConfigured { display_id } => {
+                    let display_id = Some(*display_id);
+                    if !intent.display_changes.contains(&display_id) {
+                        intent.display_changes.push(display_id);
+                    }
+                }
+                Event::DisplayChanged => {
+                    intent.active_display_changed = true;
+                }
+                _ => {}
+            }
+        }
+
+        intent
+    }
+
+    fn requires_state(&self) -> bool {
+        self.virtual_workspace_changed
+            || self.windows_changed
+            || self.window_focused
+            || self.active_display_changed
+    }
+
+    fn is_empty(&self) -> bool {
+        !self.requires_state() && self.title_changes.is_empty() && self.display_changes.is_empty()
+    }
+}
+
 pub(super) fn register_query_commands(app: &mut App) {
     let active_subscribers = |subscribers: Option<Res<StateSubscribers>>| {
         subscribers.is_some_and(|subscribers| !subscribers.streams.is_empty())
@@ -124,6 +198,7 @@ fn state_subscribe_handler(
     }
 }
 
+#[cfg(test)]
 fn collect_state_broadcast_events<'a>(
     events: impl IntoIterator<Item = &'a Event>,
     state: &PaneruQueryState,
@@ -131,50 +206,54 @@ fn collect_state_broadcast_events<'a>(
     title_for_window: impl Fn(WinID) -> Option<String>,
     signals: StateBroadcastSignals,
 ) -> Vec<Value> {
-    let mut virtual_workspace_changed = signals.virtual_workspace_changed;
-    let mut windows_changed = false;
-    let mut window_focused = signals.window_focused;
-    let mut title_changes = BTreeMap::new();
-    let mut display_changes = Vec::new();
+    let intent = StateBroadcastIntent::from_events(events, signals);
+    collect_state_broadcast_events_for_intent(&intent, Some(state), cache, title_for_window)
+}
 
-    for event in events {
-        match event {
-            Event::SpaceChanged
-            | Event::Command {
-                command: Command::Window(Operation::Virtual(_) | Operation::VirtualNumber(_)),
-            } => virtual_workspace_changed = true,
-            Event::WindowCreated { .. }
-            | Event::WindowDestroyed { .. }
-            | Event::WindowMinimized { .. }
-            | Event::WindowDeminimized { .. }
-            | Event::Command {
-                command:
-                    Command::Window(Operation::VirtualMove(_, _) | Operation::VirtualMoveNumber(_, _)),
-            } => windows_changed = true,
-            Event::WindowFocused { .. } => window_focused = true,
-            Event::WindowTitleChanged { window_id } => {
-                title_changes.insert(*window_id, title_for_window(*window_id).unwrap_or_default());
-            }
-            Event::DisplayAdded { display_id }
-            | Event::DisplayRemoved { display_id }
-            | Event::DisplayMoved { display_id }
-            | Event::DisplayResized { display_id }
-            | Event::DisplayConfigured { display_id } => {
-                let display_id = Some(*display_id);
-                if !display_changes.contains(&display_id) {
-                    display_changes.push(display_id);
-                }
-            }
-            Event::DisplayChanged if !display_changes.contains(&state.active.display_id) => {
-                display_changes.push(state.active.display_id);
-            }
-            _ => {}
-        }
+fn collect_state_broadcast_events_for_intent(
+    intent: &StateBroadcastIntent,
+    state: Option<&PaneruQueryState>,
+    cache: &mut StateBroadcastCache,
+    title_for_window: impl Fn(WinID) -> Option<String>,
+) -> Vec<Value> {
+    let mut display_changes = intent.display_changes.clone();
+    if intent.active_display_changed
+        && let Some(state) = state
+        && !display_changes.contains(&state.active.display_id)
+    {
+        display_changes.push(state.active.display_id);
     }
+
+    let mut title_changes = BTreeMap::new();
+    for window_id in &intent.title_changes {
+        title_changes.insert(*window_id, title_for_window(*window_id).unwrap_or_default());
+    }
+
+    let Some(state) = state else {
+        let mut outgoing = Vec::new();
+        for (window_id, title) in title_changes {
+            if cache.titles.get(&window_id) == Some(&title) {
+                continue;
+            }
+            outgoing.push(json!({
+                "event": "window_title_changed",
+                "window_id": window_id,
+                "title": title,
+            }));
+            cache.titles.insert(window_id, title);
+        }
+        for display_id in display_changes {
+            outgoing.push(json!({
+                "event": "display_changed",
+                "display_id": display_id,
+            }));
+        }
+        return outgoing;
+    };
 
     let mut outgoing = Vec::new();
 
-    if virtual_workspace_changed {
+    if intent.virtual_workspace_changed {
         let workspace = WorkspaceBroadcastSnapshot::from(&state.active);
         if cache.workspace.as_ref() != Some(&workspace)
             && (workspace.native_workspace_id.is_some()
@@ -188,7 +267,9 @@ fn collect_state_broadcast_events<'a>(
         }
     }
 
-    if windows_changed && cache.virtual_workspaces.as_ref() != Some(&state.virtual_workspaces) {
+    if intent.windows_changed
+        && cache.virtual_workspaces.as_ref() != Some(&state.virtual_workspaces)
+    {
         outgoing.push(json!({
             "event": "windows_changed",
             "virtual_workspace_number": state.active.virtual_workspace_number,
@@ -197,7 +278,7 @@ fn collect_state_broadcast_events<'a>(
         cache.virtual_workspaces = Some(state.virtual_workspaces.clone());
     }
 
-    if window_focused {
+    if intent.window_focused {
         let focus = FocusBroadcastSnapshot::from(&state.active);
         if focus.window_id.is_some() && cache.focus.as_ref() != Some(&focus) {
             outgoing.push(json!({
@@ -251,21 +332,27 @@ fn state_event_broadcast_handler(
         return;
     }
 
-    let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
     let signals = StateBroadcastSignals {
         virtual_workspace_changed: !active_workspace_changes.is_empty(),
         window_focused: !focused_changes.is_empty(),
     };
-    let outgoing = collect_state_broadcast_events(
-        events,
-        &state,
+    let intent = StateBroadcastIntent::from_events(events, signals);
+    if intent.is_empty() {
+        return;
+    }
+
+    let state = intent
+        .requires_state()
+        .then(|| PaneruQueryState::extract(&workspaces, &displays, &windows, &apps));
+    let outgoing = collect_state_broadcast_events_for_intent(
+        &intent,
+        state.as_ref(),
         &mut cache,
         |window_id| {
             windows
                 .find(window_id)
                 .and_then(|(window, _)| window.title().ok())
         },
-        signals,
     );
 
     if outgoing.is_empty() {
@@ -454,5 +541,50 @@ mod tests {
         assert_eq!(outgoing[0]["window_id"], 26_262);
         assert_eq!(outgoing[0]["bundle_id"], "com.openai.codex");
         assert_eq!(outgoing[0]["title"], "Codex");
+    }
+
+    #[test]
+    fn test_state_broadcast_intent_skips_state_for_empty_or_unrelated_events() {
+        let empty =
+            StateBroadcastIntent::from_events(std::iter::empty(), StateBroadcastSignals::default());
+        assert!(empty.is_empty());
+        assert!(!empty.requires_state());
+
+        let unrelated = StateBroadcastIntent::from_events(
+            [
+                PaneruEvent::ThemeChanged,
+                PaneruEvent::MouseUp {
+                    point: objc2_core_foundation::CGPoint::default(),
+                    modifiers: crate::platform::Modifiers::empty(),
+                },
+            ]
+            .iter(),
+            StateBroadcastSignals::default(),
+        );
+        assert!(unrelated.is_empty());
+        assert!(!unrelated.requires_state());
+    }
+
+    #[test]
+    fn test_state_broadcast_intent_classifies_relevant_events() {
+        let intent = StateBroadcastIntent::from_events(
+            [
+                PaneruEvent::SpaceChanged,
+                PaneruEvent::WindowMinimized { window_id: 10 },
+                PaneruEvent::WindowFocused { window_id: 11 },
+                PaneruEvent::WindowTitleChanged { window_id: 12 },
+                PaneruEvent::DisplayResized { display_id: 2 },
+            ]
+            .iter(),
+            StateBroadcastSignals::default(),
+        );
+
+        assert!(intent.virtual_workspace_changed);
+        assert!(intent.windows_changed);
+        assert!(intent.window_focused);
+        assert_eq!(intent.title_changes, [12].into());
+        assert_eq!(intent.display_changes, vec![Some(2)]);
+        assert!(intent.requires_state());
+        assert!(!intent.is_empty());
     }
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -73,7 +73,11 @@ pub fn register_systems(app: &mut bevy::app::App) {
     );
     app.add_systems(
         PreUpdate,
-        (systems::window_creation_event, systems::pump_events),
+        (
+            systems::window_creation_event,
+            systems::detect_tabbed_windows,
+            systems::pump_events,
+        ),
     );
     app.add_systems(
         Update,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -48,14 +48,12 @@ pub mod workspace;
 /// Registers the Bevy systems for the `WindowManager`.
 /// This function adds various systems to the `Update` schedule, including event dispatchers,
 /// process/application/window lifecycle management, animation, and periodic watchers.
-/// Systems that poll for notifications are conditionally run based on the `PollForNotifications` resource.
 ///
 /// # Arguments
 ///
 /// * `app` - The Bevy application to register the systems with.
 #[allow(clippy::too_many_lines)]
 pub fn register_systems(app: &mut bevy::app::App) {
-    const DISPLAY_CHANGE_CHECK_FREQ_MS: u64 = 1000;
     const LOW_POWER_MODE_CHECK_SEC: u64 = 60;
 
     let not_swiping = |scrolling: Query<&Scrolling, With<ActiveWorkspaceMarker>>| {
@@ -75,11 +73,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
     );
     app.add_systems(
         PreUpdate,
-        (
-            systems::dispatch_toplevel_triggers,
-            systems::window_creation_event,
-            systems::pump_events,
-        ),
+        (systems::window_creation_event, systems::pump_events),
     );
     app.add_systems(
         Update,
@@ -112,17 +106,6 @@ pub fn register_systems(app: &mut bevy::app::App) {
             state::periodic_state_save.run_if(on_timer(Duration::from_secs(300))),
             state::cleanup_on_exit,
         ),
-    );
-    app.add_systems(
-        Update,
-        (
-            systems::display_changes_watcher,
-            workspace::workspace_change_watcher,
-        )
-            .run_if(resource_exists::<PollForNotifications>)
-            .run_if(on_timer(Duration::from_millis(
-                DISPLAY_CHANGE_CHECK_FREQ_MS,
-            ))),
     );
     app.add_systems(
         PostUpdate,
@@ -417,10 +400,6 @@ pub struct MissionControlActive(pub bool);
 #[derive(Resource)]
 pub struct FocusFollowsMouse(pub Option<WinID>);
 
-/// Resource to control whether the application should poll for notifications.
-#[derive(PartialEq, Resource)]
-pub struct PollForNotifications;
-
 #[derive(PartialEq, Resource)]
 pub struct Initializing;
 
@@ -496,7 +475,6 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         })
         .insert_resource(MissionControlActive(false))
         .insert_resource(FocusFollowsMouse(None))
-        .insert_resource(PollForNotifications)
         .insert_resource(Initializing)
         .insert_non_send_resource(watcher)
         .add_plugins(mouse::MouseEventsPlugin)

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -252,7 +252,6 @@ pub struct NativeFullscreenMarker {
 #[derive(Component)]
 pub struct FullWidthMarker {
     pub width_ratio: f64,
-    pub height_ratio: f64,
 }
 
 /// Enum component indicating the unmanaged state of a window.

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -210,6 +210,15 @@ pub struct ResizeMarker(pub Size);
 #[derive(Component)]
 pub struct ReshuffleAroundMarker;
 
+/// Marker component requesting that the strip scroll *minimally* to keep the
+/// entity's NEW layout position inside the viewport. Unlike
+/// [`ReshuffleAroundMarker`], this does not anchor the entity to its old visual
+/// position — if the new layout slot is already on-screen, the strip is left
+/// alone and the entity is free to slide there. Only when the new slot would
+/// fall off the edge does the strip scroll just enough to expose it.
+#[derive(Component)]
+pub struct EnsureVisibleMarker;
+
 #[derive(Component, Debug)]
 pub struct Scrolling {
     pub velocity: f64,
@@ -449,6 +458,13 @@ pub fn resize_entity(entity: Entity, size: Size, commands: &mut Commands) {
 pub fn reshuffle_around(entity: Entity, commands: &mut Commands) {
     if let Ok(mut entity_commands) = commands.get_entity(entity) {
         entity_commands.try_insert(ReshuffleAroundMarker);
+    }
+}
+
+#[instrument(level = Level::TRACE, skip(commands))]
+pub fn ensure_visible(entity: Entity, commands: &mut Commands) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+        entity_commands.try_insert(EnsureVisibleMarker);
     }
 }
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -80,6 +80,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
     app.add_systems(
         Update,
         (
+            triggers::apply_window_properties,
             (
                 systems::add_existing_process,
                 systems::add_existing_application,
@@ -166,7 +167,6 @@ pub fn register_triggers(app: &mut bevy::app::App) {
         .add_observer(triggers::locate_dock_trigger)
         .add_observer(triggers::send_message_trigger)
         .add_observer(triggers::window_removal_trigger)
-        .add_observer(triggers::apply_window_properties)
         .add_observer(triggers::cleanup_timeout_trigger)
         .add_observer(restore::restore_window_state);
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -80,7 +80,8 @@ pub fn register_systems(app: &mut bevy::app::App) {
     app.add_systems(
         Update,
         (
-            triggers::apply_window_properties,
+            triggers::apply_window_defaults,
+            triggers::apply_window_positions,
             (
                 systems::add_existing_process,
                 systems::add_existing_application,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -496,7 +496,7 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
 }
 
 struct WindowProperties {
-    pub params: Vec<WindowParams>,
+    params: Vec<WindowParams>,
 }
 
 impl WindowProperties {
@@ -542,5 +542,19 @@ impl WindowProperties {
 
     pub fn width_ratio(&self) -> Option<f64> {
         self.params.iter().find_map(|props| props.width)
+    }
+
+    pub fn vertical_padding(&self) -> i32 {
+        self.params
+            .iter()
+            .find_map(|props| props.vertical_padding)
+            .unwrap_or(0)
+    }
+
+    pub fn horizontal_padding(&self) -> i32 {
+        self.params
+            .iter()
+            .find_map(|props| props.horizontal_padding)
+            .unwrap_or(0)
     }
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -75,7 +75,11 @@ pub fn register_systems(app: &mut bevy::app::App) {
     );
     app.add_systems(
         PreUpdate,
-        (systems::dispatch_toplevel_triggers, systems::pump_events),
+        (
+            systems::dispatch_toplevel_triggers,
+            systems::window_creation_event,
+            systems::pump_events,
+        ),
     );
     app.add_systems(
         Update,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -126,6 +126,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
             (
                 systems::animate_entities,
                 systems::commit_window_position.run_if(not(resource_exists::<Initializing>)),
+                systems::verify_window_position.run_if(not(resource_exists::<Initializing>)),
             )
                 .chain(),
             (
@@ -361,6 +362,24 @@ impl RefreshWindowSizes {
     pub fn ready(&self) -> bool {
         const REFRESH_WINDOW_SIZE_DELAY_SEC: u64 = 5;
         self.0.elapsed() > Duration::from_secs(REFRESH_WINDOW_SIZE_DELAY_SEC)
+    }
+}
+
+#[derive(Component)]
+pub struct VerifyWindowPosition {
+    remaining: u8,
+}
+
+impl Default for VerifyWindowPosition {
+    fn default() -> Self {
+        Self { remaining: 3 }
+    }
+}
+
+impl VerifyWindowPosition {
+    pub fn tick(&mut self) -> bool {
+        self.remaining = self.remaining.saturating_sub(1);
+        self.remaining == 0
     }
 }
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -125,13 +125,9 @@ pub fn register_systems(app: &mut bevy::app::App) {
         (
             (
                 systems::animate_entities,
-                systems::commit_window_position.run_if(not(resource_exists::<Initializing>)),
-                systems::verify_window_position.run_if(not(resource_exists::<Initializing>)),
-            )
-                .chain(),
-            (
                 systems::animate_resize_entities,
-                systems::commit_window_size.run_if(not(resource_exists::<Initializing>)),
+                systems::commit_window_frames.run_if(not(resource_exists::<Initializing>)),
+                systems::verify_window_position.run_if(not(resource_exists::<Initializing>)),
             )
                 .chain(),
             (

--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -97,6 +97,9 @@ fn autocenter_window_on_focus(
     if global_state.skip_reshuffle() || global_state.initializing() || !mouse_held.is_empty() {
         return;
     }
+    if active_display.active_strip().tabbed(entity) {
+        return;
+    }
     if config.auto_center()
         && let Some((_, _, None)) = windows.get_managed(entity)
         && let Some(size) = windows.size(entity)

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -16,8 +16,8 @@ use tracing::{Level, instrument, trace};
 use crate::config::Config;
 use crate::ecs::params::Windows;
 use crate::ecs::{
-    Bounds, DockPosition, EnsureVisibleMarker, FullWidthMarker, Initializing, LayoutPosition,
-    Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, reposition_entity,
+    Bounds, DockPosition, EnsureVisibleMarker, Initializing, LayoutPosition, Position,
+    RepositionMarker, ReshuffleAroundMarker, Scrolling, reposition_entity,
 };
 use crate::errors::{Error, Result};
 use crate::manager::{Display, Origin, Window};
@@ -857,12 +857,7 @@ fn stack_item_has_changed_window(item: &StackItem, changed_entities: &EntityHash
 fn layout_strip_changed(
     changed_strips: Populated<(&LayoutStrip, &ChildOf), Changed<LayoutStrip>>,
     mut windows: Query<
-        (
-            &Position,
-            &mut Bounds,
-            &mut LayoutPosition,
-            Has<FullWidthMarker>,
-        ),
+        (&Position, &mut Bounds, &mut LayoutPosition),
         (Without<LayoutStrip>, With<Window>),
     >,
     displays: Query<(&Display, Option<&DockPosition>)>,
@@ -871,7 +866,7 @@ fn layout_strip_changed(
     let get_window_frame = |entity| {
         windows
             .get(entity)
-            .map(|(position, bounds, _, _)| IRect::from_corners(position.0, position.0 + bounds.0))
+            .map(|(position, bounds, _)| IRect::from_corners(position.0, position.0 + bounds.0))
             .ok()
     };
 
@@ -890,10 +885,7 @@ fn layout_strip_changed(
         .collect::<Vec<_>>();
 
     for (entity, frame) in changed {
-        if let Ok((_, mut bounds, mut layout_position, full_width)) = windows.get_mut(entity) {
-            if full_width {
-                continue;
-            }
+        if let Ok((_, mut bounds, mut layout_position)) = windows.get_mut(entity) {
             if layout_position.0 != frame.min {
                 layout_position.0 = frame.min;
             }
@@ -1159,14 +1151,7 @@ fn insert_stack_item_window_contexts(
 #[instrument(level = Level::DEBUG, skip_all)]
 fn position_layout_windows(
     mut positioned_windows: Populated<
-        (
-            Entity,
-            &Window,
-            &LayoutPosition,
-            &mut Position,
-            &mut Bounds,
-            Has<FullWidthMarker>,
-        ),
+        (Entity, &Window, &LayoutPosition, &mut Position, &mut Bounds),
         (Changed<LayoutPosition>, With<Window>, Without<LayoutStrip>),
     >,
     workspaces: Query<
@@ -1206,10 +1191,7 @@ fn position_layout_windows(
     }
 
     positioned_windows.par_iter_mut().for_each(
-        |(entity, window, layout_position, mut position, mut bounds, full_width)| {
-            if full_width {
-                return;
-            }
+        |(entity, window, layout_position, mut position, mut bounds)| {
             let Some(context) = strip_contexts.get(&entity) else {
                 return;
             };

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -6,10 +6,10 @@ use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::query::{Changed, Has, Or, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
-use bevy::ecs::system::{Commands, ParallelCommands, Populated, Query, Res};
+use bevy::ecs::system::{Commands, ParallelCommands, ParamSet, Populated, Query, Res};
 use bevy::ecs::world::Ref;
 use bevy::math::IRect;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use stdext::function_name;
 use tracing::{Level, instrument, trace};
 
@@ -33,6 +33,7 @@ impl Plugin for LayoutEventsPlugin {
                 // Wait for finish_setup before tiling: until then every window
                 // sits in the active strip regardless of its real display.
                 (
+                    sync_tab_group_frames,
                     layout_sizes_changed,
                     layout_strip_changed,
                     reshuffle_layout_strip,
@@ -90,7 +91,7 @@ pub enum Column {
     Single(Entity),
     /// A panel containing a stack of items (windows or tabs), ordered from top to bottom.
     Stack(Vec<StackItem>),
-    /// A panel containing a group of native tabs, with the active "Leader" at the front.
+    /// A panel containing a group of native tabs.
     Tabs(Vec<Entity>),
     Fullscren(Entity),
 }
@@ -128,25 +129,14 @@ impl Column {
         }
     }
 
-    /// Moves the specified entity to the front of the vector (index 0).
-    /// This is used to change the Leader of a Tab group.
+    /// Moves the specified entity to the front of stack-local ordering.
+    /// Native tab ordering is stable; the focused tab is tracked by `FocusedMarker`.
     pub fn move_to_front(&mut self, entity: Entity) {
-        match self {
-            Column::Single(_) | Column::Fullscren(_) => {}
-            Column::Stack(stack) => {
-                if let Some(StackItem::Tabs(tabs)) =
-                    stack.iter_mut().find(|item| item.contains(entity))
-                    && let Some(pos) = tabs.iter().position(|&e| e == entity)
-                {
-                    tabs.swap(0, pos);
-                }
-            }
-            Column::Tabs(tabs) => {
-                if let Some(pos) = tabs.iter().position(|&e| e == entity) {
-                    tabs.swap(0, pos);
-                }
-            }
-        }
+        debug_assert!(match self {
+            Column::Single(id) | Column::Fullscren(id) => *id == entity,
+            Column::Stack(stack) => stack.iter().any(|item| item.contains(entity)),
+            Column::Tabs(tabs) => tabs.contains(&entity),
+        });
     }
 }
 
@@ -237,6 +227,37 @@ impl LayoutStrip {
             return;
         }
         self.columns.push_back(Column::Single(entity));
+    }
+
+    pub fn append_tab_group(&mut self, entities: &[Entity]) {
+        let mut group = Vec::new();
+        for entity in entities {
+            if !group.contains(entity) {
+                group.push(*entity);
+            }
+        }
+        if group.is_empty() {
+            return;
+        }
+
+        let index = group
+            .iter()
+            .filter_map(|entity| self.index_of(*entity).ok())
+            .min()
+            .unwrap_or(self.len());
+
+        for entity in &group {
+            self.remove(*entity);
+        }
+
+        let index = index.min(self.len());
+        if group.len() == 1 {
+            self.insert_at(index, group[0]);
+        } else if index >= self.len() {
+            self.columns.push_back(Column::Tabs(group));
+        } else {
+            self.columns.insert(index, Column::Tabs(group));
+        }
     }
 
     /// Converts a column containing `leader` to a `Tabs` column and adds `follower`.
@@ -652,6 +673,19 @@ impl LayoutStrip {
             .is_ok_and(|t| t)
     }
 
+    pub fn tab_group(&self, entity: Entity) -> Option<Vec<Entity>> {
+        self.columns.iter().find_map(|column| match column {
+            Column::Tabs(tabs) if tabs.contains(&entity) && tabs.len() > 1 => Some(tabs.clone()),
+            Column::Stack(items) => items.iter().find_map(|item| match item {
+                StackItem::Tabs(tabs) if tabs.contains(&entity) && tabs.len() > 1 => {
+                    Some(tabs.clone())
+                }
+                StackItem::Single(_) | StackItem::Tabs(_) => None,
+            }),
+            Column::Single(_) | Column::Fullscren(_) | Column::Tabs(_) => None,
+        })
+    }
+
     pub fn is_fullscreen(&self) -> bool {
         self.columns
             .front()
@@ -722,6 +756,49 @@ fn binpack_heights(heights: &[i32], min_height: i32, total_height: i32) -> Optio
     }
 
     Some(output)
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+#[instrument(level = Level::DEBUG, skip_all)]
+fn sync_tab_group_frames(
+    mut windows: ParamSet<(
+        Query<Entity, (With<Window>, Or<(Changed<Bounds>, Changed<Position>)>)>,
+        Query<(&Position, &Bounds), With<Window>>,
+        Query<(&mut Position, &mut Bounds), With<Window>>,
+    )>,
+    workspaces: Query<&LayoutStrip>,
+) {
+    let changed = windows.p0().iter().collect::<Vec<_>>();
+    let mut updates = HashMap::new();
+
+    for entity in changed {
+        let Some(tab_group) = workspaces.iter().find_map(|strip| strip.tab_group(entity)) else {
+            continue;
+        };
+        let (source_position, source_bounds) = {
+            let positions = windows.p1();
+            let Ok((position, bounds)) = positions.get(entity) else {
+                continue;
+            };
+            (position.clone(), bounds.clone())
+        };
+        for sibling in tab_group.into_iter().filter(|sibling| *sibling != entity) {
+            updates.insert(sibling, (source_position.clone(), source_bounds.clone()));
+        }
+    }
+
+    for (entity, (source_position, source_bounds)) in updates {
+        let mut write_windows = windows.p2();
+        let Ok((mut position, mut bounds)) = write_windows.get_mut(entity) else {
+            continue;
+        };
+        if position.0 != source_position.0 {
+            position.0 = source_position.0;
+        }
+        if bounds.0 != source_bounds.0 {
+            bounds.0 = source_bounds.0;
+        }
+    }
 }
 
 /// Watches for size changes to windows and if they are changed, signals to the layout strip.
@@ -1709,7 +1786,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tab_leader_rotation() {
+    fn test_tab_order_stays_stable_when_focus_changes() {
         let mut world = World::new();
         let e1 = world.spawn_empty().id();
         let e2 = world.spawn_empty().id();
@@ -1718,19 +1795,17 @@ mod tests {
         let mut column = Column::Tabs(vec![e1, e2, e3]);
         assert_eq!(column.top(), Some(e1));
 
-        // Move e2 to front (new leader)
         column.move_to_front(e2);
-        assert_eq!(column.top(), Some(e2));
+        assert_eq!(column.top(), Some(e1));
         match column {
-            Column::Tabs(ref tabs) => assert_eq!(tabs, &vec![e2, e1, e3]),
+            Column::Tabs(ref tabs) => assert_eq!(tabs, &vec![e1, e2, e3]),
             _ => panic!(),
         }
 
-        // Move e3 to front
         column.move_to_front(e3);
-        assert_eq!(column.top(), Some(e3));
+        assert_eq!(column.top(), Some(e1));
         match column {
-            Column::Tabs(ref tabs) => assert_eq!(tabs, &vec![e3, e1, e2]),
+            Column::Tabs(ref tabs) => assert_eq!(tabs, &vec![e1, e2, e3]),
             _ => panic!(),
         }
     }
@@ -1765,6 +1840,80 @@ mod tests {
             Column::Single(id) => assert_eq!(id, e3),
             _ => panic!("Expected Single column after removing all but one tab"),
         }
+    }
+
+    #[test]
+    fn test_tab_group_returns_all_siblings() {
+        let mut world = World::new();
+        let e1 = world.spawn_empty().id();
+        let e2 = world.spawn_empty().id();
+        let e3 = world.spawn_empty().id();
+
+        let mut strip = LayoutStrip::default();
+        strip.append(e1);
+        strip.convert_to_tabs(e1, e2).unwrap();
+        strip.append(e3);
+
+        assert_eq!(strip.tab_group(e1), Some(vec![e1, e2]));
+        assert_eq!(strip.tab_group(e2), Some(vec![e1, e2]));
+        assert_eq!(strip.tab_group(e3), None);
+    }
+
+    #[test]
+    fn test_append_tab_group_merges_existing_members_without_duplicate_columns() {
+        let mut world = World::new();
+        let e1 = world.spawn_empty().id();
+        let e2 = world.spawn_empty().id();
+        let e3 = world.spawn_empty().id();
+
+        let mut strip = LayoutStrip::default();
+        strip.append(e2);
+        strip.append(e3);
+
+        strip.append_tab_group(&[e1, e2]);
+
+        assert_eq!(strip.len(), 2);
+        match strip.get(0).unwrap() {
+            Column::Tabs(tabs) => assert_eq!(tabs, vec![e1, e2]),
+            _ => panic!("Expected merged Tabs column"),
+        }
+        assert_eq!(strip.index_of(e1).unwrap(), 0);
+        assert_eq!(strip.index_of(e2).unwrap(), 0);
+        assert_eq!(strip.index_of(e3).unwrap(), 1);
+        assert_eq!(strip.all_windows(), vec![e1, e2, e3]);
+    }
+
+    #[test]
+    fn test_tab_relative_positions_use_stable_slot_representative() {
+        let mut world = World::new();
+        let e1 = world.spawn_empty().id();
+        let e2 = world.spawn_empty().id();
+
+        let mut strip = LayoutStrip::default();
+        strip.append(e1);
+        strip.convert_to_tabs(e1, e2).unwrap();
+        strip
+            .get_column_mut(0)
+            .expect("tab column")
+            .move_to_front(e2);
+
+        let get_window_frame = |entity| {
+            if entity == e1 {
+                Some(IRect::new(0, 0, 300, 600))
+            } else {
+                Some(IRect::new(900, 0, 1200, 400))
+            }
+        };
+
+        let out = strip
+            .relative_positions(600, &get_window_frame)
+            .collect::<Vec<_>>();
+
+        assert_eq!(out.len(), 2);
+        assert!(
+            out.iter()
+                .all(|(_, frame)| *frame == IRect::new(0, 0, 300, 600))
+        );
     }
 
     #[test]

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -1,12 +1,13 @@
 use bevy::app::{App, Plugin, Update};
-use bevy::ecs::change_detection::DetectChangesMut as _;
+use bevy::ecs::change_detection::{DetectChanges as _, DetectChangesMut as _};
 use bevy::ecs::component::Component;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::query::{Changed, Has, Or, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
-use bevy::ecs::system::{Commands, Populated, Query, Res};
+use bevy::ecs::system::{Commands, ParallelCommands, Populated, Query, Res};
+use bevy::ecs::world::Ref;
 use bevy::math::IRect;
 use std::collections::VecDeque;
 use stdext::function_name;
@@ -15,8 +16,8 @@ use tracing::{Level, instrument, trace};
 use crate::config::Config;
 use crate::ecs::params::Windows;
 use crate::ecs::{
-    Bounds, DockPosition, FullWidthMarker, Initializing, LayoutPosition, Position,
-    ReshuffleAroundMarker, Scrolling, reposition_entity,
+    Bounds, DockPosition, EnsureVisibleMarker, FullWidthMarker, Initializing, LayoutPosition,
+    Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, reposition_entity,
 };
 use crate::errors::{Error, Result};
 use crate::manager::{Display, Window};
@@ -35,6 +36,7 @@ impl Plugin for LayoutEventsPlugin {
                     layout_sizes_changed,
                     layout_strip_changed,
                     reshuffle_layout_strip,
+                    ensure_visible_in_strip,
                     position_layout_strips,
                     position_layout_windows,
                 )
@@ -855,6 +857,55 @@ fn reshuffle_layout_strip(
     });
 }
 
+/// Scrolls the strip the minimum amount needed to keep `EnsureVisibleMarker`
+/// entities on-screen at their new layout position. If the entity already fits
+/// inside the viewport with the strip where it is, the strip is left alone and
+/// the per-window animator slides the entity into its slot. Only when the new
+/// slot would fall past an edge does the strip translate, and only by the
+/// shortfall — never to anchor the entity to a particular position.
+#[allow(clippy::needless_pass_by_value)]
+#[instrument(level = Level::DEBUG, skip_all)]
+fn ensure_visible_in_strip(
+    markers: Populated<(Entity, &LayoutPosition), With<EnsureVisibleMarker>>,
+    strips: Query<(&LayoutStrip, Entity, &Position, &ChildOf)>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
+    windows: Windows,
+    config: Res<Config>,
+    mut commands: Commands,
+) {
+    for (entity, layout_position) in markers {
+        if let Ok(mut cmd) = commands.get_entity(entity) {
+            cmd.try_remove::<EnsureVisibleMarker>();
+        }
+        let Some((_, strip_entity, strip_position, child)) =
+            strips.into_iter().find(|s| s.0.contains(entity))
+        else {
+            return;
+        };
+        let Ok((display, dock)) = displays.get(child.parent()) else {
+            return;
+        };
+        let Some(size) = windows.size(entity) else {
+            return;
+        };
+        let viewport = display.actual_display_bounds(dock, &config);
+
+        // Where the entity would appear if the strip stays put.
+        let candidate_min = layout_position.0 + strip_position.0;
+        // Clamp into the viewport. If already on-screen, this is a no-op and
+        // the strip target equals its current position — no movement.
+        //let clamped_min = candidate_min.clamp(viewport.min, viewport.max - size);
+        let clamped_min =
+            candidate_min.clamp(viewport.min, (viewport.max - size).max(viewport.min));
+        if clamped_min == candidate_min {
+            return;
+        }
+        let strip_target = (clamped_min - layout_position.0).with_y(strip_position.0.y);
+        trace!("ensure_visible_in_strip: entity {entity}, scroll strip to {strip_target}");
+        reposition_entity(strip_entity, strip_target, &mut commands);
+    }
+}
+
 /// Reacts to changes in the position of the `LayoutStrip` to Display, and if changed,
 /// marks all the windows in the strip as requiring re-positioning.
 #[allow(clippy::needless_pass_by_value)]
@@ -888,9 +939,19 @@ fn position_layout_windows(
         ),
         (Changed<LayoutPosition>, With<Window>, Without<LayoutStrip>),
     >,
-    workspaces: Query<(&LayoutStrip, &Position, Has<Scrolling>, &ChildOf), With<LayoutStrip>>,
+    workspaces: Query<
+        (
+            &LayoutStrip,
+            Ref<Position>,
+            Has<Scrolling>,
+            Has<RepositionMarker>,
+            &ChildOf,
+        ),
+        With<LayoutStrip>,
+    >,
     displays: Query<(&Display, Option<&DockPosition>)>,
     config: Res<Config>,
+    commands: ParallelCommands,
 ) {
     let offscreen_sliver_width = config.sliver_width();
     let (_, pad_right, _, pad_left) = config.edge_padding();
@@ -900,11 +961,19 @@ fn position_layout_windows(
             if full_width {
                 return;
             }
-            let Some((layout_strip, Position(strip_position), swiping, child_of)) =
+            let Some((layout_strip, strip_pos, swiping, strip_animating, child_of)) =
                 workspaces.iter().find(|strip| strip.0.contains(entity))
             else {
                 return;
             };
+            let strip_position = strip_pos.0;
+            // Workspace switch: show_active_workspace directly mutates the
+            // strip's Position to slide the strip on/off-screen — no
+            // RepositionMarker, no Scrolling. We snap windows in lockstep so
+            // they don't animate the long jump from off-screen storage into
+            // view.
+            // TODO: Adjust this if workspaces need to be animated later.
+            let workspace_switching = strip_pos.is_changed() && !swiping && !strip_animating;
             let Ok((display, dock)) = displays.get(child_of.parent()) else {
                 return;
             };
@@ -964,7 +1033,31 @@ fn position_layout_windows(
             }
 
             if position.0 != frame.min {
-                position.0 = frame.min;
+                // Direct-assign (snap) when:
+                //   - The user is actively swiping: windows must track the
+                //     finger in lockstep.
+                //   - A workspace switch just moved the strip: jumping the
+                //     full off-screen distance should be instantaneous.
+                // Otherwise (programmatic strip animation, or pure layout
+                // change), animate toward the new position so layout changes
+                // (swap/add/remove) slide instead of teleport. When the strip
+                // is also being animated, the per-window target is recomputed
+                // each tick from the strip's current position, so the two
+                // motions compose: e.g., on swap, the focused window's target
+                // converges back to its old visual position as the strip
+                // settles, while the other window slides past.
+                if swiping || workspace_switching {
+                    position.0 = frame.min;
+                    commands.command_scope(|mut command| {
+                        if let Ok(mut entity_commands) = command.get_entity(entity) {
+                            entity_commands.try_remove::<RepositionMarker>();
+                        }
+                    });
+                } else {
+                    commands.command_scope(|mut command| {
+                        reposition_entity(entity, frame.min, &mut command);
+                    });
+                }
             }
         },
     );

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -3,7 +3,7 @@ use bevy::ecs::change_detection::{DetectChanges as _, DetectChangesMut as _};
 use bevy::ecs::component::Component;
 use bevy::ecs::entity::{Entity, EntityHashMap, EntityHashSet};
 use bevy::ecs::hierarchy::ChildOf;
-use bevy::ecs::query::{Changed, Has, Or, With, Without};
+use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
 use bevy::ecs::system::{Commands, ParallelCommands, ParamSet, Populated, Query, Res};
@@ -16,11 +16,12 @@ use tracing::{Level, instrument, trace};
 use crate::config::Config;
 use crate::ecs::params::Windows;
 use crate::ecs::{
-    Bounds, DockPosition, EnsureVisibleMarker, Initializing, LayoutPosition, Position,
-    RepositionMarker, ReshuffleAroundMarker, Scrolling, reposition_entity,
+    Bounds, DockPosition, EnsureVisibleMarker, FocusedMarker, Initializing, LayoutPosition,
+    Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, reposition_entity,
+    reshuffle_around,
 };
 use crate::errors::{Error, Result};
-use crate::manager::{Display, Origin, Window};
+use crate::manager::{Application, Display, Origin, Window, WindowManager};
 use crate::platform::WorkspaceId;
 
 pub struct LayoutEventsPlugin;
@@ -33,6 +34,8 @@ impl Plugin for LayoutEventsPlugin {
                 // Wait for finish_setup before tiling: until then every window
                 // sits in the active strip regardless of its real display.
                 (
+                    reconcile_native_tab_columns,
+                    sync_focused_tab_group_frames,
                     sync_tab_group_frames,
                     layout_sizes_changed,
                     layout_strip_changed,
@@ -265,6 +268,7 @@ impl LayoutStrip {
         let index = self.index_of(leader)?;
         let column = self.columns.remove(index).unwrap();
         self.remove(follower);
+        let index = index.min(self.columns.len());
         match column {
             Column::Single(id) | Column::Fullscren(id) => {
                 self.columns.insert(index, Column::Tabs(vec![id, follower]));
@@ -762,22 +766,271 @@ fn binpack_heights(heights: &[i32], min_height: i32, total_height: i32) -> Optio
 #[instrument(level = Level::DEBUG, skip_all)]
 fn sync_tab_group_frames(
     mut windows: ParamSet<(
-        Query<Entity, (With<Window>, Or<(Changed<Bounds>, Changed<Position>)>)>,
+        Query<
+            (Entity, Ref<Position>, Ref<Bounds>),
+            (With<Window>, Or<(Changed<Bounds>, Changed<Position>)>),
+        >,
+        Query<(&Window, &ChildOf, Has<FocusedMarker>, &Position, &Bounds), With<Window>>,
+        Query<(&mut Position, &mut Bounds), With<Window>>,
+    )>,
+    workspaces: Query<&LayoutStrip>,
+    apps: Query<&Application>,
+) {
+    let changed = windows
+        .p0()
+        .iter()
+        .map(|(entity, position, _)| (entity, position.is_changed()))
+        .collect::<Vec<_>>();
+    let mut updates = HashMap::new();
+
+    for (entity, position_changed) in changed {
+        let Some(tab_group) = workspaces.iter().find_map(|strip| strip.tab_group(entity)) else {
+            continue;
+        };
+        let active_tab = {
+            let read_windows = windows.p1();
+            let app_focused = read_windows
+                .get(entity)
+                .ok()
+                .and_then(|(_, child, _, _, _)| apps.get(child.parent()).ok())
+                .and_then(|app| app.focused_window_id().ok())
+                .and_then(|focused_id| {
+                    tab_group.iter().copied().find(|tab| {
+                        read_windows
+                            .get(*tab)
+                            .is_ok_and(|(window, _, _, _, _)| window.id() == focused_id)
+                    })
+                });
+            app_focused
+                .or_else(|| {
+                    tab_group.iter().copied().find(|tab| {
+                        read_windows
+                            .get(*tab)
+                            .is_ok_and(|(_, _, focused, _, _)| focused)
+                    })
+                })
+                .unwrap_or(entity)
+        };
+        let source_entity = if position_changed { active_tab } else { entity };
+        let (source_position, source_bounds) = {
+            let positions = windows.p1();
+            let Ok((_, _, _, position, bounds)) = positions.get(source_entity) else {
+                continue;
+            };
+            (position.clone(), bounds.clone())
+        };
+        for sibling in tab_group
+            .into_iter()
+            .filter(|sibling| *sibling != source_entity)
+        {
+            updates.insert(sibling, (source_position.clone(), source_bounds.clone()));
+        }
+    }
+
+    for (entity, (source_position, source_bounds)) in updates {
+        let mut write_windows = windows.p2();
+        let Ok((mut position, mut bounds)) = write_windows.get_mut(entity) else {
+            continue;
+        };
+        if position.0 != source_position.0 {
+            position.0 = source_position.0;
+        }
+        if bounds.0 != source_bounds.0 {
+            bounds.0 = source_bounds.0;
+        }
+    }
+}
+
+fn native_tab_repair_anchor(entity: Entity, candidate: Entity, windows: &Windows) -> bool {
+    windows
+        .focused()
+        .is_some_and(|(_, focused)| focused == entity || focused == candidate)
+}
+
+fn native_tab_frames_match(a: IRect, b: IRect) -> bool {
+    const MIN_OVERLAP_PERCENT: i64 = 90;
+
+    let overlap_min_x = a.min.x.max(b.min.x);
+    let overlap_max_x = a.max.x.min(b.max.x);
+    let overlap_min_y = a.min.y.max(b.min.y);
+    let overlap_max_y = a.max.y.min(b.max.y);
+    let overlap_width = i64::from((overlap_max_x - overlap_min_x).max(0));
+    let overlap_height = i64::from((overlap_max_y - overlap_min_y).max(0));
+    let overlap_area = overlap_width * overlap_height;
+    let a_area = i64::from(a.width()) * i64::from(a.height());
+    let b_area = i64::from(b.width()) * i64::from(b.height());
+    let min_area = a_area.min(b_area);
+
+    overlap_area * 100 >= min_area * MIN_OVERLAP_PERCENT
+}
+
+fn native_tab_repair_candidate(
+    entity: Entity,
+    candidate: Entity,
+    windows: &Windows,
+    apps: &Query<&Application>,
+    window_manager: &WindowManager,
+) -> bool {
+    let Some(window) = windows.get(entity) else {
+        return false;
+    };
+    let Some((_, _, parent)) = windows.find_parent(window.id()) else {
+        return false;
+    };
+    let Some(candidate_window) = windows.get(candidate) else {
+        return false;
+    };
+    if windows
+        .find_parent(candidate_window.id())
+        .is_none_or(|(_, _, candidate_parent)| candidate_parent != parent)
+    {
+        return false;
+    }
+
+    let app_focused = apps
+        .get(parent)
+        .ok()
+        .and_then(|app| app.focused_window_id().ok())
+        .and_then(|window_id| windows.find(window_id).map(|(_, entity)| entity));
+    let focused_anchor = app_focused
+        .is_some_and(|focused| focused == entity || focused == candidate)
+        || native_tab_repair_anchor(entity, candidate, windows);
+    if !focused_anchor {
+        return false;
+    }
+
+    let native_tab_signal =
+        window.native_tab_count() >= 2 || candidate_window.native_tab_count() >= 2;
+    let visibility_signal = window_manager
+        .windows_on_screen()
+        .is_some_and(|ids| !ids.contains(&window.id()) || !ids.contains(&candidate_window.id()));
+    if !native_tab_signal && !visibility_signal {
+        return false;
+    }
+
+    windows
+        .size(entity)
+        .zip(windows.size(candidate))
+        .is_some_and(|(size, candidate_size)| size == candidate_size)
+}
+
+fn native_tab_repair_pair(
+    strip: &LayoutStrip,
+    windows: &Windows,
+    apps: &Query<&Application>,
+    window_manager: &WindowManager,
+) -> Option<Vec<Entity>> {
+    let repair_group = |entity| {
+        strip
+            .tab_group(entity)
+            .map_or_else(|| (vec![entity], false), |group| (group, true))
+    };
+
+    for entity in strip.all_windows() {
+        let (entity_group, entity_is_tab_group) = repair_group(entity);
+        if entity_group.first().copied() != Some(entity) {
+            continue;
+        }
+
+        let candidates = [strip.left_neighbour(entity), strip.right_neighbour(entity)];
+        for candidate in candidates.into_iter().flatten() {
+            let (candidate_group, candidate_is_tab_group) = repair_group(candidate);
+            if candidate_group
+                .iter()
+                .any(|candidate| entity_group.contains(candidate))
+            {
+                continue;
+            }
+            if entity_is_tab_group && candidate_is_tab_group {
+                continue;
+            }
+            if !entity_group.iter().any(|entity| {
+                candidate_group.iter().any(|candidate| {
+                    native_tab_repair_candidate(*entity, *candidate, windows, apps, window_manager)
+                })
+            }) {
+                continue;
+            }
+
+            let has_hidden_window = window_manager.windows_on_screen().is_some_and(|ids| {
+                entity_group
+                    .iter()
+                    .chain(candidate_group.iter())
+                    .filter_map(|entity| windows.get(*entity))
+                    .any(|window| !ids.contains(&window.id()))
+            });
+            let frames_match = entity_group.iter().any(|entity| {
+                candidate_group.iter().any(|candidate| {
+                    windows
+                        .frame(*entity)
+                        .zip(windows.frame(*candidate))
+                        .is_some_and(|(frame, candidate_frame)| {
+                            native_tab_frames_match(frame, candidate_frame)
+                        })
+                })
+            });
+            if (has_hidden_window || entity_is_tab_group || candidate_is_tab_group) && !frames_match
+            {
+                continue;
+            }
+
+            let entity_index = strip.index_of(entity_group[0]).ok()?;
+            let candidate_index = strip.index_of(candidate_group[0]).ok()?;
+            let group = if entity_index <= candidate_index {
+                [entity_group, candidate_group].concat()
+            } else {
+                [candidate_group, entity_group].concat()
+            };
+            return Some(group);
+        }
+    }
+    None
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[instrument(level = Level::DEBUG, skip_all)]
+fn reconcile_native_tab_columns(
+    mut workspaces: Query<&mut LayoutStrip>,
+    windows: Windows,
+    apps: Query<&Application>,
+    window_manager: Res<WindowManager>,
+    mut commands: Commands,
+) {
+    for mut strip in &mut workspaces {
+        while let Some(group) = native_tab_repair_pair(&strip, &windows, &apps, &window_manager) {
+            let Some(source) = group.first().copied() else {
+                break;
+            };
+            let Some(origin) = windows.origin(source) else {
+                break;
+            };
+            strip.append_tab_group(&group);
+            for follower in group.into_iter().filter(|entity| *entity != source) {
+                reposition_entity(follower, origin, &mut commands);
+            }
+            reshuffle_around(source, &mut commands);
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+#[instrument(level = Level::DEBUG, skip_all)]
+fn sync_focused_tab_group_frames(
+    focused_windows: Populated<Entity, (Added<FocusedMarker>, With<Window>)>,
+    mut windows: ParamSet<(
         Query<(&Position, &Bounds), With<Window>>,
         Query<(&mut Position, &mut Bounds), With<Window>>,
     )>,
     workspaces: Query<&LayoutStrip>,
 ) {
-    let changed = windows.p0().iter().collect::<Vec<_>>();
     let mut updates = HashMap::new();
-
-    for entity in changed {
+    for entity in focused_windows {
         let Some(tab_group) = workspaces.iter().find_map(|strip| strip.tab_group(entity)) else {
             continue;
         };
         let (source_position, source_bounds) = {
-            let positions = windows.p1();
-            let Ok((position, bounds)) = positions.get(entity) else {
+            let read_windows = windows.p0();
+            let Ok((position, bounds)) = read_windows.get(entity) else {
                 continue;
             };
             (position.clone(), bounds.clone())
@@ -788,7 +1041,7 @@ fn sync_tab_group_frames(
     }
 
     for (entity, (source_position, source_bounds)) in updates {
-        let mut write_windows = windows.p2();
+        let mut write_windows = windows.p1();
         let Ok((mut position, mut bounds)) = write_windows.get_mut(entity) else {
             continue;
         };

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -1,7 +1,7 @@
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::change_detection::{DetectChanges as _, DetectChangesMut as _};
 use bevy::ecs::component::Component;
-use bevy::ecs::entity::Entity;
+use bevy::ecs::entity::{Entity, EntityHashMap, EntityHashSet};
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::query::{Changed, Has, Or, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
@@ -20,7 +20,7 @@ use crate::ecs::{
     Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, reposition_entity,
 };
 use crate::errors::{Error, Result};
-use crate::manager::{Display, Window};
+use crate::manager::{Display, Origin, Window};
 use crate::platform::WorkspaceId;
 
 pub struct LayoutEventsPlugin;
@@ -736,11 +736,40 @@ fn layout_sizes_changed(
     >,
     workspaces: Query<&mut LayoutStrip>,
 ) {
+    let changed_entities = changed_sizes.iter().collect::<EntityHashSet>();
     workspaces.into_iter().for_each(|mut strip| {
-        if changed_sizes.iter().any(|entity| strip.contains(entity)) {
+        if strip_has_changed_window(&strip, &changed_entities) {
             strip.set_changed();
         }
     });
+}
+
+fn strip_has_changed_window(strip: &LayoutStrip, changed_entities: &EntityHashSet) -> bool {
+    strip
+        .columns
+        .iter()
+        .any(|column| column_has_changed_window(column, changed_entities))
+}
+
+fn column_has_changed_window(column: &Column, changed_entities: &EntityHashSet) -> bool {
+    match column {
+        Column::Single(entity) | Column::Fullscren(entity) => changed_entities.contains(entity),
+        Column::Stack(stack) => stack
+            .iter()
+            .any(|item| stack_item_has_changed_window(item, changed_entities)),
+        Column::Tabs(entities) => entities
+            .iter()
+            .any(|entity| changed_entities.contains(entity)),
+    }
+}
+
+fn stack_item_has_changed_window(item: &StackItem, changed_entities: &EntityHashSet) -> bool {
+    match item {
+        StackItem::Single(entity) => changed_entities.contains(entity),
+        StackItem::Tabs(entities) => entities
+            .iter()
+            .any(|entity| changed_entities.contains(entity)),
+    }
 }
 
 /// Watches for changes to `LayoutStrip` (i.e. a window added or window order changed) and
@@ -923,6 +952,129 @@ fn position_layout_strips(
     }
 }
 
+#[derive(Clone, Copy)]
+struct StripWindowContext {
+    strip_position: Origin,
+    swiping: bool,
+    // Cached per strip so parallel window updates keep the same snap/animate
+    // decision that would have been made while iterating the strip directly.
+    workspace_switching: bool,
+    display_entity: Entity,
+    stacked: bool,
+}
+
+fn insert_strip_window_contexts(
+    contexts: &mut EntityHashMap<StripWindowContext>,
+    strip: &LayoutStrip,
+    strip_position: Origin,
+    swiping: bool,
+    workspace_switching: bool,
+    display_entity: Entity,
+) {
+    for column in &strip.columns {
+        insert_column_window_contexts(
+            contexts,
+            column,
+            strip_position,
+            swiping,
+            workspace_switching,
+            display_entity,
+            matches!(column, Column::Stack(_)),
+        );
+    }
+}
+
+fn insert_column_window_contexts(
+    contexts: &mut EntityHashMap<StripWindowContext>,
+    column: &Column,
+    strip_position: Origin,
+    swiping: bool,
+    workspace_switching: bool,
+    display_entity: Entity,
+    stacked: bool,
+) {
+    match column {
+        Column::Single(entity) | Column::Fullscren(entity) => {
+            contexts.insert(
+                *entity,
+                StripWindowContext {
+                    strip_position,
+                    swiping,
+                    workspace_switching,
+                    display_entity,
+                    stacked,
+                },
+            );
+        }
+        Column::Stack(items) => {
+            for item in items {
+                insert_stack_item_window_contexts(
+                    contexts,
+                    item,
+                    strip_position,
+                    swiping,
+                    workspace_switching,
+                    display_entity,
+                    stacked,
+                );
+            }
+        }
+        Column::Tabs(entities) => {
+            for entity in entities {
+                contexts.insert(
+                    *entity,
+                    StripWindowContext {
+                        strip_position,
+                        swiping,
+                        workspace_switching,
+                        display_entity,
+                        stacked,
+                    },
+                );
+            }
+        }
+    }
+}
+
+fn insert_stack_item_window_contexts(
+    contexts: &mut EntityHashMap<StripWindowContext>,
+    item: &StackItem,
+    strip_position: Origin,
+    swiping: bool,
+    workspace_switching: bool,
+    display_entity: Entity,
+    stacked: bool,
+) {
+    match item {
+        StackItem::Single(entity) => {
+            contexts.insert(
+                *entity,
+                StripWindowContext {
+                    strip_position,
+                    swiping,
+                    workspace_switching,
+                    display_entity,
+                    stacked,
+                },
+            );
+        }
+        StackItem::Tabs(entities) => {
+            for entity in entities {
+                contexts.insert(
+                    *entity,
+                    StripWindowContext {
+                        strip_position,
+                        swiping,
+                        workspace_switching,
+                        display_entity,
+                        stacked,
+                    },
+                );
+            }
+        }
+    }
+}
+
 /// Reacts to changes of logical window layout in the strip and any have been changed, reposition
 /// the layout strip against the current display viewport.
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
@@ -955,26 +1107,35 @@ fn position_layout_windows(
 ) {
     let offscreen_sliver_width = config.sliver_width();
     let (_, pad_right, _, pad_left) = config.edge_padding();
+    let mut strip_contexts = EntityHashMap::default();
+    for (layout_strip, strip_pos, swiping, strip_animating, child_of) in &workspaces {
+        let strip_position = strip_pos.0;
+        // Workspace switch: show_active_workspace directly mutates the
+        // strip's Position to slide the strip on/off-screen - no
+        // RepositionMarker, no Scrolling. We snap windows in lockstep so
+        // they don't animate the long jump from off-screen storage into
+        // view.
+        // TODO: Adjust this if workspaces need to be animated later.
+        let workspace_switching = strip_pos.is_changed() && !swiping && !strip_animating;
+        insert_strip_window_contexts(
+            &mut strip_contexts,
+            layout_strip,
+            strip_position,
+            swiping,
+            workspace_switching,
+            child_of.parent(),
+        );
+    }
 
     positioned_windows.par_iter_mut().for_each(
         |(entity, window, layout_position, mut position, mut bounds, full_width)| {
             if full_width {
                 return;
             }
-            let Some((layout_strip, strip_pos, swiping, strip_animating, child_of)) =
-                workspaces.iter().find(|strip| strip.0.contains(entity))
-            else {
+            let Some(context) = strip_contexts.get(&entity) else {
                 return;
             };
-            let strip_position = strip_pos.0;
-            // Workspace switch: show_active_workspace directly mutates the
-            // strip's Position to slide the strip on/off-screen — no
-            // RepositionMarker, no Scrolling. We snap windows in lockstep so
-            // they don't animate the long jump from off-screen storage into
-            // view.
-            // TODO: Adjust this if workspaces need to be animated later.
-            let workspace_switching = strip_pos.is_changed() && !swiping && !strip_animating;
-            let Ok((display, dock)) = displays.get(child_of.parent()) else {
+            let Ok((display, dock)) = displays.get(context.display_entity) else {
                 return;
             };
             let viewport = display.actual_display_bounds(dock, &config);
@@ -985,8 +1146,8 @@ fn position_layout_windows(
             let h_pad = window.horizontal_padding();
             let mut frame = IRect::from_corners(layout_position.0, layout_position.0 + bounds.0);
             let width = frame.width();
-            frame.min += strip_position;
-            frame.max += strip_position;
+            frame.min += context.strip_position;
+            frame.max += context.strip_position;
 
             let mut offscreen = false;
             if frame.max.x <= viewport.min.x + h_pad {
@@ -1009,18 +1170,12 @@ fn position_layout_windows(
             // applies to horizontally off-screen windows, so they expose just
             // a `sliver_height` fraction of their height at the viewport's
             // vertical center.
-            if !swiping && offscreen {
-                let stacked = layout_strip
-                    .index_of(entity)
-                    .ok()
-                    .and_then(|idx| layout_strip.get(idx).ok())
-                    .is_some_and(|col| matches!(col, Column::Stack(_)));
-
+            if !context.swiping && offscreen {
                 // Don't compress stacked windows vertically when off-screen.
                 // The height reduction corrupts their proportions: when the
                 // column scrolls back on-screen, binpack_heights makes the
                 // last window absorb all remaining space.
-                if !stacked {
+                if !context.stacked {
                     let inset = (f64::from(viewport.height()) * (1.0 - config.sliver_height())
                         / 2.0) as i32;
                     frame.min.y += inset;
@@ -1046,7 +1201,7 @@ fn position_layout_windows(
                 // motions compose: e.g., on swap, the focused window's target
                 // converges back to its old visual position as the strip
                 // settles, while the other window slides past.
-                if swiping || workspace_switching {
+                if context.swiping || context.workspace_switching {
                     position.0 = frame.min;
                     commands.command_scope(|mut command| {
                         if let Ok(mut entity_commands) = command.get_entity(entity) {
@@ -1078,6 +1233,53 @@ mod tests {
         strip.append(entities[2]);
 
         (world, strip, entities)
+    }
+
+    #[test]
+    fn strip_has_changed_window_matches_nested_entities() {
+        let (mut world, mut strip, entities) = setup_world_and_strip();
+        strip.stack(entities[1]).unwrap();
+        strip.convert_to_tabs(entities[0], entities[1]).unwrap();
+
+        let mut changed = EntityHashSet::default();
+        changed.insert(entities[1]);
+
+        assert!(strip_has_changed_window(&strip, &changed));
+
+        changed.clear();
+        changed.insert(world.spawn_empty().id());
+
+        assert!(!strip_has_changed_window(&strip, &changed));
+    }
+
+    #[test]
+    fn strip_window_contexts_capture_stack_membership_once() {
+        let (mut world, mut strip, entities) = setup_world_and_strip();
+        strip.stack(entities[1]).unwrap();
+        let display_entity = world.spawn_empty().id();
+        let strip_position = Origin::new(10, 20);
+        let mut contexts = EntityHashMap::default();
+
+        insert_strip_window_contexts(
+            &mut contexts,
+            &strip,
+            strip_position,
+            true,
+            false,
+            display_entity,
+        );
+
+        let stacked_leader = contexts.get(&entities[0]).unwrap();
+        let stacked_follower = contexts.get(&entities[1]).unwrap();
+        let single_window = contexts.get(&entities[2]).unwrap();
+
+        assert_eq!(stacked_leader.strip_position, strip_position);
+        assert_eq!(stacked_leader.display_entity, display_entity);
+        assert!(stacked_leader.swiping);
+        assert!(!stacked_leader.workspace_switching);
+        assert!(stacked_leader.stacked);
+        assert!(stacked_follower.stacked);
+        assert!(!single_window.stacked);
     }
 
     #[test]

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -243,6 +243,7 @@ impl LayoutStrip {
     pub fn convert_to_tabs(&mut self, leader: Entity, follower: Entity) -> Result<()> {
         let index = self.index_of(leader)?;
         let column = self.columns.remove(index).unwrap();
+        self.remove(follower);
         match column {
             Column::Single(id) | Column::Fullscren(id) => {
                 self.columns.insert(index, Column::Tabs(vec![id, follower]));

--- a/src/ecs/mouse.rs
+++ b/src/ecs/mouse.rs
@@ -117,6 +117,14 @@ fn mouse_moved_trigger(
             trace!("ffm_window_id > 0");
             continue;
         }
+        let pointer = origin_from(*point);
+        if windows
+            .focused()
+            .is_some_and(|(window, _)| window.frame().contains(pointer))
+        {
+            trace!("pointer still inside focused window");
+            continue;
+        }
         let Ok(window_id) = window_manager.find_window_at_point(point) else {
             debug!("can not find window at point {point:?}");
             continue;
@@ -279,13 +287,15 @@ fn mouse_resize_trigger(
             continue;
         }
 
-        let Ok(window_id) = window_manager.find_window_at_point(point) else {
-            continue;
+        let window_id = if let Some(window_id) = state.window_id {
+            window_id
+        } else {
+            let Ok(window_id) = window_manager.find_window_at_point(point) else {
+                continue;
+            };
+            state.window_id = Some(window_id);
+            window_id
         };
-        if state.window_id.is_some_and(|id| window_id != id) {
-            continue;
-        }
-        state.window_id = Some(window_id);
 
         let Some((window, entity)) = windows.find(window_id) else {
             continue;

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -271,12 +271,6 @@ impl Windows<'_, '_> {
             .map(|(window, entity, _, _)| (window, entity))
     }
 
-    pub fn all_iter(&self) -> impl Iterator<Item = (&Window, Entity, &ChildOf)> {
-        self.all
-            .iter()
-            .map(|(window, entity, childof, _)| (window, entity, childof))
-    }
-
     pub fn managed_iter(&self) -> impl Iterator<Item = (&Window, Entity, &ChildOf)> {
         self.all
             .iter()

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -261,6 +261,15 @@ impl Windows<'_, '_> {
         })
     }
 
+    pub fn app<'a>(
+        &self,
+        entity: Entity,
+        apps: &'a Query<&Application>,
+    ) -> Option<&'a Application> {
+        let (_, _, childof, _) = self.get_all(entity)?;
+        apps.get(childof.parent()).ok()
+    }
+
     pub fn focused(&self) -> Option<(&Window, Entity)> {
         self.focus.single().ok()
     }

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -29,13 +29,16 @@ use crate::platform::{Pid, WinID, WorkspaceId};
 pub(crate) struct SessionRestore {
     state: PaneruState,
     timer: Timer,
+    saved_hard_keys: HashSet<WindowHardMatchKey>,
 }
 
 impl SessionRestore {
     fn new(state: PaneruState, grace: Duration) -> Self {
+        let saved_hard_keys = saved_hard_match_keys(&state);
         Self {
             state,
             timer: Timer::new(grace, TimerMode::Once),
+            saved_hard_keys,
         }
     }
 }
@@ -71,6 +74,10 @@ pub(crate) struct CurrentWindowIdentity {
 }
 
 impl CurrentWindowIdentity {
+    fn hard_key(&self) -> WindowHardMatchKey {
+        WindowHardMatchKey::new(self.window_id, self.pid, self.bundle_id.clone())
+    }
+
     #[cfg(test)]
     pub(crate) fn fallback_only(entity: Entity, bundle_id: &str, title: &str) -> Self {
         Self {
@@ -82,6 +89,23 @@ impl CurrentWindowIdentity {
             identifier: "main".to_string(),
             role: "AXWindow".to_string(),
             subrole: "AXStandardWindow".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct WindowHardMatchKey {
+    window_id: WinID,
+    pid: Pid,
+    bundle_id: String,
+}
+
+impl WindowHardMatchKey {
+    fn new(window_id: WinID, pid: Pid, bundle_id: String) -> Self {
+        Self {
+            window_id,
+            pid,
+            bundle_id,
         }
     }
 }
@@ -119,11 +143,15 @@ pub(crate) struct RestorePlan {
 
 pub(crate) struct RestorePlanner<'a> {
     state: &'a PaneruState,
+    saved_hard_keys: HashSet<WindowHardMatchKey>,
 }
 
 impl<'a> RestorePlanner<'a> {
     pub(crate) fn new(state: &'a PaneruState) -> Self {
-        Self { state }
+        Self {
+            state,
+            saved_hard_keys: saved_hard_match_keys(state),
+        }
     }
 
     pub(crate) fn plan(&self, current: &[CurrentWindowIdentity]) -> RestorePlan {
@@ -257,17 +285,7 @@ impl<'a> RestorePlanner<'a> {
     }
 
     fn current_window_has_saved_hard_match(&self, current: &CurrentWindowIdentity) -> bool {
-        self.saved_windows()
-            .any(|saved| saved.hard_match(current.window_id, current.pid, &current.bundle_id))
-    }
-
-    fn saved_windows(&self) -> impl Iterator<Item = &SavedWindow> {
-        self.state
-            .workspaces
-            .iter()
-            .flat_map(|workspace| &workspace.strips)
-            .flat_map(|strip| &strip.columns)
-            .flat_map(saved_windows_in_column)
+        self.saved_hard_keys.contains(&current.hard_key())
     }
 
     fn record_active_virtual(
@@ -299,6 +317,15 @@ impl<'a> RestorePlanner<'a> {
     }
 }
 
+fn saved_windows_in_state(state: &PaneruState) -> impl Iterator<Item = &SavedWindow> {
+    state
+        .workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.strips)
+        .flat_map(|strip| &strip.columns)
+        .flat_map(saved_windows_in_column)
+}
+
 fn saved_windows_in_column(column: &SavedColumn) -> Box<dyn Iterator<Item = &SavedWindow> + '_> {
     match column {
         SavedColumn::Single(saved) | SavedColumn::Fullscreen(saved) => {
@@ -319,6 +346,10 @@ fn saved_windows_in_stack_item(
 }
 
 impl SavedWindow {
+    fn hard_key(&self) -> WindowHardMatchKey {
+        WindowHardMatchKey::new(self.window_id, self.pid, self.bundle_id.clone())
+    }
+
     fn fallback_match(&self, current: &CurrentWindowIdentity) -> bool {
         !self.title.is_empty()
             && self.bundle_id == current.bundle_id
@@ -327,6 +358,16 @@ impl SavedWindow {
             && self.role == current.role
             && self.subrole == current.subrole
     }
+}
+
+fn saved_hard_match_keys(state: &PaneruState) -> HashSet<WindowHardMatchKey> {
+    saved_windows_in_state(state)
+        .map(SavedWindow::hard_key)
+        .collect()
+}
+
+fn has_saved_fallback_windows(state: &PaneruState) -> bool {
+    saved_windows_in_state(state).any(|window| !window.title.is_empty())
 }
 
 pub(crate) fn matches_startup_restore_state(
@@ -340,18 +381,20 @@ pub(crate) fn matches_startup_restore_state(
         return false;
     }
 
-    let state = session.map_or(restoration, |session| Some(&session.state));
-    let Some(state) = state else {
-        return false;
-    };
     let Ok(pid) = window.pid() else {
         return false;
     };
     let bundle_id = app.bundle_id().unwrap_or_default().to_string();
+    let key = WindowHardMatchKey::new(window.id(), pid, bundle_id.clone());
 
-    RestorePlanner::new(state)
-        .saved_windows()
-        .any(|saved| saved.hard_match(window.id(), pid, &bundle_id))
+    if let Some(session) = session {
+        return session.saved_hard_keys.contains(&key);
+    }
+
+    let Some(state) = restoration else {
+        return false;
+    };
+    saved_windows_in_state(state).any(|saved| saved.hard_match(window.id(), pid, &bundle_id))
 }
 
 #[allow(
@@ -376,10 +419,10 @@ pub(super) fn restore_window_state(
     restoration: Option<Res<PaneruState>>,
     mut commands: Commands,
 ) {
-    let restoration = if let Some(session) = session {
-        session.state.clone()
+    let restoration = if let Some(session) = session.as_deref() {
+        &session.state
     } else {
-        let Some(restoration) = restoration else {
+        let Some(restoration) = restoration.as_deref() else {
             return;
         };
         if !config.restore_enabled() {
@@ -390,7 +433,6 @@ pub(super) fn restore_window_state(
         match config.restore_missing_windows() {
             MissingWindowBehavior::Ignore => {}
         }
-        let restoration = restoration.as_ref().clone();
         commands.insert_resource(SessionRestore::new(
             restoration.clone(),
             config.restore_startup_grace(),
@@ -398,8 +440,8 @@ pub(super) fn restore_window_state(
         restoration
     };
 
-    let current = current_window_identities(&windows, &apps);
-    let plan = RestorePlanner::new(&restoration).plan(&current);
+    let current = current_window_identities(&windows, &apps, restoration);
+    let plan = RestorePlanner::new(restoration).plan(&current);
 
     if plan.consumed_entities.is_empty() {
         info!(
@@ -528,8 +570,9 @@ fn layout_strip_from_plan(planned: &PlannedStrip) -> LayoutStrip {
 fn current_window_identities(
     windows: &Windows,
     apps: &Query<&Application>,
+    restoration: &PaneruState,
 ) -> Vec<CurrentWindowIdentity> {
-    windows
+    let mut current = windows
         .managed_iter()
         .filter_map(|(window, entity, child)| {
             let app = apps.get(child.parent()).ok()?;
@@ -538,13 +581,42 @@ fn current_window_identities(
                 window_id: window.id(),
                 pid: window.pid().ok()?,
                 bundle_id: app.bundle_id().unwrap_or_default().to_string(),
-                title: window.title().unwrap_or_default(),
-                identifier: window.identifier().unwrap_or_default(),
-                role: window.role().unwrap_or_default(),
-                subrole: window.subrole().unwrap_or_default(),
+                title: String::new(),
+                identifier: String::new(),
+                role: String::new(),
+                subrole: String::new(),
             })
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    if has_saved_fallback_windows(restoration) {
+        let saved_hard_keys = saved_hard_match_keys(restoration);
+        hydrate_fallback_identities(&mut current, windows, &saved_hard_keys);
+    }
+
+    current
+}
+
+fn hydrate_fallback_identities(
+    current: &mut [CurrentWindowIdentity],
+    windows: &Windows,
+    saved_hard_keys: &HashSet<WindowHardMatchKey>,
+) {
+    for identity in current {
+        if saved_hard_keys.contains(&identity.hard_key()) {
+            continue;
+        }
+        let Some(window) = windows.get(identity.entity) else {
+            continue;
+        };
+        identity.title = window.title().unwrap_or_default();
+        if identity.title.is_empty() {
+            continue;
+        }
+        identity.identifier = window.identifier().unwrap_or_default();
+        identity.role = window.role().unwrap_or_default();
+        identity.subrole = window.subrole().unwrap_or_default();
+    }
 }
 
 fn select_display<'a>(

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,4 +1,5 @@
 use bevy::app::AppExit;
+use bevy::ecs::change_detection::DetectChanges;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
@@ -37,7 +38,7 @@ use crate::manager::{
     Application, Display, Process, Window, WindowManager, WindowOS, bruteforce_windows,
 };
 use crate::overlay::{FlashMessageManager, OverlayManager};
-use crate::platform::PlatformCallbacks;
+use crate::platform::{PlatformCallbacks, WinID};
 
 const ANIAMTE_SNAP_THRESHOLD: f32 = 5.0;
 
@@ -834,7 +835,14 @@ pub(crate) fn gather_initial_processes(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[derive(Default)]
+pub(super) struct OverlayWindowConfigCache {
+    window_id: Option<WinID>,
+    focused_border_radius: Option<f64>,
+    detected_border_radius: Option<f64>,
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub(super) fn update_overlays(
     windows: Windows,
     applications: Query<&Application>,
@@ -842,6 +850,7 @@ pub(super) fn update_overlays(
     overlay_mgr: Option<NonSendMut<OverlayManager>>,
     mission_control_active: Res<MissionControlActive>,
     config: Res<Config>,
+    mut window_config_cache: Local<OverlayWindowConfigCache>,
 ) {
     use crate::overlay::BorderParams;
     use objc2_foundation::{NSPoint, NSRect, NSSize};
@@ -871,60 +880,66 @@ pub(super) fn update_overlays(
 
     // Find the focused managed window's absolute CG frame.
     // Skip floating/unmanaged windows — no overlay or border for those.
-    let (focused_abs_cg, focused_border_radius, detected_border_radius) =
-        if let Some((window, _, unmanaged)) = windows
-            .focused()
-            .and_then(|(_, entity)| windows.get_managed(entity))
-            && unmanaged.is_none()
-            && !window.is_full_screen()
-        {
-            let frame = window.frame();
-            let h_pad = window.horizontal_padding();
-            let v_pad = window.vertical_padding();
-            let focused_abs_cg = Some(NSRect::new(
-                NSPoint::new(
-                    f64::from(frame.min.x + h_pad),
-                    f64::from(frame.min.y + v_pad),
-                ),
-                NSSize::new(
-                    f64::from(frame.width() - 2 * h_pad),
-                    f64::from(frame.height() - 2 * v_pad),
-                ),
-            ));
+    let (focused_abs_cg, focused_window_id) = if let Some((window, _, unmanaged)) = windows
+        .focused()
+        .and_then(|(_, entity)| windows.get_managed(entity))
+        && unmanaged.is_none()
+        && !window.is_full_screen()
+    {
+        let frame = window.frame();
+        let h_pad = window.horizontal_padding();
+        let v_pad = window.vertical_padding();
+        let focused_abs_cg = Some(NSRect::new(
+            NSPoint::new(
+                f64::from(frame.min.x + h_pad),
+                f64::from(frame.min.y + v_pad),
+            ),
+            NSSize::new(
+                f64::from(frame.width() - 2 * h_pad),
+                f64::from(frame.height() - 2 * v_pad),
+            ),
+        ));
 
-            // Look up per-window border_radius from config (dynamic, respects hot-reload).
-            let Some(app) = windows
-                .find_parent(window.id())
-                .and_then(|(_, _, parent)| applications.get(parent).ok())
-            else {
+        (focused_abs_cg, window.id())
+    } else {
+        // No managed window has focus — hide the overlay rather than
+        // dimming everything (e.g. during startup or when only floating
+        // windows exist).
+        overlay_mgr.hide_all();
+        return;
+    };
+
+    let border_params = if border_enabled {
+        if window_config_cache.window_id != Some(focused_window_id) || config.is_changed() {
+            let Some((window, _, parent)) = windows.find_parent(focused_window_id) else {
+                return;
+            };
+            let Ok(app) = applications.get(parent) else {
                 return;
             };
             let properties = WindowProperties::new(app, window, &config);
-            let focused_border_radius = properties.border_radius();
-            (
-                focused_abs_cg,
-                focused_border_radius,
-                window.border_radius(),
-            )
-        } else {
-            // No managed window has focus — hide the overlay rather than
-            // dimming everything (e.g. during startup or when only floating
-            // windows exist).
-            overlay_mgr.hide_all();
-            return;
+            window_config_cache.window_id = Some(focused_window_id);
+            window_config_cache.focused_border_radius = properties.border_radius();
+            window_config_cache.detected_border_radius = window.border_radius();
+        }
+
+        let calculated_radius = match config.border_radius() {
+            BorderRadiusOption::Auto => window_config_cache.detected_border_radius.unwrap_or(10.0),
+            BorderRadiusOption::Value(value) => value.max(0.0),
         };
 
-    let calculated_radius = match config.border_radius() {
-        BorderRadiusOption::Auto => detected_border_radius.unwrap_or(10.0),
-        BorderRadiusOption::Value(value) => value.max(0.0),
+        Some(BorderParams {
+            color: config.border_color(),
+            opacity: config.border_opacity(),
+            width: config.border_width(),
+            radius: window_config_cache
+                .focused_border_radius
+                .unwrap_or(calculated_radius),
+        })
+    } else {
+        window_config_cache.window_id = None;
+        None
     };
-
-    let border_params = border_enabled.then(|| BorderParams {
-        color: config.border_color(),
-        opacity: config.border_opacity(),
-        width: config.border_width(),
-        radius: focused_border_radius.unwrap_or(calculated_radius),
-    });
 
     let dim_color = config.dim_inactive_color();
     overlay_mgr.update(

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -20,6 +20,7 @@ use tracing::{Level, debug, error, info, instrument, trace, warn};
 use super::{
     ActiveDisplayMarker, BProcess, ExistingMarker, FreshMarker, PollForNotifications,
     RepositionMarker, ResizeMarker, RetryFrontSwitch, SpawnWindowTrigger, Timeout,
+    VerifyWindowPosition,
 };
 
 use crate::config::{Config, decorations::BorderRadiusOption};
@@ -687,11 +688,20 @@ pub(super) fn pump_events(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn window_resized_update_frame(
     mut messages: MessageReader<Event>,
-    mut windows: Query<(&mut Window, Entity, &Position, &mut Bounds), Without<LayoutStrip>>,
+    mut windows: Query<
+        (
+            &mut Window,
+            Entity,
+            &Position,
+            &mut Bounds,
+            Option<&Unmanaged>,
+        ),
+        Without<LayoutStrip>,
+    >,
     mut active_workspace: Single<(&LayoutStrip, &mut Position), With<ActiveWorkspaceMarker>>,
 ) {
     for event in messages.read() {
@@ -699,12 +709,15 @@ pub(super) fn window_resized_update_frame(
             continue;
         };
 
-        let Some((mut window, entity, position, mut bounds)) = windows
+        let Some((mut window, entity, position, mut bounds, unmanaged)) = windows
             .iter_mut()
             .find(|window| window.0.id() == *window_id)
         else {
             continue;
         };
+        if matches!(unmanaged, Some(Unmanaged::Minimized | Unmanaged::Hidden)) {
+            continue;
+        }
         let Ok(new_frame) = window.update_frame() else {
             continue;
         };
@@ -732,7 +745,7 @@ pub(super) fn window_resized_update_frame(
         let diff = old_frame.min.y - new_frame.min.y;
         if diff.abs() > 0
             && let Some(above_entity) = active_strip.above(entity)
-            && let Ok((_, _, _, mut above_bounds)) = windows.get_mut(above_entity)
+            && let Ok((_, _, _, mut above_bounds, _)) = windows.get_mut(above_entity)
             && above_bounds.0.y - diff > 200
         {
             above_bounds.0.y -= diff;
@@ -744,19 +757,25 @@ pub(super) fn window_resized_update_frame(
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn window_moved_update_frame(
     mut messages: MessageReader<Event>,
-    mut windows: Query<(&mut Window, &mut Position, &Bounds), Without<LayoutStrip>>,
+    mut windows: Query<
+        (&mut Window, &mut Position, &Bounds, Option<&Unmanaged>),
+        Without<LayoutStrip>,
+    >,
 ) {
     for event in messages.read() {
         let Event::WindowMoved { window_id } = event else {
             continue;
         };
 
-        let Some((mut window, mut position, bounds)) = windows
+        let Some((mut window, mut position, bounds, unmanaged)) = windows
             .iter_mut()
             .find(|window| window.0.id() == *window_id)
         else {
             continue;
         };
+        if matches!(unmanaged, Some(Unmanaged::Minimized | Unmanaged::Hidden)) {
+            continue;
+        }
         let Ok(new_frame) = window.update_frame() else {
             continue;
         };
@@ -923,6 +942,28 @@ pub(super) fn commit_window_position(
     moved_windows
         .par_iter_mut()
         .for_each(|(mut window, position)| window.reposition(position.0));
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[instrument(level = Level::TRACE, skip_all)]
+pub(super) fn verify_window_position(
+    mut windows: Populated<(Entity, &mut Window, &Position, &mut VerifyWindowPosition)>,
+    mut commands: Commands,
+) {
+    for (entity, mut window, position, mut verification) in &mut windows {
+        if window
+            .update_frame()
+            .is_ok_and(|frame| frame.min == position.0)
+        {
+            commands.entity(entity).try_remove::<VerifyWindowPosition>();
+            continue;
+        }
+
+        window.reposition(position.0);
+        if verification.tick() {
+            commands.entity(entity).try_remove::<VerifyWindowPosition>();
+        }
+    }
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -655,6 +655,11 @@ pub(super) fn window_resized_update_frame(
             // Floating window, don't nudge the strip.
             continue;
         }
+        if active_strip.tabbed(entity) {
+            // Native tabs share a single layout slot. Keep the strip anchored
+            // and let the tab sync/layout systems propagate the new size.
+            continue;
+        }
 
         if old_frame.min.x != new_frame.min.x {
             let shift = (old_frame.size() - new_frame.size()).with_y(0);

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -40,6 +40,10 @@ use crate::overlay::{FlashMessageManager, OverlayManager};
 use crate::platform::{PlatformCallbacks, WinID};
 
 const ANIAMTE_SNAP_THRESHOLD: f32 = 5.0;
+const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
+const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
+const LOOP_MAX_TIMEOUT_MS: u32 = 50;
+const LOOP_TIMEOUT_STEP: u32 = 1;
 
 /// Gathers all present displays and spawns them as entities in the Bevy world.
 /// The currently active display (identified by `window_manager.active_display_id()`) is marked with `ActiveDisplayMarker`.
@@ -591,10 +595,14 @@ pub(super) fn pump_events(
                     || !resizing.is_empty()
                     || !scrolling.is_empty()
                     || !flash_messages.is_empty();
-                let timeout_limit = pump_timeout_limit(
-                    low_power_mode.is_some_and(|low_power| low_power.0),
-                    frame_active,
-                );
+                let low_power = low_power_mode.is_some_and(|low_power| low_power.0);
+                let timeout_limit = if frame_active {
+                    LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+                } else if low_power {
+                    LOOP_MAX_TIMEOUT_LOWPOWER_MS
+                } else {
+                    LOOP_MAX_TIMEOUT_MS
+                };
                 *timeout = timeout.min(timeout_limit) + LOOP_TIMEOUT_STEP;
                 break;
             }
@@ -1070,50 +1078,5 @@ pub(crate) fn detect_tabbed_windows(
                 reshuffle_around(entity, &mut commands);
             }
         }
-    }
-}
-
-const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
-
-const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
-
-const LOOP_MAX_TIMEOUT_MS: u32 = 50;
-
-const LOOP_TIMEOUT_STEP: u32 = 1;
-
-fn pump_timeout_limit(low_power_active: bool, frame_active: bool) -> u32 {
-    if frame_active {
-        LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
-    } else if low_power_active {
-        LOOP_MAX_TIMEOUT_LOWPOWER_MS
-    } else {
-        LOOP_MAX_TIMEOUT_MS
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn pump_timeout_limit_uses_frame_active_cap_for_visible_work() {
-        assert_eq!(pump_timeout_limit(false, false), LOOP_MAX_TIMEOUT_MS);
-        assert_eq!(
-            pump_timeout_limit(true, false),
-            LOOP_MAX_TIMEOUT_LOWPOWER_MS
-        );
-        assert_eq!(
-            pump_timeout_limit(false, true),
-            LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
-        );
-        assert_eq!(
-            pump_timeout_limit(true, true),
-            LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
-        );
-    }
-
-    #[test]
-    fn low_power_idle_timeout_stays_below_interactive_latency_budget() {
-        assert!(pump_timeout_limit(true, false) <= 50);
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -58,17 +58,6 @@ pub(super) fn dispatch_toplevel_triggers(
 ) {
     for event in messages.read() {
         match event {
-            Event::WindowCreated { element } => {
-                if let Ok(window) = WindowOS::new(element)
-                    .inspect_err(|err| {
-                        trace!("not adding window {element:?}: {err}");
-                    })
-                    .map(|window| Window::new(Box::new(window)))
-                {
-                    commands.trigger(SpawnWindowTrigger(vec![window]));
-                }
-            }
-
             Event::SpaceChanged if broken_notifications.is_some() => {
                 info!(
                     "Workspace and display notifications arriving correctly. Disabling the polling.",
@@ -1091,4 +1080,22 @@ pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>
     };
     let process_info = objc2_foundation::NSProcessInfo::processInfo();
     state.0 = process_info.isLowPowerModeEnabled();
+}
+
+#[instrument(level = Level::DEBUG, skip_all)]
+pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut commands: Commands) {
+    for event in messages.read() {
+        let Event::WindowCreated { element } = event else {
+            continue;
+        };
+
+        if let Ok(window) = WindowOS::new(element)
+            .inspect_err(|err| {
+                trace!("not adding window {element:?}: {err}");
+            })
+            .map(|window| Window::new(Box::new(window)))
+        {
+            commands.trigger(SpawnWindowTrigger(vec![window]));
+        }
+    }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,5 +1,5 @@
 use bevy::app::AppExit;
-use bevy::ecs::change_detection::DetectChanges;
+use bevy::ecs::change_detection::{DetectChanges, Ref};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
@@ -950,15 +950,6 @@ pub(super) fn update_overlays(
     );
 }
 
-#[instrument(level = Level::TRACE, skip_all)]
-pub(super) fn commit_window_position(
-    mut moved_windows: Populated<(&mut Window, &Position), Changed<Position>>,
-) {
-    moved_windows
-        .par_iter_mut()
-        .for_each(|(mut window, position)| window.reposition(position.0));
-}
-
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn verify_window_position(
@@ -981,19 +972,22 @@ pub(super) fn verify_window_position(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
-pub(super) fn commit_window_size(
+pub(super) fn commit_window_frames(
     active_display: ActiveDisplay,
-    mut resized_windows: Populated<(&mut Window, &Bounds, &mut WidthRatio), Changed<Bounds>>,
+    mut framed_windows: Populated<
+        (&mut Window, Ref<Position>, Ref<Bounds>, &mut WidthRatio),
+        Or<(Changed<Position>, Changed<Bounds>)>,
+    >,
 ) {
     let display_bounds = active_display.bounds();
-    resized_windows
-        .par_iter_mut()
-        .for_each(|(mut window, size, mut width_ratio)| {
-            width_ratio.0 = f64::from(size.0.x) / f64::from(display_bounds.width());
-            window.resize(size.0);
-        });
+    for (mut window, position, bounds, mut width_ratio) in &mut framed_windows {
+        if bounds.is_changed() {
+            width_ratio.0 = f64::from(bounds.0.x) / f64::from(display_bounds.width());
+        }
+        window.set_frame(position.0, bounds.0);
+    }
 }
 
 /// Restores user-visible window state before Paneru shuts down: clears any

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -3,7 +3,7 @@ use bevy::ecs::change_detection::{DetectChanges, Ref};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::message::{MessageReader, MessageWriter};
-use bevy::ecs::query::{Changed, Has, Or, With, Without};
+use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::system::{
     Commands, Local, NonSend, NonSendMut, ParallelCommands, Populated, Query, Res, ResMut, Single,
 };
@@ -30,7 +30,7 @@ use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, Initializing,
     LocateDockTrigger, LowPowerMode, MissionControlActive, Position, RestoreWindowState, Scrolling,
     SelectedVirtualMarker, SendMessageTrigger, Unmanaged, WidthRatio, WindowProperties,
-    focus_entity,
+    focus_entity, reposition_entity, reshuffle_around,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -994,6 +994,7 @@ pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>
     state.0 = process_info.isLowPowerModeEnabled();
 }
 
+#[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut commands: Commands) {
     for event in messages.read() {
@@ -1008,6 +1009,54 @@ pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut comm
             .map(|window| Window::new(Box::new(window)))
         {
             commands.trigger(SpawnWindowTrigger(vec![window]));
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn detect_tabbed_windows(
+    created: Populated<(Entity, &Bounds, &ChildOf), Added<Window>>,
+    windows: Query<(Entity, &Window, &Position, &Bounds, &ChildOf), With<Window>>,
+    apps: Query<Entity, With<Application>>,
+    mut workspaces: Query<&mut LayoutStrip>,
+    window_manager: Res<WindowManager>,
+    mut commands: Commands,
+) {
+    for (entity, Bounds(bounds), child) in created {
+        let Ok(app_entity) = apps.get(child.parent()) else {
+            continue;
+        };
+
+        // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
+        // window from the same application. If so, it's likely a native tab.
+        let tabbed = windows.iter().find_map(
+            |(leader, window, Position(leader_position), Bounds(leader_bounds), parent)| {
+                (leader != entity && parent.parent() == app_entity && leader_bounds.x == bounds.x)
+                    .then_some((leader, window.id(), leader_position))
+            },
+        );
+
+        // Tab detection heuristics:
+        // If the two windows are overlapping, and the previous window is suddenly not visible on
+        // the scren - it's a tab stack.
+        if let Some((leader, leader_id, leader_position)) = tabbed
+            && window_manager
+                .windows_on_screen()
+                .is_some_and(|ids| !ids.contains(&leader_id))
+            && let Some(mut strip) = workspaces.iter_mut().find(|strip| strip.contains(entity))
+            && strip.contains(leader)
+        {
+            debug!("Tabbed window detected: adding {entity} to leader {leader}");
+            if strip
+                .convert_to_tabs(leader, entity)
+                .inspect_err(|err| error!("Failed to convert to tabs: {err}"))
+                .is_ok()
+            {
+                // Reposition and reshuffle - otherwise the window will attempt to where the new
+                // tab was previously added.
+                reposition_entity(entity, *leader_position, &mut commands);
+                reshuffle_around(entity, &mut commands);
+            }
         }
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -547,25 +547,27 @@ pub(super) fn animate_resize_entities(
         });
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub(super) fn pump_events(
     mut exit: MessageWriter<AppExit>,
     mut messages: MessageWriter<Event>,
     low_power_mode: Option<Res<LowPowerMode>>,
     incoming_events: Option<NonSend<Receiver<Event>>>,
     platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
+    repositioning: Query<(), With<RepositionMarker>>,
+    resizing: Query<(), With<ResizeMarker>>,
+    scrolling: Query<(), With<Scrolling>>,
+    flash_messages: Query<(), With<FlashMessage>>,
     mut timeout: Local<u32>,
 ) {
-    const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
-    const LOOP_MAX_TIMEOUT_MS: u32 = 50;
-    const LOOP_TIMEOUT_STEP: u32 = 1;
-
     let Some((ref mut platform, incoming_events)) = platform.zip(incoming_events) else {
         // No platform interface or incoming event pipe - probably executing in a unit test.
         return;
     };
 
     platform.pump_cocoa_event_loop(f64::from(*timeout) / 1000.0);
+    let mut received_events = Vec::new();
+    let mut pending_mouse = None;
     loop {
         // Repeatedly drain the events until timeout.
         match incoming_events.recv_timeout(Duration::from_millis(1)) {
@@ -574,15 +576,25 @@ pub(super) fn pump_events(
                 break;
             }
             Ok(event) => {
-                messages.write(event);
+                if matches!(event, Event::MouseMoved { .. }) {
+                    pending_mouse = Some(event);
+                } else {
+                    received_events.extend(pending_mouse.take());
+                    received_events.push(event);
+                }
                 *timeout = LOOP_TIMEOUT_STEP;
             }
             Err(RecvTimeoutError::Timeout) => {
-                let timeout_limit = if low_power_mode.is_some_and(|low_power| low_power.0) {
-                    LOOP_MAX_TIMEOUT_LOWPOWER_MS
-                } else {
-                    LOOP_MAX_TIMEOUT_MS
-                };
+                received_events.extend(pending_mouse.take());
+                messages.write_batch(received_events);
+                let frame_active = !repositioning.is_empty()
+                    || !resizing.is_empty()
+                    || !scrolling.is_empty()
+                    || !flash_messages.is_empty();
+                let timeout_limit = pump_timeout_limit(
+                    low_power_mode.is_some_and(|low_power| low_power.0),
+                    frame_active,
+                );
                 *timeout = timeout.min(timeout_limit) + LOOP_TIMEOUT_STEP;
                 break;
             }
@@ -1058,5 +1070,50 @@ pub(crate) fn detect_tabbed_windows(
                 reshuffle_around(entity, &mut commands);
             }
         }
+    }
+}
+
+const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
+
+const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
+
+const LOOP_MAX_TIMEOUT_MS: u32 = 50;
+
+const LOOP_TIMEOUT_STEP: u32 = 1;
+
+fn pump_timeout_limit(low_power_active: bool, frame_active: bool) -> u32 {
+    if frame_active {
+        LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+    } else if low_power_active {
+        LOOP_MAX_TIMEOUT_LOWPOWER_MS
+    } else {
+        LOOP_MAX_TIMEOUT_MS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pump_timeout_limit_uses_frame_active_cap_for_visible_work() {
+        assert_eq!(pump_timeout_limit(false, false), LOOP_MAX_TIMEOUT_MS);
+        assert_eq!(
+            pump_timeout_limit(true, false),
+            LOOP_MAX_TIMEOUT_LOWPOWER_MS
+        );
+        assert_eq!(
+            pump_timeout_limit(false, true),
+            LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+        );
+        assert_eq!(
+            pump_timeout_limit(true, true),
+            LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
+        );
+    }
+
+    #[test]
+    fn low_power_idle_timeout_stays_below_interactive_latency_budget() {
+        assert!(pump_timeout_limit(true, false) <= 50);
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -19,9 +19,8 @@ use std::time::Duration;
 use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
-    ActiveDisplayMarker, BProcess, ExistingMarker, FreshMarker, PollForNotifications,
-    RepositionMarker, ResizeMarker, RetryFrontSwitch, SpawnWindowTrigger, Timeout,
-    VerifyWindowPosition,
+    ActiveDisplayMarker, BProcess, ExistingMarker, FreshMarker, RepositionMarker, ResizeMarker,
+    RetryFrontSwitch, SpawnWindowTrigger, Timeout, VerifyWindowPosition,
 };
 
 use crate::config::{Config, decorations::BorderRadiusOption};
@@ -41,50 +40,6 @@ use crate::overlay::{FlashMessageManager, OverlayManager};
 use crate::platform::{PlatformCallbacks, WinID};
 
 const ANIAMTE_SNAP_THRESHOLD: f32 = 5.0;
-
-/// Processes a single incoming `Event`. It dispatches various event types to the `WindowManager` or other internal handlers.
-/// This system reads `Event` messages and triggers appropriate Bevy events or modifies resources based on the event type.
-///
-/// # Arguments
-///
-/// * `messages` - A `MessageReader` for incoming `Event` messages.
-/// * `broken_notifications` - A mutable `ResMut` for the `PollForNotifications` resource, used to manage polling state.
-/// * `commands` - Bevy commands to trigger events or insert resources.
-#[allow(clippy::needless_pass_by_value)]
-pub(super) fn dispatch_toplevel_triggers(
-    mut messages: MessageReader<Event>,
-    broken_notifications: Option<Res<PollForNotifications>>,
-    mut commands: Commands,
-) {
-    for event in messages.read() {
-        match event {
-            Event::SpaceChanged if broken_notifications.is_some() => {
-                info!(
-                    "Workspace and display notifications arriving correctly. Disabling the polling.",
-                );
-                commands.remove_resource::<PollForNotifications>();
-            }
-
-            Event::WindowTitleChanged { window_id } => {
-                trace!("WindowTitleChanged: {window_id:?}");
-            }
-            Event::MenuClosed { window_id } => {
-                trace!("MenuClosed event: {window_id:?}");
-            }
-            Event::DisplayResized { display_id } => {
-                debug!("Display Resized: {display_id:?}");
-            }
-            Event::DisplayConfigured { display_id } => {
-                debug!("Display Configured: {display_id:?}");
-            }
-            Event::SystemWoke { msg } => {
-                debug!("system woke: {msg:?}");
-            }
-
-            _ => (),
-        }
-    }
-}
 
 /// Gathers all present displays and spawns them as entities in the Bevy world.
 /// The currently active display (identified by `window_manager.active_display_id()`) is marked with `ActiveDisplayMarker`.
@@ -485,49 +440,6 @@ pub(super) fn retry_front_switch(
         }
         // Otherwise, let timeout_ticker handle expiry.
     }
-}
-
-/// Periodically checks for displays added and removed, as well as changes in the active display.
-/// This system acts as a workaround for inconsistent display change notifications on some macOS versions.
-/// It uses `ThrottledSystem` to limit its execution frequency.
-#[allow(clippy::needless_pass_by_value)]
-pub(super) fn display_changes_watcher(
-    displays: Query<(&Display, Has<ActiveDisplayMarker>)>,
-    window_manager: Res<WindowManager>,
-    mut commands: Commands,
-) {
-    let Ok(current_display_id) = window_manager.active_display_id() else {
-        return;
-    };
-    let found = displays
-        .iter()
-        .find(|(display, _)| display.id() == current_display_id);
-    if let Some((_, active)) = found {
-        if active {
-            return;
-        }
-        debug!("detected dislay change from {current_display_id}.");
-        commands.trigger(SendMessageTrigger(Event::DisplayChanged));
-    } else {
-        debug!("new display {current_display_id} detected.");
-        commands.trigger(SendMessageTrigger(Event::DisplayAdded {
-            display_id: current_display_id,
-        }));
-    }
-
-    let present_displays = window_manager.present_displays();
-    displays.iter().for_each(|(display, _)| {
-        if !present_displays
-            .iter()
-            .any(|(present_display, _)| present_display.id() == display.id())
-        {
-            let display_id = display.id();
-            debug!("detected removal of display {display_id}");
-            commands.trigger(SendMessageTrigger(Event::DisplayRemoved {
-                display_id: display.id(),
-            }));
-        }
-    });
 }
 
 /// Animates window movement.

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -660,6 +660,11 @@ pub(super) fn window_resized_update_frame(
             // and let the tab sync/layout systems propagate the new size.
             continue;
         }
+        if active_strip.tabbed(entity) {
+            // Native tabs share a single layout slot. Keep the strip anchored
+            // and let the tab sync/layout systems propagate the new size.
+            continue;
+        }
 
         if old_frame.min.x != new_frame.min.x {
             let shift = (old_frame.size() - new_frame.size()).with_y(0);
@@ -1040,18 +1045,17 @@ pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut comm
 
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn detect_tabbed_windows(
-    created: Populated<(Entity, &Bounds, &ChildOf), Added<Window>>,
+    created: Populated<(Entity, &Window, &Bounds, &ChildOf), Added<Window>>,
     windows: Query<(Entity, &Window, &Position, &Bounds, &ChildOf), With<Window>>,
     apps: Query<Entity, With<Application>>,
     mut workspaces: Query<&mut LayoutStrip>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
-    for (entity, Bounds(bounds), child) in created {
+    for (entity, new_window, Bounds(bounds), child) in created {
         let Ok(app_entity) = apps.get(child.parent()) else {
             continue;
         };
-
         // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
         // window from the same application. If so, it's likely a native tab.
         let tabbed = windows.iter().find_map(
@@ -1062,12 +1066,14 @@ pub(crate) fn detect_tabbed_windows(
         );
 
         // Tab detection heuristics:
-        // If the two windows are overlapping, and the previous window is suddenly not visible on
-        // the scren - it's a tab stack.
+        // If a new native-tabbed window overlaps an existing same-app window,
+        // or the previous same-app window disappeared from the on-screen list,
+        // it belongs to that window's native tab group.
         if let Some((leader, leader_id, leader_position)) = tabbed
-            && window_manager
-                .windows_on_screen()
-                .is_some_and(|ids| !ids.contains(&leader_id))
+            && (new_window.native_tab_count() >= 2
+                || window_manager
+                    .windows_on_screen()
+                    .is_some_and(|ids| !ids.contains(&leader_id)))
             && let Some(mut strip) = workspaces.iter_mut().find(|strip| strip.contains(entity))
             && strip.contains(leader)
         {

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -19,7 +19,7 @@ use super::{
     PreviousManagedStrip, RetryFrontSwitch, SelectedVirtualMarker, SpawnWindowTrigger,
     StrayFocusEvent, SystemTheme, Timeout, Unmanaged,
 };
-use crate::config::{Config, WindowParams};
+use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
@@ -878,7 +878,7 @@ pub(super) fn spawn_window_trigger(
         apply_window_defaults(
             &mut window,
             &mut active_display,
-            &properties.params,
+            &properties,
             &config,
             initializing.is_some(),
         );
@@ -936,31 +936,14 @@ pub(super) fn spawn_window_trigger(
 fn apply_window_defaults(
     window: &mut Window,
     active_display: &mut ActiveDisplayMut,
-    properties: &[WindowParams],
+    properties: &WindowProperties,
     config: &Config,
     initializing: bool,
 ) {
-    let floating = properties
-        .iter()
-        .find_map(|props| props.floating)
-        .unwrap_or(false);
-
     // Do not add padding to floating windows.
-    if let Some(padding) = properties.iter().find_map(|props| props.vertical_padding)
-        && !floating
-    {
-        window.set_padding(WindowPadding::Vertical(padding.clamp(0, 50)));
-    }
-    if let Some(padding) = properties.iter().find_map(|props| props.horizontal_padding)
-        && !floating
-    {
-        window.set_padding(WindowPadding::Horizontal(padding.clamp(0, 50)));
-    }
-    if floating {
+    if properties.floating() {
         // Skip grid_ratios during init: we don't know this window's display.
-        if !initializing
-            && let Some((rx, ry, rw, rh)) = properties.iter().find_map(WindowParams::grid_ratios)
-        {
+        if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
             let bounds = active_display.bounds();
             let x = (f64::from(bounds.width()) * rx) as i32;
             let y = (f64::from(bounds.height()) * ry) as i32;
@@ -972,11 +955,16 @@ fn apply_window_defaults(
         return;
     }
 
+    let vpadding = properties.vertical_padding();
+    let hpadding = properties.horizontal_padding();
+    window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
+    window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+
     // Apply configured width AFTER update_frame so it isn't overwritten.
     // Use padded display width (matching window_resize command behavior).
     // Safe during init: this only resizes, it doesn't reposition, so a
     // window on an inactive display stays put.
-    if let Some(width) = properties.iter().find_map(|props| props.width) {
+    if let Some(width) = properties.width_ratio() {
         _ = window.update_frame().inspect_err(|err| error!("{err}"));
         let bounds = active_display.bounds();
         let (_, pad_right, _, pad_left) = config.edge_padding();

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -819,14 +819,13 @@ fn give_away_focus(
 /// * `active_display` - A query for the active display.
 /// * `main_cid` - The main connection ID resource.
 /// * `commands` - Bevy commands to manage components and trigger events.
-#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+#[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn spawn_window_trigger(
     mut trigger: On<SpawnWindowTrigger>,
-    windows: Windows,
+    windows: Query<(&Window, Entity, &ChildOf)>,
     mut apps: Query<(Entity, &mut Application)>,
-    mut active_display: ActiveDisplayMut,
-    config: Res<Config>,
+    active_display: ActiveDisplayMut,
     initializing: Option<Res<Initializing>>,
     restore: Option<Res<crate::ecs::restore::SessionRestore>>,
     mut commands: Commands,
@@ -836,7 +835,7 @@ pub(super) fn spawn_window_trigger(
     while let Some(mut window) = new_windows.pop() {
         let window_id = window.id();
 
-        if windows.find(window_id).is_some() {
+        if windows.iter().any(|window| window.0.id() == window_id) {
             continue;
         }
 
@@ -870,19 +869,6 @@ pub(super) fn spawn_window_trigger(
             window.title().unwrap_or_default()
         );
 
-        let properties = WindowProperties::new(&app, &window, &config);
-        if !properties.params.is_empty() {
-            debug!("Applying window properties for '{}'", window.id());
-        }
-
-        apply_window_defaults(
-            &mut window,
-            &mut active_display,
-            &properties,
-            &config,
-            initializing.is_some(),
-        );
-
         // update_frame expands the OS rect by the per-window padding, so calling it *after*
         // set_padding produces the correct logical frame for the ECS components below.
         let Ok(frame) = window.update_frame().inspect_err(|err| error!("{err}")) else {
@@ -894,37 +880,16 @@ pub(super) fn spawn_window_trigger(
             WidthRatio(f64::from(frame.width()) / f64::from(active_display.bounds().width()));
         let layout_position = LayoutPosition::default();
 
-        // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
-        // window from the same application. If so, it's likely a native tab.
-        let tabbed_entity = windows
-            .all_iter()
-            .find_map(|(existing_window, entity, parent)| {
-                (parent.parent() == app_entity && existing_window.frame() == window.frame())
-                    .then_some(entity)
-            });
-
         // Insert the window into the internal Bevy state.
         // This insertion triggers window attributes observer.
-        let entity = commands
-            .spawn((
-                position,
-                bounds,
-                width_ratio,
-                window,
-                layout_position,
-                ChildOf(app_entity),
-            ))
-            .id();
-
-        if let Some(leader) = tabbed_entity {
-            debug!(
-                "Adding window {window_id} as a tab follower for leader {leader:?} (overlapping frame)"
-            );
-            let layout_strip = active_display.active_strip();
-            _ = layout_strip
-                .convert_to_tabs(leader, entity)
-                .inspect_err(|err| error!("Failed to convert to tabs: {err}"));
-        }
+        commands.spawn((
+            position,
+            bounds,
+            width_ratio,
+            window,
+            layout_position,
+            ChildOf(app_entity),
+        ));
     }
 
     if initializing.is_none() && restore.is_some() {
@@ -932,55 +897,73 @@ pub(super) fn spawn_window_trigger(
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
-fn apply_window_defaults(
-    window: &mut Window,
-    active_display: &mut ActiveDisplayMut,
-    properties: &WindowProperties,
-    config: &Config,
-    initializing: bool,
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn apply_window_defaults(
+    added: Populated<(&mut Window, Entity, &ChildOf), Added<Window>>,
+    apps: Query<(Entity, &Application)>,
+    active_display: ActiveDisplay,
+    config: Res<Config>,
+    initializing: Option<Res<Initializing>>,
 ) {
-    // Do not add padding to floating windows.
-    if properties.floating() {
-        // Skip grid_ratios during init: we don't know this window's display.
-        if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
-            let bounds = active_display.bounds();
-            let x = (f64::from(bounds.width()) * rx) as i32;
-            let y = (f64::from(bounds.height()) * ry) as i32;
-            let w = (f64::from(bounds.width()) * rw) as i32;
-            let h = (f64::from(bounds.height()) * rh) as i32;
-            window.reposition(Origin::new(x, y));
-            window.resize(Size::new(w, h));
+    for (ref mut window, entity, child) in added {
+        if active_display.active_strip().tabbed(entity) {
+            debug!("Ignoring tabbed {entity} attributes.");
+            continue;
         }
-        return;
-    }
 
-    let vpadding = properties.vertical_padding();
-    let hpadding = properties.horizontal_padding();
-    window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
-    window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+        let Ok((_, app)) = apps.get(child.parent()) else {
+            continue;
+        };
 
-    // Apply configured width AFTER update_frame so it isn't overwritten.
-    // Use padded display width (matching window_resize command behavior).
-    // Safe during init: this only resizes, it doesn't reposition, so a
-    // window on an inactive display stays put.
-    if let Some(width) = properties.width_ratio() {
-        _ = window.update_frame().inspect_err(|err| error!("{err}"));
-        let bounds = active_display.bounds();
-        let (_, pad_right, _, pad_left) = config.edge_padding();
-        let padded_width = bounds.width() - pad_left - pad_right;
-        let new_width = (f64::from(padded_width) * width).round() as i32;
-        let height = window.frame().height();
-        window.resize(Size::new(new_width, height));
-        // Re-read the actual OS size: the app may enforce a minimum width
-        // that differs from our request.
-        _ = window.update_frame().inspect_err(|err| error!("{err}"));
+        let properties = WindowProperties::new(app, window, &config);
+        if !properties.params.is_empty() {
+            debug!("Applying window defaults for '{}'", window.id());
+        }
+
+        let initializing = initializing.is_some();
+        let floating = properties.floating();
+
+        // Do not add padding to floating windows.
+        if floating {
+            // Skip grid_ratios during init: we don't know this window's display.
+            if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
+                let bounds = active_display.bounds();
+                let x = (f64::from(bounds.width()) * rx) as i32;
+                let y = (f64::from(bounds.height()) * ry) as i32;
+                let w = (f64::from(bounds.width()) * rw) as i32;
+                let h = (f64::from(bounds.height()) * rh) as i32;
+                window.reposition(Origin::new(x, y));
+                window.resize(Size::new(w, h));
+            }
+            continue;
+        }
+        let vpadding = properties.vertical_padding();
+        let hpadding = properties.horizontal_padding();
+        window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
+        window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+
+        // Apply configured width AFTER update_frame so it isn't overwritten.
+        // Use padded display width (matching window_resize command behavior).
+        // Safe during init: this only resizes, it doesn't reposition, so a
+        // window on an inactive display stays put.
+        if let Some(width) = properties.width_ratio() {
+            _ = window.update_frame().inspect_err(|err| error!("{err}"));
+            let bounds = active_display.bounds();
+            let (_, pad_right, _, pad_left) = config.edge_padding();
+            let padded_width = bounds.width() - pad_left - pad_right;
+            let new_width = (f64::from(padded_width) * width).round() as i32;
+            let height = window.frame().height();
+            window.resize(Size::new(new_width, height));
+            // Re-read the actual OS size: the app may enforce a minimum width
+            // that differs from our request.
+            _ = window.update_frame().inspect_err(|err| error!("{err}"));
+        }
     }
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
-pub(super) fn apply_window_properties(
+pub(super) fn apply_window_positions(
     added: Populated<Entity, Added<Window>>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     windows: Windows,

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -899,26 +899,19 @@ pub(super) fn spawn_window_trigger(
 
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn apply_window_defaults(
-    added: Populated<(&mut Window, Entity, &ChildOf), Added<Window>>,
+    added: Populated<(&mut Window, &mut Position, &mut Bounds, &ChildOf), Added<Window>>,
     apps: Query<(Entity, &Application)>,
     active_display: ActiveDisplay,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
 ) {
-    for (ref mut window, entity, child) in added {
-        if active_display.active_strip().tabbed(entity) {
-            debug!("Ignoring tabbed {entity} attributes.");
-            continue;
-        }
-
+    for (ref mut window, mut position, mut bounds, child) in added {
         let Ok((_, app)) = apps.get(child.parent()) else {
             continue;
         };
 
         let properties = WindowProperties::new(app, window, &config);
-        if !properties.params.is_empty() {
-            debug!("Applying window defaults for '{}'", window.id());
-        }
+        debug!("Applying window defaults for '{}'", window.id());
 
         let initializing = initializing.is_some();
         let floating = properties.floating();
@@ -941,6 +934,10 @@ pub(super) fn apply_window_defaults(
         let hpadding = properties.horizontal_padding();
         window.set_padding(WindowPadding::Vertical(vpadding.clamp(0, 50)));
         window.set_padding(WindowPadding::Horizontal(hpadding.clamp(0, 50)));
+        if let Ok(frame) = window.update_frame() {
+            position.0 = frame.min;
+            bounds.0 = frame.size();
+        }
 
         // Apply configured width AFTER update_frame so it isn't overwritten.
         // Use padded display width (matching window_resize command behavior).

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -42,6 +42,43 @@ fn update_passthrough(window: &Window, app: &Application, config: &Config) {
     crate::platform::input::set_focused_passthrough(properties.passthrough_keys());
 }
 
+fn native_tab_frames_match(a: IRect, b: IRect) -> bool {
+    const MIN_OVERLAP_PERCENT: i64 = 90;
+
+    if a.width() <= 0 || a.height() <= 0 || b.width() <= 0 || b.height() <= 0 {
+        return false;
+    }
+
+    let overlap = a.intersect(b);
+    let overlap_width = i64::from(overlap.width().max(0));
+    let overlap_height = i64::from(overlap.height().max(0));
+    let overlap_area = overlap_width * overlap_height;
+    let a_area = i64::from(a.width()) * i64::from(a.height());
+    let b_area = i64::from(b.width()) * i64::from(b.height());
+    let min_area = a_area.min(b_area);
+
+    overlap_area * 100 >= min_area * MIN_OVERLAP_PERCENT
+}
+
+fn native_tab_leader(
+    strip: &LayoutStrip,
+    entity: Entity,
+    parent: Entity,
+    frame: IRect,
+    windows: &Windows,
+) -> Option<Entity> {
+    strip.all_windows().into_iter().find(|candidate| {
+        *candidate != entity
+            && windows
+                .get(*candidate)
+                .and_then(|candidate_window| windows.find_parent(candidate_window.id()))
+                .is_some_and(|(_, _, candidate_parent)| candidate_parent == parent)
+            && windows
+                .frame(*candidate)
+                .is_some_and(|candidate_frame| native_tab_frames_match(frame, candidate_frame))
+    })
+}
+
 /// Handles the event when an application switches to the front. It updates the focused window and PSN.
 ///
 /// # Arguments
@@ -245,10 +282,12 @@ pub(super) fn window_focused_trigger(
         // Also reactivate the owning virtual strip before treating duplicate
         // focus as a no-op; the focus marker can be stale on a hidden strip.
         let mut owner = None;
+        let mut focused_tabbed = false;
         for (strip_entity, mut strip, active) in &mut workspaces {
             if !strip.contains(entity) {
                 continue;
             }
+            focused_tabbed = strip.tabbed(entity);
             if let Ok(index) = strip.index_of(entity)
                 && let Some(column) = strip.get_column_mut(index)
             {
@@ -268,7 +307,7 @@ pub(super) fn window_focused_trigger(
         }
 
         if already_focused {
-            if !global_state.skip_reshuffle() && !global_state.initializing() {
+            if !focused_tabbed && !global_state.skip_reshuffle() && !global_state.initializing() {
                 reshuffle_around(entity, &mut commands);
             }
             continue;
@@ -1014,22 +1053,38 @@ pub(super) fn apply_window_positions(
             continue;
         }
 
-        // During startup, the window is already inserted into some strip.
-        let allready_inserted = workspaces
-            .iter_mut()
-            .find_map(|(strip, _)| strip.contains(entity).then_some(strip));
+        // During startup, the window may already be inserted into some strip.
+        let already_inserted = workspaces.iter().any(|(strip, _)| strip.contains(entity));
         let properties = WindowProperties::new(app, window, &config);
 
         if properties.floating() {
             // Avoid managing window if it's floating.
             commands.entity(entity).try_insert(Unmanaged::Floating);
-            if let Some(mut strip) = allready_inserted {
-                strip.remove(entity);
+            if already_inserted {
+                for (mut strip, _) in &mut workspaces {
+                    strip.remove(entity);
+                }
             }
             continue;
         }
 
-        if allready_inserted.is_none()
+        let mut inserted_as_tab = false;
+        if !already_inserted && let Some(frame) = windows.frame(entity) {
+            for (mut strip, _) in &mut workspaces {
+                let Some(leader) = native_tab_leader(&strip, entity, parent, frame, &windows)
+                else {
+                    continue;
+                };
+                if strip.convert_to_tabs(leader, entity).is_ok() {
+                    debug!("New window {entity} grouped with native tab leader {leader}");
+                    inserted_as_tab = true;
+                    break;
+                }
+            }
+        }
+
+        if !already_inserted
+            && !inserted_as_tab
             && let Some(mut strip) = workspaces
                 .iter_mut()
                 .find_map(|(strip, active)| active.then_some(strip))

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -25,8 +25,8 @@ use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, LocateDockTrigger,
-    Position, RestoreWindowState, Scrolling, SendMessageTrigger, WidthRatio, WindowProperties,
-    focus_entity, reposition_entity, reshuffle_around, resize_entity,
+    Position, RestoreWindowState, Scrolling, SendMessageTrigger, VerifyWindowPosition, WidthRatio,
+    WindowProperties, focus_entity, reposition_entity, reshuffle_around, resize_entity,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -182,6 +182,7 @@ pub(super) fn window_focused_trigger(
     windows: Windows,
     mut workspaces: Query<(Entity, &mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     config: Res<Config>,
+    global_state: GlobalState,
     mut commands: Commands,
 ) {
     const STRAY_FOCUS_RETRY_SEC: u64 = 2;
@@ -229,6 +230,17 @@ pub(super) fn window_focused_trigger(
             continue;
         }
 
+        if matches!(
+            windows.get_managed(entity),
+            Some((_, _, Some(Unmanaged::Hidden)))
+        ) {
+            if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                entity_commands.try_remove::<Unmanaged>();
+            }
+            commands.trigger(SendMessageTrigger(Event::WindowFocused { window_id }));
+            continue;
+        }
+
         // Handle tab switching: if the focused window is a tab, make it the leader.
         // Also reactivate the owning virtual strip before treating duplicate
         // focus as a no-op; the focus marker can be stale on a hidden strip.
@@ -256,6 +268,9 @@ pub(super) fn window_focused_trigger(
         }
 
         if already_focused {
+            if !global_state.skip_reshuffle() && !global_state.initializing() {
+                reshuffle_around(entity, &mut commands);
+            }
             continue;
         }
 
@@ -698,7 +713,13 @@ pub(super) fn window_managed_trigger(
         }
     }
 
-    commands.entity(entity).try_remove::<PreviousManagedStrip>();
+    if let Some(origin) = windows.origin(entity) {
+        reposition_entity(entity, origin, &mut commands);
+    }
+    commands
+        .entity(entity)
+        .try_insert(VerifyWindowPosition::default())
+        .try_remove::<PreviousManagedStrip>();
     reshuffle_around(entity, &mut commands);
 }
 

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -869,26 +869,22 @@ pub(super) fn spawn_window_trigger(
             continue;
         };
 
-        debug!(
-            "created {} title: {} role: {} subrole: {} element: {}",
-            window_id,
-            window.title().unwrap_or_default(),
-            window.role().unwrap_or_default(),
-            window.subrole().unwrap_or_default(),
-            window
+        if tracing::enabled!(Level::DEBUG) {
+            let title = window.title().unwrap_or_default();
+            let role = window.role().unwrap_or_default();
+            let subrole = window.subrole().unwrap_or_default();
+            let element = window
                 .element()
                 .map(|element| format!("{element}"))
-                .unwrap_or_default(),
-        );
+                .unwrap_or_default();
+            debug!(
+                "created {window_id} title: {title} role: {role} subrole: {subrole} element: {element}",
+            );
+        }
 
         if app.observe_window(&window).is_err() {
             warn!("Error observing window {window_id}.");
         }
-        debug!(
-            "window {} title: {}",
-            window_id,
-            window.title().unwrap_or_default()
-        );
 
         // update_frame expands the OS rect by the per-window padding, so calling it *after*
         // set_padding produces the correct logical frame for the ECS components below.

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -69,13 +69,15 @@ fn native_tab_leader(
 ) -> Option<Entity> {
     strip.all_windows().into_iter().find(|candidate| {
         *candidate != entity
-            && windows
-                .get(*candidate)
-                .and_then(|candidate_window| windows.find_parent(candidate_window.id()))
-                .is_some_and(|(_, _, candidate_parent)| candidate_parent == parent)
-            && windows
-                .frame(*candidate)
-                .is_some_and(|candidate_frame| native_tab_frames_match(frame, candidate_frame))
+            && windows.get(*candidate).is_some_and(|candidate_window| {
+                let candidate_id = candidate_window.id();
+                windows
+                    .find_parent(candidate_id)
+                    .is_some_and(|(_, _, candidate_parent)| candidate_parent == parent)
+                    && windows.frame(*candidate).is_some_and(|candidate_frame| {
+                        native_tab_frames_match(frame, candidate_frame)
+                    })
+            })
     })
 }
 
@@ -640,6 +642,12 @@ pub(super) fn window_minimized_trigger(
         let display_bounds = active_display.bounds();
 
         for (mut strip, active) in workspaces {
+            let has_managed_tab_sibling = strip.tab_group(entity).is_some_and(|tab_group| {
+                tab_group.iter().any(|sibling| {
+                    *sibling != entity
+                        && matches!(windows.get_managed(*sibling), Some((_, _, None)))
+                })
+            });
             if active {
                 give_away_focus(
                     entity,
@@ -649,6 +657,9 @@ pub(super) fn window_minimized_trigger(
                     &mut config,
                     &mut commands,
                 );
+            }
+            if has_managed_tab_sibling {
+                continue;
             }
             if strip.contains(entity) {
                 if let Ok(index) = strip.index_of(entity) {
@@ -682,6 +693,11 @@ pub(super) fn window_managed_trigger(
         return;
     }
     let entity = trigger.event().entity;
+
+    if workspaces.iter().any(|(strip, _)| strip.contains(entity)) {
+        commands.entity(entity).try_remove::<PreviousManagedStrip>();
+        return;
+    }
 
     debug!("Entity {entity} is managed again.");
     let (display, dock) = *active_display;
@@ -1069,7 +1085,10 @@ pub(super) fn apply_window_positions(
         }
 
         let mut inserted_as_tab = false;
-        if !already_inserted && let Some(frame) = windows.frame(entity) {
+        if !already_inserted
+            && window.native_tab_count() >= 2
+            && let Some(frame) = windows.frame(entity)
+        {
             for (mut strip, _) in &mut workspaces {
                 let Some(leader) = native_tab_leader(&strip, entity, parent, frame, &windows)
                 else {

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -3,8 +3,8 @@ use bevy::ecs::hierarchy::{ChildOf, Children};
 use bevy::ecs::lifecycle::{Add, Remove};
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
-use bevy::ecs::query::{Has, With};
-use bevy::ecs::system::{Commands, NonSend, NonSendMut, Query, Res, ResMut, Single};
+use bevy::ecs::query::{Added, Has, With};
+use bevy::ecs::system::{Commands, NonSend, NonSendMut, Populated, Query, Res, ResMut, Single};
 use bevy::math::IRect;
 use notify::event::{DataChange, MetadataKind, ModifyKind};
 use notify::{EventKind, Watcher};
@@ -991,10 +991,10 @@ fn apply_window_defaults(
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
-#[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
+#[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn apply_window_properties(
-    trigger: On<Add, Window>,
-    mut active_display: ActiveDisplayMut,
+    added: Populated<Entity, Added<Window>>,
+    mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     windows: Windows,
     apps: Query<&Application>,
     config: Res<Config>,
@@ -1003,81 +1003,94 @@ pub(super) fn apply_window_properties(
     restoration: Option<Res<PaneruState>>,
     mut commands: Commands,
 ) {
-    let entity = trigger.event().entity;
-
-    if active_display.active_strip().tabbed(entity) {
-        debug!("Ignoring tabbed {entity} attributes.");
-        return;
-    }
-
-    let Some((window, _, parent)) = windows
-        .get(entity)
-        .and_then(|window| windows.find_parent(window.id()))
-    else {
-        return;
-    };
-    let Ok(app) = apps.get(parent) else {
-        return;
-    };
-
-    if crate::ecs::restore::matches_startup_restore_state(
-        window,
-        app,
-        restore.as_deref(),
-        restoration.as_deref(),
-        &config,
-    ) {
-        return;
-    }
-
-    let properties = WindowProperties::new(app, window, &config);
-
-    if properties.floating() {
-        // Avoid managing window if it's floating.
-        commands.entity(entity).try_insert(Unmanaged::Floating);
-        return;
-    }
-
-    let strip = active_display.active_strip();
-
-    // Attempt inserting the window at a pre-defined position.
-    let insert_at = properties.insertion().map_or_else(
-        || {
-            // Otherwise attempt inserting it after the current focus.
-            let focused_window = windows.focused();
-            // Insert to the right of the currently focused window
-            focused_window
-                .and_then(|(_, entity)| strip.index_of(entity).ok())
-                .and_then(|insert_at| (insert_at + 1 < strip.len()).then_some(insert_at + 1))
-        },
-        Some,
-    );
-
-    debug!("New window adding at {strip}");
-    match insert_at {
-        Some(after) => {
-            debug!("New window inserted at {after}");
-            strip.insert_at(after, entity);
+    for entity in added {
+        if workspaces.iter().any(|(strip, _)| strip.tabbed(entity)) {
+            debug!("Ignoring tabbed {entity} attributes.");
+            continue;
         }
-        None => strip.append(entity),
-    }
 
-    // During init, skip per-window reshuffles. finish_setup does a single
-    // reshuffle after all windows are added.
-    if initializing.is_none() {
-        if properties.dont_focus() {
-            if let Some((focus, prev)) = windows.focused() {
-                debug!(
-                    "Not focusing new window {entity}, keeping focus on '{}'",
-                    focus.title().unwrap_or_default()
-                );
-                focus_entity(prev, true, &mut commands);
+        let Some((window, _, parent)) = windows
+            .get(entity)
+            .and_then(|window| windows.find_parent(window.id()))
+        else {
+            continue;
+        };
+        let Ok(app) = apps.get(parent) else {
+            continue;
+        };
+
+        if crate::ecs::restore::matches_startup_restore_state(
+            window,
+            app,
+            restore.as_deref(),
+            restoration.as_deref(),
+            &config,
+        ) {
+            continue;
+        }
+
+        // During startup, the window is already inserted into some strip.
+        let allready_inserted = workspaces
+            .iter_mut()
+            .find_map(|(strip, _)| strip.contains(entity).then_some(strip));
+        let properties = WindowProperties::new(app, window, &config);
+
+        if properties.floating() {
+            // Avoid managing window if it's floating.
+            commands.entity(entity).try_insert(Unmanaged::Floating);
+            if let Some(mut strip) = allready_inserted {
+                strip.remove(entity);
             }
-        } else {
-            debug!("Synthesizing WindowFocused for newly spawned window {entity}");
-            commands.trigger(SendMessageTrigger(Event::WindowFocused {
-                window_id: window.id(),
-            }));
+            continue;
+        }
+
+        if allready_inserted.is_none()
+            && let Some(mut strip) = workspaces
+                .iter_mut()
+                .find_map(|(strip, active)| active.then_some(strip))
+        {
+            // Attempt inserting the window at a pre-defined position.
+            let insert_at = properties.insertion().map_or_else(
+                || {
+                    // Otherwise attempt inserting it after the current focus.
+                    let focused_window = windows.focused();
+                    // Insert to the right of the currently focused window
+                    focused_window
+                        .and_then(|(_, entity)| strip.index_of(entity).ok())
+                        .and_then(|insert_at| {
+                            (insert_at + 1 < strip.len()).then_some(insert_at + 1)
+                        })
+                },
+                Some,
+            );
+
+            debug!("New window {entity} adding at {}", *strip);
+            match insert_at {
+                Some(after) => {
+                    debug!("New window inserted at {after}");
+                    strip.insert_at(after, entity);
+                }
+                None => strip.append(entity),
+            }
+        }
+
+        // During init, skip per-window reshuffles. finish_setup does a single
+        // reshuffle after all windows are added.
+        if initializing.is_none() {
+            if properties.dont_focus() {
+                if let Some((focus, prev)) = windows.focused() {
+                    debug!(
+                        "Not focusing new window {entity}, keeping focus on '{}'",
+                        focus.title().unwrap_or_default()
+                    );
+                    focus_entity(prev, true, &mut commands);
+                }
+            } else {
+                debug!("Synthesizing WindowFocused for newly spawned window {entity}");
+                commands.trigger(SendMessageTrigger(Event::WindowFocused {
+                    window_id: window.id(),
+                }));
+            }
         }
     }
 }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -210,6 +210,7 @@ fn detect_moved_windows(
     });
 
     if !unresolved.is_empty() {
+        let unresolved_ids = unresolved.iter().copied().collect::<HashSet<_>>();
         // Retry unresolved window IDs: during startup bruteforce, windows on
         // inactive workspaces may have stale AX attributes (e.g. AXGroup instead
         // of AXWindow).  Now that this workspace is active, re-query each app's
@@ -219,11 +220,11 @@ fn detect_moved_windows(
             .flat_map(|app| {
                 app.window_list()
                     .into_iter()
-                    .filter(|window| unresolved.contains(&window.id()))
+                    .filter(|window| unresolved_ids.contains(&window.id()))
             })
             .collect::<Vec<_>>();
         if retry_windows.is_empty() {
-            for id in unresolved {
+            for id in unresolved_ids {
                 ignored_windows.insert(id);
             }
         } else {

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -70,7 +70,7 @@ impl Plugin for WorkspaceEventsPlugin {
 }
 
 /// Marker component to move a window to a specific virtual index on its current workspace.
-#[derive(Component)]
+#[derive(Clone, Copy, Component)]
 struct VirtualMoveMarker {
     pub target_virtual_index: u32,
     pub move_focus: MoveFocus,
@@ -544,6 +544,19 @@ fn cleanup_selected_space_marker(
     });
 }
 
+fn clear_virtual_move_markers(
+    moving_entities: &[Entity],
+    processed: &mut HashSet<Entity>,
+    commands: &mut Commands,
+) {
+    for moving_entity in moving_entities {
+        processed.insert(*moving_entity);
+        commands
+            .entity(*moving_entity)
+            .remove::<VirtualMoveMarker>();
+    }
+}
+
 #[allow(clippy::needless_pass_by_value)]
 fn handle_virtual_window_moves(
     moved_windows: Populated<(Entity, &VirtualMoveMarker), With<Window>>,
@@ -564,17 +577,17 @@ fn handle_virtual_window_moves(
     };
 
     let (display_entity, active_display) = *active_display;
+    let mut processed = HashSet::new();
     for (window_entity, move_marker) in &moved_windows {
+        if !processed.insert(window_entity) {
+            continue;
+        }
         let moving_entities = workspaces
             .get(source_entity)
             .ok()
             .and_then(|(_, strip, _, _)| strip.tab_group(window_entity))
             .unwrap_or_else(|| vec![window_entity]);
-        for moving_entity in &moving_entities {
-            commands
-                .entity(*moving_entity)
-                .remove::<VirtualMoveMarker>();
-        }
+        clear_virtual_move_markers(&moving_entities, &mut processed, &mut commands);
         let follow = matches!(move_marker.move_focus, MoveFocus::Follow);
 
         let target_idx = move_marker.target_virtual_index;
@@ -800,10 +813,18 @@ fn move_virtual_workspace_bind(
         _ => return,
     };
 
-    commands.entity(focused_entity).insert(VirtualMoveMarker {
+    let move_marker = VirtualMoveMarker {
         target_virtual_index,
         move_focus,
-    });
+    };
+
+    let moving_entities = active_display
+        .active_strip()
+        .tab_group(focused_entity)
+        .unwrap_or_else(|| vec![focused_entity]);
+    for moving_entity in moving_entities {
+        commands.entity(moving_entity).insert(move_marker);
+    }
 
     if move_focus == MoveFocus::Follow {
         flash_message(format!("{}", target_virtual_index + 1), 1.0, &mut commands);

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -21,8 +21,8 @@ use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, Initializing, NativeFullscreenMarker, Position,
-    RefreshWindowSizes, SelectedVirtualMarker, SendMessageTrigger, Timeout, Unmanaged,
-    flash_message, focus_entity, reposition_entity, reshuffle_around,
+    RefreshWindowSizes, SelectedVirtualMarker, Timeout, Unmanaged, flash_message, focus_entity,
+    reposition_entity, reshuffle_around,
 };
 use crate::errors::Result;
 use crate::events::Event;
@@ -490,31 +490,6 @@ fn refresh_workspace_window_sizes(
 
     if let Ok(mut cmds) = commands.get_entity(strip_entity) {
         cmds.try_remove::<RefreshWindowSizes>();
-    }
-}
-
-/// Periodically checks for changes in the active workspace (space) on the active display.
-/// This system acts as a workaround for inconsistent workspace change notifications on some macOS versions.
-/// If a change is detected, it triggers an `Event::SpaceChanged` event.
-#[allow(clippy::needless_pass_by_value)]
-pub(crate) fn workspace_change_watcher(
-    active_display: ActiveDisplay,
-    window_manager: Res<WindowManager>,
-    mut current_space: Local<WorkspaceId>,
-    mut commands: Commands,
-) {
-    let Ok(space_id) = window_manager
-        .0
-        .active_display_space(active_display.id())
-        .inspect_err(|err| warn!("{err}"))
-    else {
-        return;
-    };
-
-    if *current_space != space_id {
-        *current_space = space_id;
-        debug!("workspace changed to {space_id}");
-        commands.trigger(SendMessageTrigger(Event::SpaceChanged));
     }
 }
 

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -251,11 +251,17 @@ fn detect_moved_windows(
         }
 
         debug!("Window {entity} moved to workspace {workspace_id}.");
+        let moving_entities = workspaces
+            .iter()
+            .find_map(|(strip, _, _)| strip.tab_group(entity))
+            .unwrap_or_else(|| vec![entity]);
         for (mut strip, strip_entity, _) in &mut workspaces {
             if strip_entity == *activated_workspace {
-                strip.append(entity);
+                strip.append_tab_group(&moving_entities);
             } else {
-                strip.remove(entity);
+                for moving_entity in &moving_entities {
+                    strip.remove(*moving_entity);
+                }
             }
         }
     }
@@ -559,7 +565,16 @@ fn handle_virtual_window_moves(
 
     let (display_entity, active_display) = *active_display;
     for (window_entity, move_marker) in &moved_windows {
-        commands.entity(window_entity).remove::<VirtualMoveMarker>();
+        let moving_entities = workspaces
+            .get(source_entity)
+            .ok()
+            .and_then(|(_, strip, _, _)| strip.tab_group(window_entity))
+            .unwrap_or_else(|| vec![window_entity]);
+        for moving_entity in &moving_entities {
+            commands
+                .entity(*moving_entity)
+                .remove::<VirtualMoveMarker>();
+        }
         let follow = matches!(move_marker.move_focus, MoveFocus::Follow);
 
         let target_idx = move_marker.target_virtual_index;
@@ -596,7 +611,7 @@ fn handle_virtual_window_moves(
                 workspace_id
             );
             let mut new_strip = LayoutStrip::new(workspace_id, target_idx);
-            new_strip.append(window_entity);
+            new_strip.append_tab_group(&moving_entities);
 
             let mut spawned = commands.spawn((
                 new_strip,
@@ -632,9 +647,11 @@ fn handle_virtual_window_moves(
         // Move the window before moving markers to avoid being detected as a moved window.
         for (entity, mut strip, _, _) in &mut workspaces {
             if entity == target_entity {
-                strip.append(window_entity);
+                strip.append_tab_group(&moving_entities);
             } else {
-                strip.remove(window_entity);
+                for moving_entity in &moving_entities {
+                    strip.remove(*moving_entity);
+                }
             }
         }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -26,7 +26,7 @@ use crate::manager::skylight::SLSSetWindowListBrightness;
 use crate::platform::{ConnID, Pid, ProcessSerialNumber, WinID, WorkspaceId};
 use crate::util::{AXUIWrapper, MacResult, create_array, symlink_target};
 use app::ApplicationOS;
-pub use app::{Application, ApplicationApi};
+pub use app::{Application, ApplicationApi, NativeTabDirection};
 pub use display::Display;
 pub use process::{Process, ProcessApi};
 pub use skylight::AXUIElementCopyAttributeValue;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -10,7 +10,8 @@ use objc2_core_foundation::{
 };
 use objc2_core_graphics::{
     CGAssociateMouseAndMouseCursorPosition, CGDirectDisplayID, CGDisplayBounds,
-    CGGetActiveDisplayList, CGWarpMouseCursorPosition,
+    CGGetActiveDisplayList, CGWarpMouseCursorPosition, CGWindowListCopyWindowInfo,
+    CGWindowListOption, kCGNullWindowID, kCGWindowNumber,
 };
 use std::path::Path;
 use std::ptr::null_mut;
@@ -170,6 +171,8 @@ pub trait WindowManagerApi: Send + Sync {
     fn cursor_position(&self) -> Option<CGPoint>;
 
     fn dim_windows(&self, windows: &[WinID], level: f32);
+
+    fn windows_on_screen(&self) -> Option<Vec<WinID>>;
 }
 
 /// `WindowManager` is a Bevy resource that holds a boxed `WindowManagerApi` trait object.
@@ -543,6 +546,22 @@ impl WindowManagerApi for WindowManagerOS {
         }
         .to_result(function_name!())
         .inspect_err(|err| debug!("{err}"));
+    }
+
+    fn windows_on_screen(&self) -> Option<Vec<WinID>> {
+        let options =
+            CGWindowListOption::OptionOnScreenOnly | CGWindowListOption::ExcludeDesktopElements;
+        let window_list_info = CGWindowListCopyWindowInfo(options, kCGNullWindowID);
+        window_list_info.map(|window_info| {
+            let array = unsafe { window_info.cast_unchecked::<CFDictionary<CFString, CFNumber>>() };
+            array
+                .iter()
+                .filter_map(|dict| {
+                    dict.get(unsafe { kCGWindowNumber })
+                        .and_then(|id| id.as_i32())
+                })
+                .collect::<Vec<_>>()
+        })
     }
 }
 

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -51,7 +51,7 @@ pub static AX_WINDOW_NOTIFICATIONS: LazyLock<Vec<&str>> = LazyLock::new(|| {
     ]
 });
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NativeTabDirection {
     Previous,
     Next,

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -5,6 +5,7 @@ use bevy::ecs::component::Component;
 use core::ptr::NonNull;
 use derive_more::{DerefMut, with_trait::Deref};
 use objc2_core_foundation::{CFRetained, CFString, kCFRunLoopCommonModes};
+use objc2_core_graphics::{CGEvent, CGEventFlags, CGEventTapLocation};
 use std::ffi::c_void;
 use std::pin::Pin;
 use std::ptr::null_mut;
@@ -49,6 +50,12 @@ pub static AX_WINDOW_NOTIFICATIONS: LazyLock<Vec<&str>> = LazyLock::new(|| {
         accessibility_sys::kAXWindowDeminiaturizedNotification,
     ]
 });
+
+#[derive(Clone, Copy, Debug)]
+pub enum NativeTabDirection {
+    Previous,
+    Next,
+}
 
 pub trait ApplicationApi: Send + Sync {
     /// Returns the process ID of the application.
@@ -97,6 +104,10 @@ pub trait ApplicationApi: Send + Sync {
     fn bundle_id(&self) -> Option<&str>;
     /// Returns the display name of the application.
     fn name(&self) -> &str;
+    /// Asks the frontmost app to switch its native macOS tab selection.
+    fn select_native_tab(&self, direction: NativeTabDirection, _target: WinID) {
+        post_native_tab_shortcut(direction);
+    }
 }
 
 /// A wrapper struct for `ApplicationApi` trait objects, allowing for dynamic dispatch.
@@ -118,6 +129,26 @@ impl Application {
     /// * `app` - A `Box<dyn ApplicationApi>` representing the application implementation.
     pub fn new(app: Box<dyn ApplicationApi>) -> Self {
         Application(app)
+    }
+}
+
+fn post_native_tab_shortcut(direction: NativeTabDirection) {
+    const LEFT_BRACKET_KEY: u16 = 0x21;
+    const RIGHT_BRACKET_KEY: u16 = 0x1e;
+
+    let key = match direction {
+        NativeTabDirection::Previous => LEFT_BRACKET_KEY,
+        NativeTabDirection::Next => RIGHT_BRACKET_KEY,
+    };
+    let flags = CGEventFlags::MaskCommand | CGEventFlags::MaskShift;
+
+    if let Some(key_down) = CGEvent::new_keyboard_event(None, key, true) {
+        CGEvent::set_flags(Some(&key_down), flags);
+        CGEvent::post(CGEventTapLocation::HIDEventTap, Some(&key_down));
+    }
+    if let Some(key_up) = CGEvent::new_keyboard_event(None, key, false) {
+        CGEvent::set_flags(Some(&key_up), flags);
+        CGEvent::post(CGEventTapLocation::HIDEventTap, Some(&key_up));
     }
 }
 

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -55,6 +55,10 @@ pub trait WindowApi: Send + Sync {
     fn is_full_screen(&self) -> bool;
     fn reposition(&mut self, origin: Origin);
     fn resize(&mut self, size: Size);
+    fn set_frame(&mut self, origin: Origin, size: Size) {
+        self.reposition(origin);
+        self.resize(size);
+    }
     fn update_frame(&mut self) -> Result<IRect>;
     fn focus_without_raise(
         &self,
@@ -297,6 +301,62 @@ impl WindowOS {
         event_bytes[0x08] = 0x02;
         unsafe { SLPSPostEventRecordTo(psn, event_bytes.as_ptr().cast()) };
     }
+
+    fn set_position_attribute(&mut self, origin: Origin) -> bool {
+        let mut point = CGPoint::new(
+            f64::from(origin.x + self.horizontal_padding),
+            f64::from(origin.y + self.vertical_padding),
+        );
+        let position_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGPoint,
+                NonNull::from(&mut point).as_ptr().cast(),
+            )
+        };
+        if let Ok(position) = AXUIWrapper::retain(position_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
+                    position.as_ref(),
+                )
+            };
+            let size = self.frame.size();
+            self.frame.min = origin;
+            self.frame.max = origin + size;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn set_size_attribute(&mut self, size: Size) -> bool {
+        let width_padding = 2 * self.horizontal_padding;
+        let height_padding = 2 * self.vertical_padding;
+        let mut cgsize = CGSize::new(
+            f64::from(size.x - width_padding),
+            f64::from(size.y - height_padding),
+        );
+        let size_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGSize,
+                NonNull::from(&mut cgsize).as_ptr().cast(),
+            )
+        };
+        if let Ok(position) = AXUIWrapper::retain(size_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
+                    position.as_ref(),
+                )
+            };
+            self.frame.max = self.frame.min + size;
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl WindowApi for WindowOS {
@@ -382,28 +442,7 @@ impl WindowApi for WindowOS {
             return;
         }
         self.disable_enhanced_ui();
-        let mut point = CGPoint::new(
-            f64::from(origin.x + self.horizontal_padding),
-            f64::from(origin.y + self.vertical_padding),
-        );
-        let position_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGPoint,
-                NonNull::from(&mut point).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(position_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
-                    position.as_ref(),
-                )
-            };
-            let size = self.frame.size();
-            self.frame.min = origin;
-            self.frame.max = origin + size;
-        }
+        self.set_position_attribute(origin);
         self.reenable_enhanced_ui();
     }
 
@@ -414,27 +453,25 @@ impl WindowApi for WindowOS {
             return;
         }
         self.disable_enhanced_ui();
-        let width_padding = 2 * self.horizontal_padding;
-        let height_padding = 2 * self.vertical_padding;
-        let mut cgsize = CGSize::new(
-            f64::from(size.x - width_padding),
-            f64::from(size.y - height_padding),
-        );
-        let size_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGSize,
-                NonNull::from(&mut cgsize).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(size_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
-                    position.as_ref(),
-                )
-            };
-            self.frame.max = self.frame.min + size;
+        self.set_size_attribute(size);
+        self.reenable_enhanced_ui();
+    }
+
+    #[instrument(level = Level::TRACE)]
+    fn set_frame(&mut self, origin: Origin, size: Size) {
+        let position_changed = self.frame.min != origin;
+        let size_changed = self.frame.size() != size;
+        if !position_changed && !size_changed {
+            trace!("already correct frame.");
+            return;
+        }
+
+        self.disable_enhanced_ui();
+        if position_changed {
+            self.set_position_attribute(origin);
+        }
+        if size_changed {
+            self.set_size_attribute(size);
         }
         self.reenable_enhanced_ui();
     }

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -524,7 +524,7 @@ impl WindowApi for WindowOS {
                 SLPSPostEventRecordTo(&focused_psn, event_bytes.as_ptr().cast());
             }
 
-            // Artificially delay the activation by 1ms. This is necessary because some
+            // Artificially delay the activation. This is necessary because some
             // applications appear to be confused if both of the events appear instantaneously.
             thread::sleep(Duration::from_millis(20));
 

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -53,6 +53,7 @@ pub trait WindowApi: Send + Sync {
     fn subrole(&self) -> Result<String>;
     fn is_minimized(&self) -> bool;
     fn is_full_screen(&self) -> bool;
+    fn native_tab_count(&self) -> usize;
     fn reposition(&mut self, origin: Origin);
     fn resize(&mut self, size: Size);
     fn set_frame(&mut self, origin: Origin, size: Size) {
@@ -433,6 +434,13 @@ impl WindowApi for WindowOS {
 
     fn is_full_screen(&self) -> bool {
         self.ax_element.full_screen().unwrap_or(false)
+    }
+
+    fn native_tab_count(&self) -> usize {
+        let axname = CFString::from_str("AXTabs");
+        self.ax_element
+            .get_attribute::<CFArray<AXUIWrapper>>(&axname)
+            .map_or(0, |tabs| tabs.len())
     }
 
     #[instrument(level = Level::TRACE)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -152,6 +152,10 @@ impl CommandReader {
             if is_subscribe_request(&argv_ref) {
                 match stream.try_clone() {
                     Ok(clone) => {
+                        if let Err(err) = clone.set_nonblocking(true) {
+                            error!("configuring state subscriber as nonblocking: {err}");
+                            continue;
+                        }
                         _ = self
                             .events
                             .send(Event::StateSubscribe {

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -357,7 +357,7 @@ fn test_send_next_display_stays_on_source() {
 /// inactive displays onto the active display. `apply_window_properties`
 /// initially appends every observed window to the active strip; if the
 /// layout writers run before `finish_setup` has reassigned them, they
-/// cache active-display coordinates into `Position` and `commit_window_position`
+/// cache active-display coordinates into `Position` and `commit_window_frames`
 /// later pushes those to macOS, moving the windows.
 #[test]
 fn test_init_keeps_windows_on_their_real_displays() {

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -109,6 +110,7 @@ fn test_multi_workspace_orphaning() {
     let wm = MockWindowManager {
         windows: spawner,
         workspaces: vec![TEST_WORKSPACE_ID, TEST_WORKSPACE_ID + 1],
+        visible_windows: HashMap::new(),
     };
 
     TestHarness::new()

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -301,13 +301,13 @@ fn test_send_next_display_stays_on_source() {
             let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
             vec![
                 Window::new(Box::new(MockWindow::new(
-                    100,
+                    101,
                     IRect::from_corners(origin, origin + size),
                     eq.clone(),
                     app.clone(),
                 ))),
                 Window::new(Box::new(MockWindow::new(
-                    101,
+                    100,
                     IRect::from_corners(origin, origin + size),
                     eq.clone(),
                     app.clone(),

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -169,7 +169,7 @@ pub(crate) fn window_spawner(
     mock_app: MockApplication,
 ) -> TestWindowSpawner {
     Box::new(move |_| {
-        (0..count)
+        let mut windows = (0..count)
             .map(|i| {
                 let origin = Origin::new(0, 0);
                 let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
@@ -184,7 +184,9 @@ pub(crate) fn window_spawner(
                 );
                 Window::new(Box::new(window))
             })
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+        windows.reverse();
+        windows
     })
 }
 

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -52,6 +52,7 @@ impl TestHarness {
         let wm = MockWindowManager {
             windows: spawner,
             workspaces: vec![TEST_WORKSPACE_ID],
+            visible_windows: HashMap::new(),
         };
         self.app
             .world_mut()

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -171,7 +171,7 @@ pub(crate) fn window_spawner(
         let mut windows = (0..count)
             .map(|i| {
                 let origin = Origin::new(0, 0);
-                let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+                let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT - i);
                 let window = MockWindow::new(
                     i,
                     IRect {

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -17,7 +17,7 @@ use crate::ecs::scroll::ScrollEventsPlugin;
 use crate::ecs::workspace::WorkspaceEventsPlugin;
 use crate::ecs::{
     BProcess, ExistingMarker, FocusFollowsMouse, FocusedMarker, Initializing, MissionControlActive,
-    PollForNotifications, SkipReshuffle, register_systems, register_triggers,
+    SkipReshuffle, register_systems, register_triggers,
 };
 use crate::events::Event;
 use crate::manager::{Application, Origin, Size, Window, WindowManager, WindowManagerApi};
@@ -127,7 +127,6 @@ pub(crate) fn setup_world() -> App {
     bevy_app
         .add_plugins(MinimalPlugins)
         .init_resource::<bevy::ecs::message::Messages<Event>>()
-        .insert_resource(PollForNotifications)
         .insert_resource(SkipReshuffle(false))
         .insert_resource(MissionControlActive(false))
         .insert_resource(FocusFollowsMouse(None))

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bevy::prelude::*;
+use stdext::prelude::RwLockExt;
 
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
@@ -8,7 +11,7 @@ use crate::ecs::Bounds;
 use crate::ecs::SpawnWindowTrigger;
 use crate::ecs::{ActiveWorkspaceMarker, Position, layout::LayoutStrip};
 use crate::events::Event;
-use crate::manager::{Origin, Size, Window};
+use crate::manager::{NativeTabDirection, Origin, Size, Window};
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
@@ -34,6 +37,7 @@ fn harness_with_one_window() -> (TestHarness, MockApplication) {
             vec![Window::new(Box::new(window))]
         }),
         workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::new(),
     };
 
     (harness.with_wm(wm), app)
@@ -55,7 +59,8 @@ fn spawn_matching_native_tab(
         },
         event_queue,
         app,
-    );
+    )
+    .with_native_tab_count(2);
     world.trigger(SpawnWindowTrigger(vec![Window::new(Box::new(window))]));
 }
 
@@ -254,6 +259,7 @@ fn test_native_tab_focus_east_switches_tabs_inside_group() {
     ];
 
     let (harness, app) = harness_with_one_window();
+    let focused_app = app.clone();
     let internal_queue = harness.internal_queue.clone();
 
     harness
@@ -273,6 +279,11 @@ fn test_native_tab_focus_east_switches_tabs_inside_group() {
             assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
             assert_eq!(strip.index_of(tab_one).unwrap(), 0);
             assert_focused!(world, 1);
+            assert_eq!(focused_app.inner.force_read().focused_id, Some(1));
+            assert_eq!(
+                focused_app.inner.force_read().native_tab_selections,
+                vec![(NativeTabDirection::Next, 1)]
+            );
         })
         .run(commands);
 }
@@ -500,6 +511,892 @@ fn test_native_tab_removal_keeps_remaining_window_column() {
             assert_eq!(strip.len(), 1, "removing a tab should not empty the column");
             assert_eq!(strip.tab_group(tab_zero), None);
             assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+        })
+        .run(commands);
+}
+
+fn spawn_native_window_tab(
+    world: &mut World,
+    window_id: i32,
+    origin: Origin,
+    size: Size,
+    event_queue: EventQueue,
+    app: MockApplication,
+) {
+    let window = MockWindow::new(
+        window_id,
+        IRect {
+            min: origin,
+            max: origin + size,
+        },
+        event_queue,
+        app,
+    )
+    .with_native_tab_count(2);
+    world.trigger(SpawnWindowTrigger(vec![Window::new(Box::new(window))]));
+}
+
+fn spawn_native_window_tab_count_ref(
+    world: &mut World,
+    window_id: i32,
+    event_queue: EventQueue,
+    app: MockApplication,
+    native_tab_count: Arc<AtomicUsize>,
+) {
+    let origin = Origin::new(0, TEST_MENUBAR_HEIGHT);
+    let size = Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT);
+    let window = MockWindow::new(
+        window_id,
+        IRect {
+            min: origin,
+            max: origin + size,
+        },
+        event_queue,
+        app,
+    )
+    .with_native_tab_count_ref(native_tab_count);
+    world.trigger(SpawnWindowTrigger(vec![Window::new(Box::new(window))]));
+}
+
+#[test]
+fn test_same_app_distinct_windows_keep_separate_native_tab_groups() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+            spawn_native_window_tab(
+                world,
+                3,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(1, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let tab_two = find_window_entity(2, world);
+            let tab_three = find_window_entity(3, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 2);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_two).unwrap(), 1);
+            assert_eq!(strip.index_of(tab_three).unwrap(), 1);
+            assert_eq!(strip.tab_group(tab_zero), Some(vec![tab_zero, tab_one]));
+            assert_eq!(strip.tab_group(tab_two), Some(vec![tab_two, tab_three]));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_same_app_overlapping_second_window_stays_separate_without_native_tab_signal() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_native_window(
+                world,
+                1,
+                Origin::new(0, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(1, move |world| {
+            let first = find_window_entity(0, world);
+            let second = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 2);
+            assert_eq!(strip.index_of(first).unwrap(), 0);
+            assert_eq!(strip.index_of(second).unwrap(), 1);
+            assert_eq!(strip.tab_group(first), None);
+            assert_eq!(strip.tab_group(second), None);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_runtime_native_tab_groups_after_delayed_tab_signal() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+    let native_tab_count = Arc::new(AtomicUsize::new(1));
+    let count_for_spawn = native_tab_count.clone();
+    let count_for_update = native_tab_count.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_native_window_tab_count_ref(
+                world,
+                1,
+                internal_queue.clone(),
+                app.clone(),
+                count_for_spawn.clone(),
+            );
+        })
+        .on_iteration(1, move |_| {
+            count_for_update.store(2, Ordering::Relaxed);
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.tab_group(tab_zero), Some(vec![tab_zero, tab_one]));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_runtime_native_tab_groups_when_previous_tab_disappears_from_screen() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let mut harness = TestHarness::new();
+    let app = setup_process(harness.app.world_mut());
+    let initial_app = app.clone();
+    let initial_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                initial_queue.clone(),
+                initial_app.clone(),
+            );
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::from([(0, vec![1])]),
+    };
+    let harness = harness.with_wm(wm);
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_native_window(
+                world,
+                1,
+                Origin::new(0, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(1, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.tab_group(tab_zero), Some(vec![tab_zero, tab_one]));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_runtime_native_tab_repair_preserves_existing_group_order() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    let mut harness = TestHarness::new();
+    let app = setup_process(harness.app.world_mut());
+    let initial_app = app.clone();
+    let focused_app = app.clone();
+    let asserted_app = app.clone();
+    let initial_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                initial_queue.clone(),
+                initial_app.clone(),
+            );
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::from([(0, vec![2])]),
+    };
+    let harness = harness.with_wm(wm);
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(0, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+            focused_app.inner.force_write().focused_id = Some(0);
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let tab_two = find_window_entity(2, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1);
+            assert_eq!(
+                strip.tab_group(tab_zero),
+                Some(vec![tab_zero, tab_one, tab_two])
+            );
+            assert_focused!(world, 2);
+            assert_eq!(
+                asserted_app.inner.force_read().native_tab_selections,
+                vec![(NativeTabDirection::Next, 1), (NativeTabDirection::Next, 2)]
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_runtime_hidden_native_tab_joins_hidden_same_app_window() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let mut harness = TestHarness::new();
+    let app = setup_process(harness.app.world_mut());
+    let initial_app = app.clone();
+    let app_for_second_window = app.clone();
+    let app_for_second_tab = app.clone();
+    let focused_app = app.clone();
+    let initial_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                initial_queue.clone(),
+                initial_app.clone(),
+            );
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::from([(0, vec![0, 3])]),
+    };
+    let harness = harness.with_wm(wm);
+    let second_queue = harness.internal_queue.clone();
+    let tab_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                second_queue.clone(),
+                app_for_second_window.clone(),
+            );
+            focused_app.inner.force_write().focused_id = Some(2);
+        })
+        .on_iteration(1, move |world| {
+            spawn_native_window(
+                world,
+                3,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                tab_queue.clone(),
+                app_for_second_tab.clone(),
+            );
+        })
+        .on_iteration(2, move |world| {
+            let first_window = find_window_entity(0, world);
+            let second_window = find_window_entity(2, world);
+            let second_tab = find_window_entity(3, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 2);
+            assert_eq!(strip.index_of(first_window).unwrap(), 0);
+            assert_eq!(strip.index_of(second_window).unwrap(), 1);
+            assert_eq!(strip.index_of(second_tab).unwrap(), 1);
+            assert_eq!(strip.tab_group(first_window), None);
+            assert_eq!(
+                strip.tab_group(second_window),
+                Some(vec![second_window, second_tab])
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_same_app_overlapping_visible_window_stays_separate() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let mut harness = TestHarness::new();
+    let app = setup_process(harness.app.world_mut());
+    let initial_app = app.clone();
+    let initial_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                initial_queue.clone(),
+                initial_app.clone(),
+            );
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::from([(0, vec![0, 1])]),
+    };
+    let harness = harness.with_wm(wm);
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_native_window(
+                world,
+                1,
+                Origin::new(0, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(1, move |world| {
+            let first = find_window_entity(0, world);
+            let second = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 2);
+            assert_eq!(strip.index_of(first).unwrap(), 0);
+            assert_eq!(strip.index_of(second).unwrap(), 1);
+            assert_eq!(strip.tab_group(first), None);
+            assert_eq!(strip.tab_group(second), None);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_focus_east_uses_app_active_tab_at_group_edge() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let focused_app = app.clone();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(1, move |_| {
+            focused_app.inner.force_write().focused_id = Some(1);
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.index_of(other).unwrap(), 1);
+            assert_focused!(world, 2);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_focus_west_uses_app_active_tab_inside_group() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::West)),
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let focused_app = app.clone();
+    let asserted_app = app.clone();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(1, move |_| {
+            focused_app.inner.force_write().focused_id = Some(1);
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_focused!(world, 0);
+            assert_eq!(asserted_app.inner.force_read().focused_id, Some(0));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_ignores_inactive_tab_frame_updates() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::WindowFocused { window_id: 1 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let focused_app = app.clone();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(1, move |_| {
+            focused_app.inner.force_write().focused_id = Some(1);
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let stale_origin = Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT);
+            world
+                .entity_mut(tab_zero)
+                .get_mut::<Position>()
+                .expect("tab position not found")
+                .0 = stale_origin;
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+
+            let tab_zero_position = world
+                .entity(tab_zero)
+                .get::<Position>()
+                .expect("tab zero position not found")
+                .0;
+            let tab_one_position = world
+                .entity(tab_one)
+                .get::<Position>()
+                .expect("tab one position not found")
+                .0;
+            let expected_origin = Origin::new(0, TEST_MENUBAR_HEIGHT);
+
+            assert_eq!(tab_zero_position, expected_origin);
+            assert_eq!(tab_one_position, expected_origin);
+            assert_focused!(world, 1);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_focus_normalizes_existing_stale_tab_frame() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::WindowFocused { window_id: 1 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let focused_app = app.clone();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(1, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let stale_origin = Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT);
+            world
+                .entity_mut(tab_zero)
+                .get_mut::<Position>()
+                .expect("tab position not found")
+                .bypass_change_detection()
+                .0 = stale_origin;
+            focused_app.inner.force_write().focused_id = Some(1);
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let expected_origin = Origin::new(0, TEST_MENUBAR_HEIGHT);
+
+            assert_eq!(
+                world
+                    .entity(tab_zero)
+                    .get::<Position>()
+                    .expect("tab zero position not found")
+                    .0,
+                expected_origin
+            );
+            assert_eq!(
+                world
+                    .entity(tab_one)
+                    .get::<Position>()
+                    .expect("tab one position not found")
+                    .0,
+                expected_origin
+            );
+            assert_focused!(world, 1);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_hidden_cycle_keeps_grouped_column() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::WindowMinimized { window_id: 0 },
+        Event::WindowDeminimized { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(4, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.tab_group(tab_zero), Some(vec![tab_zero, tab_one]));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_virtual_move_stay_keeps_remaining_tab_on_target_after_close() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+
+            world.entity_mut(tab_one).despawn();
+
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let source = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+            assert_eq!(source.virtual_index, 0);
+            assert!(source.contains(other));
+            assert!(!source.contains(tab_zero));
+            assert!(!source.contains(tab_one));
+
+            let mut query = world.query::<&LayoutStrip>();
+            let target = query
+                .iter(world)
+                .find(|strip| strip.virtual_index == 1)
+                .expect("target strip not found");
+            assert!(target.contains(tab_zero));
+            assert!(!target.contains(tab_one));
+            assert_eq!(target.index_of(tab_zero).unwrap(), 0);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_swap_keeps_remaining_tab_in_moved_column_after_close() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Swap(Direction::East)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(4, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+
+            world.entity_mut(tab_one).despawn();
+
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+            assert_eq!(strip.index_of(other).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 1);
+            assert!(!strip.contains(tab_one));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_stack_keeps_remaining_tab_in_moved_column_after_close() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Stack(true)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(5, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+
+            world.entity_mut(tab_one).despawn();
+
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+            assert_eq!(strip.len(), 1);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(other).unwrap(), 0);
+            assert!(!strip.contains(tab_one));
         })
         .run(commands);
 }
@@ -987,6 +1884,7 @@ fn test_external_focus_restores_hidden_window_without_visible_event() {
             vec![Window::new(Box::new(window))]
         }),
         workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::new(),
     };
 
     harness

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use bevy::prelude::*;
 
 use crate::commands::{Command, Direction, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::SpawnWindowTrigger;
-use crate::ecs::{ActiveWorkspaceMarker, layout::LayoutStrip};
+use crate::ecs::{ActiveWorkspaceMarker, Position, layout::LayoutStrip};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
 use crate::{assert_focused, assert_window_at, assert_window_size};
@@ -212,7 +214,7 @@ fn test_scrolling_stop() {
     TestHarness::new()
         .with_config(config)
         .with_windows(3)
-        .on_iteration(2, |world| {
+        .on_iteration(3, |world| {
             use crate::ecs::Scrolling;
             let mut query = world.query::<&Scrolling>();
             let scroll = query.single(world).unwrap();
@@ -338,8 +340,52 @@ fn test_stale_focus_event_ignored() {
         .on_iteration(1, |world| {
             assert_focused!(world, 3);
         })
-        .on_iteration(3, |world| {
+        .on_iteration(2, |world| {
             assert_focused!(world, 3);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_repeated_external_focus_reshuffles_already_focused_window() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::WindowFocused { window_id: 0 },
+    ];
+
+    TestHarness::new()
+        .with_windows(5)
+        .on_iteration(5, |world| {
+            assert_focused!(world, 0);
+
+            let mut query =
+                world.query::<(&mut Position, &LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let (mut position, _, _) = query
+                .iter_mut(world)
+                .find(|(_, _, active)| *active)
+                .expect("active strip");
+            position.0.x = TEST_DISPLAY_WIDTH * 2;
+        })
+        .on_iteration(4, |world| {
+            assert_focused!(world, 0);
+            assert_window_at!(
+                world,
+                0,
+                TEST_DISPLAY_WIDTH - TEST_WINDOW_WIDTH,
+                TEST_MENUBAR_HEIGHT
+            );
         })
         .run(commands);
 }
@@ -415,6 +461,73 @@ fn test_external_focus_restores_app_hidden_window_to_original_virtual_strip() {
             assert_eq!(active, 1);
         })
         .on_iteration(5, |world| {
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip.virtual_index))
+                .expect("an active virtual strip");
+            assert_eq!(active, 0);
+            assert_window_at!(world, 0, 0, TEST_MENUBAR_HEIGHT);
+            assert_focused!(world, 0);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_external_focus_restores_hidden_window_without_visible_event() {
+    let ignored_repositions = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ignored_repositions_for_window = ignored_repositions.clone();
+
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::ApplicationHidden {
+            pid: TEST_PROCESS_ID,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        Event::WindowFocused { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                internal_queue.clone(),
+                mock_app.clone(),
+            )
+            .with_ignored_repositions(ignored_repositions_for_window.clone());
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+    };
+
+    harness
+        .with_wm(wm)
+        .on_iteration(1, move |world| {
+            let mut query = world.query::<&mut Window>();
+            let mut window = query
+                .iter_mut(world)
+                .find(|window| window.id() == 0)
+                .expect("window 0");
+            window.reposition(Origin::new(0, TEST_DISPLAY_HEIGHT));
+            ignored_repositions.store(1, std::sync::atomic::Ordering::SeqCst);
+        })
+        .on_iteration(4, |world| {
             let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
             let active = query
                 .iter(world)

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -774,6 +774,9 @@ fn test_rapid_focus_not_swallowed() {
         Event::Command {
             command: Command::PrintState,
         },
+        Event::Command {
+            command: Command::PrintState,
+        },
     ]);
 
     verify_focused_window(0, harness.app.world_mut());

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -259,7 +259,15 @@ fn test_window_hidden_ratio() {
 }
 
 #[test]
-fn test_window_hidden_ratio_swap() {
+fn test_window_swap_brings_focused_into_view() {
+    // After Center, id=4 is at the centered position. Swap(Last) bubbles
+    // id=4 to column 4 (layout x=1600); with the strip at +312 that would
+    // put id=4 off-screen to the right (1912). ensure_visible_in_strip
+    // scrolls the strip by exactly the shortfall so id=4 sits at the right
+    // edge of the viewport (max.x - width = 624). The strip does NOT
+    // re-anchor id=4 to its old centered position — there was room to the
+    // right, so it slides there. id=0 takes the slot immediately to the
+    // left.
     let commands = vec![
         Event::MenuOpened { window_id: 0 },
         Event::Command {
@@ -272,7 +280,6 @@ fn test_window_hidden_ratio_swap() {
 
     let config: Config = (
         MainOptions {
-            window_hidden_ratio: Some(1.0),
             animation_speed: Some(10000.0),
             ..Default::default()
         },
@@ -281,6 +288,7 @@ fn test_window_hidden_ratio_swap() {
         .into();
 
     let centered = (TEST_DISPLAY_WIDTH - TEST_WINDOW_WIDTH) / 2;
+    let right_edge = TEST_DISPLAY_WIDTH - TEST_WINDOW_WIDTH;
 
     TestHarness::new()
         .with_config(config)
@@ -289,8 +297,51 @@ fn test_window_hidden_ratio_swap() {
             assert_window_at!(world, 4, centered, TEST_MENUBAR_HEIGHT);
         })
         .on_iteration(2, move |world| {
-            assert_window_at!(world, 4, centered, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 0, centered - TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT);
+            assert_window_at!(world, 4, right_edge, TEST_MENUBAR_HEIGHT);
+            assert_window_at!(
+                world,
+                0,
+                right_edge - TEST_WINDOW_WIDTH,
+                TEST_MENUBAR_HEIGHT
+            );
+            assert_focused!(world, 4);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_window_swap_keeps_strip_when_in_view() {
+    // Two windows fit the viewport. Swap(West) on the focused (right)
+    // window swaps the columns: both new layout slots are still inside the
+    // viewport with the strip where it is, so ensure_visible_in_strip does
+    // nothing. The per-window animation slides each window into the other's
+    // old position.
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::Last)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Swap(Direction::West)),
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(2)
+        .on_iteration(2, |world| {
+            assert_window_at!(world, 0, 0, TEST_MENUBAR_HEIGHT);
+            assert_window_at!(world, 1, TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT);
+            assert_focused!(world, 0);
         })
         .run(commands);
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -355,6 +355,9 @@ fn test_rapid_focus_not_swallowed() {
         Event::Command {
             command: Command::Window(Operation::Focus(Direction::Last)),
         },
+        Event::Command {
+            command: Command::PrintState,
+        },
     ]);
 
     verify_focused_window(0, harness.app.world_mut());

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use bevy::prelude::*;
 
-use crate::commands::{Command, Direction, Operation};
+use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
+use crate::ecs::Bounds;
 use crate::ecs::SpawnWindowTrigger;
 use crate::ecs::{ActiveWorkspaceMarker, Position, layout::LayoutStrip};
 use crate::events::Event;
@@ -11,6 +12,72 @@ use crate::manager::{Origin, Size, Window};
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
+
+fn harness_with_one_window() -> (TestHarness, MockApplication) {
+    let mut harness = TestHarness::new();
+    let app = setup_process(harness.app.world_mut());
+    let initial_app = app.clone();
+    let initial_queue = harness.internal_queue.clone();
+    let wm = MockWindowManager {
+        windows: Box::new(move |_| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let window = MockWindow::new(
+                0,
+                IRect {
+                    min: origin,
+                    max: origin + size,
+                },
+                initial_queue.clone(),
+                initial_app.clone(),
+            );
+            vec![Window::new(Box::new(window))]
+        }),
+        workspaces: vec![TEST_WORKSPACE_ID],
+    };
+
+    (harness.with_wm(wm), app)
+}
+
+fn spawn_matching_native_tab(
+    world: &mut World,
+    window_id: i32,
+    event_queue: EventQueue,
+    app: MockApplication,
+) {
+    let origin = Origin::new(0, TEST_MENUBAR_HEIGHT);
+    let size = Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT);
+    let window = MockWindow::new(
+        window_id,
+        IRect {
+            min: origin,
+            max: origin + size,
+        },
+        event_queue,
+        app,
+    );
+    world.trigger(SpawnWindowTrigger(vec![Window::new(Box::new(window))]));
+}
+
+fn spawn_native_window(
+    world: &mut World,
+    window_id: i32,
+    origin: Origin,
+    size: Size,
+    event_queue: EventQueue,
+    app: MockApplication,
+) {
+    let window = MockWindow::new(
+        window_id,
+        IRect {
+            min: origin,
+            max: origin + size,
+        },
+        event_queue,
+        app,
+    );
+    world.trigger(SpawnWindowTrigger(vec![Window::new(Box::new(window))]));
+}
 
 #[test]
 fn test_dont_focus() {
@@ -84,6 +151,355 @@ fn test_offscreen_windows_preserve_height() {
             assert_window_size!(world, 2, TEST_WINDOW_WIDTH, expected_height);
             assert_window_size!(world, 1, TEST_WINDOW_WIDTH, expected_height);
             assert_window_size!(world, 0, TEST_WINDOW_WIDTH, expected_height);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_same_app_same_frame_native_tab_reuses_existing_column() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(1, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1, "native tab should not add a column");
+            assert_eq!(strip.tab_group(tab_zero), Some(vec![tab_zero, tab_one]));
+            assert_eq!(strip.tab_group(tab_one), Some(vec![tab_zero, tab_one]));
+            assert_window_size!(
+                world,
+                0,
+                TEST_WINDOW_WIDTH,
+                TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT
+            );
+            assert_window_size!(
+                world,
+                1,
+                TEST_WINDOW_WIDTH,
+                TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_resize_syncs_sibling_size() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(1, move |world| {
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<&mut Bounds>();
+            let mut bounds = query.get_mut(world, tab_one).expect("tab bounds missing");
+            bounds.0.x = TEST_WINDOW_WIDTH + 160;
+        })
+        .on_iteration(2, move |world| {
+            assert_window_size!(
+                world,
+                0,
+                TEST_WINDOW_WIDTH + 160,
+                TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT
+            );
+            assert_window_size!(
+                world,
+                1,
+                TEST_WINDOW_WIDTH + 160,
+                TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_focus_east_switches_tabs_inside_group() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_focused!(world, 1);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_focus_east_at_last_tab_moves_to_neighbor_column() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.index_of(other).unwrap(), 1);
+            assert_focused!(world, 2);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_swap_east_switches_tabs_inside_group() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Swap(Direction::East)),
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 0);
+            assert_eq!(strip.index_of(other).unwrap(), 1);
+            assert_focused!(world, 1);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_swap_east_at_last_tab_moves_whole_column() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Swap(Direction::East)),
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+            spawn_native_window(
+                world,
+                2,
+                Origin::new(TEST_WINDOW_WIDTH, TEST_MENUBAR_HEIGHT),
+                Size::new(TEST_WINDOW_WIDTH, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT),
+                internal_queue.clone(),
+                app.clone(),
+            );
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let other = find_window_entity(2, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 1);
+            assert_eq!(strip.index_of(tab_one).unwrap(), 1);
+            assert_eq!(strip.index_of(other).unwrap(), 0);
+            assert_focused!(world, 1);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_virtual_move_moves_all_tabs() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(3, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let tab_one = find_window_entity(1, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let active = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(active.virtual_index, 1);
+            assert_eq!(active.len(), 1);
+            assert_eq!(active.index_of(tab_zero).unwrap(), 0);
+            assert_eq!(active.index_of(tab_one).unwrap(), 0);
+            assert_eq!(active.tab_group(tab_zero), Some(vec![tab_zero, tab_one]));
+
+            let mut query = world.query::<&LayoutStrip>();
+            let source = query
+                .iter(world)
+                .find(|strip| strip.virtual_index == 0)
+                .expect("source strip not found");
+            assert!(!source.contains(tab_zero));
+            assert!(!source.contains(tab_one));
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_native_tab_removal_keeps_remaining_window_column() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let (harness, app) = harness_with_one_window();
+    let internal_queue = harness.internal_queue.clone();
+
+    harness
+        .on_iteration(0, move |world| {
+            spawn_matching_native_tab(world, 1, internal_queue.clone(), app.clone());
+        })
+        .on_iteration(1, move |world| {
+            let tab_one = find_window_entity(1, world);
+            world.entity_mut(tab_one).despawn();
+        })
+        .on_iteration(2, move |world| {
+            let tab_zero = find_window_entity(0, world);
+            let mut query = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+            let strip = query
+                .iter(world)
+                .find_map(|(strip, active)| active.then_some(strip))
+                .expect("active strip not found");
+
+            assert_eq!(strip.len(), 1, "removing a tab should not empty the column");
+            assert_eq!(strip.tab_group(tab_zero), None);
+            assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
         })
         .run(commands);
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -11,8 +11,8 @@ use tracing::{Level, debug, instrument};
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::manager::{
-    Application, ApplicationApi, Display, Origin, ProcessApi, Size, Window, WindowApi,
-    WindowManagerApi,
+    Application, ApplicationApi, Display, NativeTabDirection, Origin, ProcessApi, Size, Window,
+    WindowApi, WindowManagerApi,
 };
 use crate::platform::{ConnID, Pid, WinID, WorkspaceId};
 use crate::{platform::ProcessSerialNumber, util::AXUIWrapper};
@@ -183,6 +183,10 @@ impl ApplicationApi for MockApplication {
 
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn select_native_tab(&self, _direction: NativeTabDirection, target: WinID) {
+        self.inner.force_write().focused_id = Some(target);
     }
 }
 

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use bevy::prelude::*;
@@ -328,6 +328,7 @@ pub(crate) struct MockWindow {
     pub(crate) identifier: String,
     pub(crate) role: String,
     pub(crate) subrole: String,
+    pub(crate) ignored_repositions: Arc<AtomicUsize>,
 }
 
 impl WindowApi for MockWindow {
@@ -385,6 +386,10 @@ impl WindowApi for MockWindow {
     #[instrument(level = Level::DEBUG, skip(self))]
     fn reposition(&mut self, origin: Origin) {
         debug!("{}: id {} to {origin}", function_name!(), self.id);
+        if self.ignored_repositions.load(Ordering::SeqCst) > 0 {
+            self.ignored_repositions.fetch_sub(1, Ordering::SeqCst);
+            return;
+        }
         let size = self.frame.size();
         self.frame.min = origin;
         self.frame.max = origin + size;
@@ -500,7 +505,16 @@ impl MockWindow {
             identifier: String::new(),
             role: "AXWindow".to_string(),
             subrole: "AXStandardWindow".to_string(),
+            ignored_repositions: Arc::default(),
         }
+    }
+
+    pub(crate) fn with_ignored_repositions(
+        mut self,
+        ignored_repositions: Arc<AtomicUsize>,
+    ) -> Self {
+        self.ignored_repositions = ignored_repositions;
+        self
     }
 }
 

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -312,6 +312,11 @@ impl WindowManagerApi for MockWindowManager {
 
     #[instrument(level = Level::DEBUG, skip(self))]
     fn dim_windows(&self, windows: &[WinID], level: f32) {}
+
+    #[instrument(level = Level::DEBUG, skip(self))]
+    fn windows_on_screen(&self) -> Option<Vec<WinID>> {
+        None
+    }
 }
 
 /// A mock implementation of the `WindowApi` trait for testing purposes.
@@ -632,4 +637,8 @@ impl WindowManagerApi for TwoDisplayMock {
     }
 
     fn dim_windows(&self, _windows: &[WinID], _level: f32) {}
+
+    fn windows_on_screen(&self) -> Option<Vec<WinID>> {
+        None
+    }
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -321,6 +321,10 @@ impl WindowManagerApi for MockWindowManager {
     fn windows_on_screen(&self) -> Option<Vec<WinID>> {
         None
     }
+    #[instrument(level = Level::DEBUG, skip(self))]
+    fn visible_on_screen(&self, window_id: WinID) -> Option<Vec<WinID>> {
+        None
+    }
 }
 
 /// A mock implementation of the `WindowApi` trait for testing purposes.
@@ -643,6 +647,9 @@ impl WindowManagerApi for TwoDisplayMock {
     fn dim_windows(&self, _windows: &[WinID], _level: f32) {}
 
     fn windows_on_screen(&self) -> Option<Vec<WinID>> {
+        None
+    }
+    fn visible_on_screen(&self, _window_id: WinID) -> Option<Vec<WinID>> {
         None
     }
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -329,6 +329,7 @@ pub(crate) struct MockWindow {
     pub(crate) role: String,
     pub(crate) subrole: String,
     pub(crate) ignored_repositions: Arc<AtomicUsize>,
+    pub(crate) metadata_reads: Option<Arc<AtomicUsize>>,
 }
 
 impl WindowApi for MockWindow {
@@ -354,12 +355,18 @@ impl WindowApi for MockWindow {
     /// Returns the title of the mock window.
     #[instrument(level = Level::TRACE, skip(self), ret)]
     fn title(&self) -> Result<String> {
+        if let Some(reads) = &self.metadata_reads {
+            reads.fetch_add(1, Ordering::Relaxed);
+        }
         Ok(self.title.clone())
     }
 
     /// Returns the identifier of the mock window.
     #[instrument(level = Level::TRACE, skip(self), ret)]
     fn identifier(&self) -> Result<String> {
+        if let Some(reads) = &self.metadata_reads {
+            reads.fetch_add(1, Ordering::Relaxed);
+        }
         Ok(self.identifier.clone())
     }
 
@@ -506,6 +513,7 @@ impl MockWindow {
             role: "AXWindow".to_string(),
             subrole: "AXStandardWindow".to_string(),
             ignored_repositions: Arc::default(),
+            metadata_reads: None,
         }
     }
 

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -83,6 +84,7 @@ pub(crate) struct InnerMockApplication {
     pub(crate) pid: Pid,
     pub(crate) focused_id: Option<WinID>,
     pub(crate) bundle_id: String,
+    pub(crate) native_tab_selections: Vec<(NativeTabDirection, WinID)>,
 }
 
 impl MockApplication {
@@ -95,6 +97,7 @@ impl MockApplication {
                 pid,
                 focused_id: None,
                 bundle_id,
+                native_tab_selections: Vec::new(),
             })),
             name: "test".to_string(),
         }
@@ -185,8 +188,10 @@ impl ApplicationApi for MockApplication {
         &self.name
     }
 
-    fn select_native_tab(&self, _direction: NativeTabDirection, target: WinID) {
-        self.inner.force_write().focused_id = Some(target);
+    fn select_native_tab(&self, direction: NativeTabDirection, target: WinID) {
+        let mut inner = self.inner.force_write();
+        inner.native_tab_selections.push((direction, target));
+        inner.focused_id = Some(target);
     }
 }
 
@@ -194,6 +199,7 @@ impl ApplicationApi for MockApplication {
 pub(crate) struct MockWindowManager {
     pub(crate) windows: TestWindowSpawner,
     pub(crate) workspaces: Vec<WorkspaceId>,
+    pub(crate) visible_windows: HashMap<WinID, Vec<WinID>>,
 }
 
 impl std::fmt::Debug for MockWindowManager {
@@ -214,6 +220,7 @@ impl WindowManagerApi for MockWindowManager {
                 pid: process.pid(),
                 focused_id: None,
                 bundle_id: "test".to_string(),
+                native_tab_selections: Vec::new(),
             })),
             name: "test".to_string(),
         })))
@@ -319,11 +326,7 @@ impl WindowManagerApi for MockWindowManager {
 
     #[instrument(level = Level::DEBUG, skip(self))]
     fn windows_on_screen(&self) -> Option<Vec<WinID>> {
-        None
-    }
-    #[instrument(level = Level::DEBUG, skip(self))]
-    fn visible_on_screen(&self, window_id: WinID) -> Option<Vec<WinID>> {
-        None
+        self.visible_windows.values().next().cloned()
     }
 }
 
@@ -343,6 +346,7 @@ pub(crate) struct MockWindow {
     pub(crate) subrole: String,
     pub(crate) ignored_repositions: Arc<AtomicUsize>,
     pub(crate) metadata_reads: Option<Arc<AtomicUsize>>,
+    pub(crate) native_tab_count: Arc<AtomicUsize>,
 }
 
 impl WindowApi for MockWindow {
@@ -500,6 +504,10 @@ impl WindowApi for MockWindow {
         false
     }
 
+    fn native_tab_count(&self) -> usize {
+        self.native_tab_count.load(Ordering::Relaxed)
+    }
+
     fn border_radius(&self) -> Option<f64> {
         None
     }
@@ -527,6 +535,7 @@ impl MockWindow {
             subrole: "AXStandardWindow".to_string(),
             ignored_repositions: Arc::default(),
             metadata_reads: None,
+            native_tab_count: Arc::new(AtomicUsize::new(1)),
         }
     }
 
@@ -535,6 +544,16 @@ impl MockWindow {
         ignored_repositions: Arc<AtomicUsize>,
     ) -> Self {
         self.ignored_repositions = ignored_repositions;
+        self
+    }
+
+    pub(crate) fn with_native_tab_count(mut self, count: usize) -> Self {
+        self.native_tab_count = Arc::new(AtomicUsize::new(count));
+        self
+    }
+
+    pub(crate) fn with_native_tab_count_ref(mut self, count: Arc<AtomicUsize>) -> Self {
+        self.native_tab_count = count;
         self
     }
 }
@@ -564,6 +583,7 @@ impl WindowManagerApi for TwoDisplayMock {
                 pid: process.pid(),
                 focused_id: None,
                 bundle_id: "test".to_string(),
+                native_tab_selections: Vec::new(),
             })),
             name: "test".to_string(),
         })))
@@ -647,9 +667,6 @@ impl WindowManagerApi for TwoDisplayMock {
     fn dim_windows(&self, _windows: &[WinID], _level: f32) {}
 
     fn windows_on_screen(&self) -> Option<Vec<WinID>> {
-        None
-    }
-    fn visible_on_screen(&self, _window_id: WinID) -> Option<Vec<WinID>> {
         None
     }
 }

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -1,7 +1,7 @@
 use bevy::ecs::query::Has;
 use bevy::prelude::*;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::layout::{Column, LayoutStrip};
@@ -77,6 +77,63 @@ fn test_startup_restore_rebuilds_virtual_workspace_layout() {
     assert_eq!(columns.len(), 2);
     assert!(matches!(columns[0], Column::Single(_)));
     assert!(matches!(columns[1], Column::Single(_)));
+}
+
+#[test]
+fn test_startup_restore_hard_matches_without_extra_fallback_metadata_reads() {
+    let baseline_reads = startup_restore_metadata_reads(None);
+    let restore_reads = startup_restore_metadata_reads(Some(state_with_strips(
+        (0_u32..20)
+            .map(|id| SavedStrip {
+                virtual_index: id,
+                columns: vec![SavedColumn::Single(saved_window(
+                    i32::try_from(id).expect("test id should fit in i32"),
+                ))],
+            })
+            .collect(),
+    )));
+
+    assert!(
+        restore_reads <= baseline_reads,
+        "hard-match restore should not add fallback window metadata reads"
+    );
+}
+
+fn startup_restore_metadata_reads(state: Option<PaneruState>) -> usize {
+    let metadata_reads = Arc::new(AtomicUsize::new(0));
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+    let reads = metadata_reads.clone();
+    let windows: TestWindowSpawner = Box::new(move |_| {
+        (0..20)
+            .map(|id| {
+                let origin = Origin::new(0, 0);
+                let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+                let mut window = MockWindow::new(
+                    id,
+                    IRect::from_corners(origin, origin + size),
+                    internal_queue.clone(),
+                    mock_app.clone(),
+                );
+                window.metadata_reads = Some(reads.clone());
+                Window::new(Box::new(window))
+            })
+            .collect()
+    });
+    harness = harness.with_wm(MockWindowManager {
+        windows,
+        workspaces: vec![TEST_WORKSPACE_ID],
+    });
+    if let Some(state) = state {
+        harness.app.world_mut().insert_resource(state);
+    }
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    metadata_reads.load(Ordering::Relaxed)
 }
 
 #[test]

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -1,5 +1,6 @@
 use bevy::ecs::query::Has;
 use bevy::prelude::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
@@ -124,6 +125,7 @@ fn startup_restore_metadata_reads(state: Option<PaneruState>) -> usize {
     harness = harness.with_wm(MockWindowManager {
         windows,
         workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::new(),
     });
     if let Some(state) = state {
         harness.app.world_mut().insert_resource(state);
@@ -613,6 +615,7 @@ fn test_late_startup_window_restores_during_grace_period() {
     harness = harness.with_wm(MockWindowManager {
         windows,
         workspaces: vec![TEST_WORKSPACE_ID],
+        visible_windows: HashMap::new(),
     });
     harness
         .app

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -104,7 +104,7 @@ fn test_window_shuffle() {
     ];
 
     // Logical width includes padding expansion on each side.
-    let logical_width = TEST_WINDOW_WIDTH + 2 * H_PAD;
+    let logical_width = TEST_WINDOW_WIDTH;
     let top_edge = TEST_MENUBAR_HEIGHT + i32::from(PADDING_TOP);
     let left_edge = i32::from(PADDING_LEFT);
     let right_edge = TEST_DISPLAY_WIDTH - i32::from(PADDING_RIGHT);

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -104,7 +104,7 @@ fn test_window_shuffle() {
     ];
 
     // Logical width includes padding expansion on each side.
-    let logical_width = TEST_WINDOW_WIDTH;
+    let logical_width = TEST_WINDOW_WIDTH + 2 * H_PAD;
     let top_edge = TEST_MENUBAR_HEIGHT + i32::from(PADDING_TOP);
     let left_edge = i32::from(PADDING_LEFT);
     let right_edge = TEST_DISPLAY_WIDTH - i32::from(PADDING_RIGHT);


### PR DESCRIPTION
Group windows that macOS exposes as native tabs into a single layout slot, keep their frames synchronized, and delegate tab switching to the native system shortcut.

Preserve tab groups when moving windows across virtual spaces and add interaction coverage for focus, swap, resize, virtual move, and removal behavior.

Tested with cargo fmt --check and cargo test

Manually tested with Ghostty.