### PR TITLE
feat: Floating-tier focus model

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,6 +22,7 @@ use crate::ecs::{
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Origin, Size, Window, WindowManager};
+use crate::platform::WorkspaceId;
 
 /// Represents a cardinal or directional choice for window manipulation.
 #[derive(Clone, Debug)]
@@ -246,27 +247,48 @@ fn pick_nearest_in_direction(
         .map(|(entity, _)| entity)
 }
 
+fn visible_floating_entities(
+    windows: &Windows,
+    window_manager: &WindowManager,
+    workspace_id: WorkspaceId,
+    display_bounds: IRect,
+) -> Vec<Entity> {
+    let workspace_window_ids: std::collections::HashSet<_> = window_manager
+        .windows_in_workspace(workspace_id)
+        .ok()
+        .map(|ids| ids.into_iter().collect())
+        .unwrap_or_default();
+
+    windows
+        .iter()
+        .filter_map(|(_, entity)| {
+            let (window, _, Some(Unmanaged::Floating)) = windows.get_managed(entity)? else {
+                return None;
+            };
+            if !workspace_window_ids.contains(&window.id()) {
+                return None;
+            }
+            let frame = windows.frame(entity)?;
+            (!display_bounds.intersect(frame).is_empty()).then_some(entity)
+        })
+        .collect()
+}
+
 fn nearest_float_in_direction(
     direction: &Direction,
     focused_entity: Entity,
     windows: &Windows,
+    window_manager: &WindowManager,
+    workspace_id: WorkspaceId,
     display_bounds: IRect,
 ) -> Option<Entity> {
     let focused_center = windows.frame(focused_entity)?.center();
 
-    let candidates = windows.iter().filter_map(|(_, entity)| {
-        if entity == focused_entity {
-            return None;
-        }
-        let (_, _, Some(Unmanaged::Floating)) = windows.get_managed(entity)? else {
-            return None;
-        };
-        let frame = windows.frame(entity)?;
-        if display_bounds.intersect(frame).is_empty() {
-            return None;
-        }
-        Some((entity, frame.center()))
-    });
+    let candidates =
+        visible_floating_entities(windows, window_manager, workspace_id, display_bounds)
+            .into_iter()
+            .filter(|entity| *entity != focused_entity)
+            .filter_map(|entity| windows.frame(entity).map(|frame| (entity, frame.center())));
 
     pick_nearest_in_direction(direction, focused_center, candidates)
 }
@@ -289,6 +311,7 @@ fn command_move_focus(
     windows: Windows,
     workspaces: Query<(&LayoutStrip, Option<&NativeFullscreenMarker>)>,
     active_display: ActiveDisplay,
+    window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     let Some(Operation::Focus(direction)) =
@@ -317,9 +340,14 @@ fn command_move_focus(
     };
 
     if let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(focused_entity) {
-        if let Some(entity) =
-            nearest_float_in_direction(direction, focused_entity, &windows, active_display.bounds())
-        {
+        if let Some(entity) = nearest_float_in_direction(
+            direction,
+            focused_entity,
+            &windows,
+            &window_manager,
+            active_strip.id(),
+            active_display.bounds(),
+        ) {
             focus_entity(entity, true, &mut commands);
         }
         return;
@@ -372,6 +400,7 @@ fn command_focus_unmanaged(
     mut messages: MessageReader<Event>,
     windows: Windows,
     active_display: ActiveDisplay,
+    window_manager: Res<WindowManager>,
     focus_history: Res<FocusHistory>,
     mut commands: Commands,
 ) {
@@ -384,24 +413,14 @@ fn command_focus_unmanaged(
 
     let display_bounds = active_display.bounds();
     let workspace_id = active_display.active_strip().id();
-    let is_visible_float = |entity: Entity| -> bool {
-        let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
-            return false;
-        };
-        let Some(frame) = windows.frame(entity) else {
-            return false;
-        };
-        !display_bounds.intersect(frame).is_empty()
-    };
+    let visible_floats =
+        visible_floating_entities(&windows, &window_manager, workspace_id, display_bounds);
+    let is_visible_float = |entity: Entity| -> bool { visible_floats.contains(&entity) };
 
     let target = focus_history
         .last_floating(workspace_id)
         .filter(|entity| is_visible_float(*entity))
-        .or_else(|| {
-            windows
-                .iter()
-                .find_map(|(_, e)| is_visible_float(e).then_some(e))
-        });
+        .or_else(|| visible_floats.into_iter().next());
 
     if let Some(entity) = target {
         focus_entity(entity, true, &mut commands);
@@ -454,35 +473,14 @@ fn command_raise_floating(
 
     let display_bounds = active_display.bounds();
     let workspace_id = active_display.active_strip().id();
-    // Floats on other macOS Spaces share the display bounds, so without an
-    // explicit workspace-membership filter they leak into the float set.
-    let workspace_window_ids: std::collections::HashSet<_> = window_manager
-        .windows_in_workspace(workspace_id)
-        .ok()
-        .map(|ids| ids.into_iter().collect())
-        .unwrap_or_default();
-
-    let is_visible_float = |entity: Entity| -> bool {
-        let Some((window, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
-            return false;
-        };
-        if !workspace_window_ids.contains(&window.id()) {
-            return false;
-        }
-        let Some(frame) = windows.frame(entity) else {
-            return false;
-        };
-        !display_bounds.intersect(frame).is_empty()
-    };
+    let visible_floats =
+        visible_floating_entities(&windows, &window_manager, workspace_id, display_bounds);
+    let is_visible_float = |entity: Entity| -> bool { visible_floats.contains(&entity) };
 
     let target = focus_history
         .last_floating(workspace_id)
         .filter(|entity| is_visible_float(*entity))
-        .or_else(|| {
-            windows
-                .iter()
-                .find_map(|(_, e)| is_visible_float(e).then_some(e))
-        });
+        .or_else(|| visible_floats.first().copied());
 
     for (window, entity) in windows.iter() {
         if is_visible_float(entity) && Some(entity) != target {
@@ -522,37 +520,17 @@ fn command_toggle_floating_layer(
     let (active_strip, layer) = &mut *active_workspace;
     let workspace_id = active_strip.id();
     let target_layer = layer.flipped();
-
-    // Floats on other macOS Spaces share the display bounds, so without an
-    // explicit workspace-membership filter they leak into the float set.
-    let workspace_window_ids: std::collections::HashSet<_> = window_manager
-        .windows_in_workspace(workspace_id)
-        .ok()
-        .map(|ids| ids.into_iter().collect())
-        .unwrap_or_default();
-
+    let visible_floats =
+        visible_floating_entities(&windows, &window_manager, workspace_id, display_bounds);
     let visible_float = |entity: Entity| -> bool {
-        let Some((window, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
-            return false;
-        };
-        if !workspace_window_ids.contains(&window.id()) {
-            return false;
-        }
-        let Some(frame) = windows.frame(entity) else {
-            return false;
-        };
-        !display_bounds.intersect(frame).is_empty() && !active_strip.contains(entity)
+        visible_floats.contains(&entity) && !active_strip.contains(entity)
     };
 
     let target = match target_layer {
         FloatingLayer::Front => focus_history
             .last_floating(workspace_id)
             .filter(|entity| visible_float(*entity))
-            .or_else(|| {
-                windows
-                    .iter()
-                    .find_map(|(_, e)| visible_float(e).then_some(e))
-            }),
+            .or_else(|| visible_floats.iter().copied().find(|e| visible_float(*e))),
         FloatingLayer::Behind => focus_history
             .last_managed(workspace_id)
             .filter(|entity| active_strip.contains(*entity))

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,6 +11,7 @@ use tracing::{debug, info};
 mod query;
 
 use crate::config::Config;
+use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
@@ -99,6 +100,10 @@ pub enum Operation {
     /// Raises all visible floating windows on the active display and focuses
     /// the last-floating window (idempotent — repeat presses behave the same).
     RaiseFloating,
+    /// Alt-tab between the floating and tiled tiers of the active workspace.
+    /// Flips `FloatingLayer`, raises the other windows in the new top tier,
+    /// and focuses the tier's last-focused window.
+    ToggleFloatingLayer,
 }
 
 /// Defines operations that can be performed on the mouse.
@@ -139,6 +144,7 @@ pub fn register_commands(app: &mut bevy::app::App) {
             command_focus_unmanaged,
             command_focus_managed,
             command_raise_floating,
+            command_toggle_floating_layer,
             command_swap_focus,
             snap_window,
         ),
@@ -420,6 +426,94 @@ fn command_raise_floating(
     if let Some(entity) = target {
         focus_entity(entity, true, &mut commands);
     }
+}
+
+/// Focus-and-raise are deliberately coupled here: macOS AX raise can't lift a
+/// window above another app's frontmost window, so the target's app must be
+/// made frontmost. Other windows in the new top tier are raised within their
+/// own apps' stacks as a best-effort.
+#[allow(clippy::needless_pass_by_value)]
+fn command_toggle_floating_layer(
+    mut messages: MessageReader<Event>,
+    active_display: ActiveDisplay,
+    mut active_workspace: Single<(&LayoutStrip, &mut FloatingLayer), With<ActiveWorkspaceMarker>>,
+    focus_history: Res<FocusHistory>,
+    window_manager: Res<WindowManager>,
+    windows: Windows,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| {
+        matches!(op, Operation::ToggleFloatingLayer)
+    })
+    .next()
+    .is_none()
+    {
+        return;
+    }
+
+    let display_bounds = active_display.bounds();
+    let (active_strip, layer) = &mut *active_workspace;
+    let workspace_id = active_strip.id();
+    let target_layer = layer.flipped();
+
+    // Floats on other macOS Spaces share the display bounds, so without an
+    // explicit workspace-membership filter they leak into the float set.
+    let workspace_window_ids: std::collections::HashSet<_> = window_manager
+        .windows_in_workspace(workspace_id)
+        .ok()
+        .map(|ids| ids.into_iter().collect())
+        .unwrap_or_default();
+
+    let visible_float = |entity: Entity| -> bool {
+        let Some((window, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
+            return false;
+        };
+        if !workspace_window_ids.contains(&window.id()) {
+            return false;
+        }
+        let Some(frame) = windows.frame(entity) else {
+            return false;
+        };
+        !display_bounds.intersect(frame).is_empty() && !active_strip.contains(entity)
+    };
+
+    let target = match target_layer {
+        FloatingLayer::Front => focus_history
+            .last_floating(workspace_id)
+            .filter(|entity| visible_float(*entity))
+            .or_else(|| {
+                windows
+                    .iter()
+                    .find_map(|(_, e)| visible_float(e).then_some(e))
+            }),
+        FloatingLayer::Behind => focus_history
+            .last_managed(workspace_id)
+            .filter(|entity| active_strip.contains(*entity))
+            .or_else(|| active_strip.all_columns().into_iter().next()),
+    };
+
+    let mut raise = |entity: Entity| {
+        if Some(entity) == target {
+            return;
+        }
+        if let Some(window) = windows.get(entity) {
+            window.raise_without_focus();
+        }
+    };
+    match target_layer {
+        FloatingLayer::Behind => active_strip.all_windows().into_iter().for_each(&mut raise),
+        FloatingLayer::Front => windows
+            .iter()
+            .filter_map(|(_, e)| visible_float(e).then_some(e))
+            .for_each(raise),
+    }
+
+    if let Some(entity) = target {
+        focus_entity(entity, true, &mut commands);
+    }
+
+    **layer = target_layer;
+    debug!("floating layer -> {target_layer:?}");
 }
 
 /// Handles the "swap" command, swapping the positions of the current window with another window in a specified direction.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -96,6 +96,9 @@ pub enum Operation {
     FocusUnmanaged,
     /// Focuses the workspace's last-focused managed (tiled) window.
     FocusManaged,
+    /// Raises all visible floating windows on the active display and focuses
+    /// the last-floating window (idempotent — repeat presses behave the same).
+    RaiseFloating,
 }
 
 /// Defines operations that can be performed on the mouse.
@@ -135,6 +138,7 @@ pub fn register_commands(app: &mut bevy::app::App) {
             command_move_focus,
             command_focus_unmanaged,
             command_focus_managed,
+            command_raise_floating,
             command_swap_focus,
             snap_window,
         ),
@@ -360,6 +364,61 @@ fn command_focus_managed(
     if let Some(entity) = target {
         focus_entity(entity, true, &mut commands);
         reshuffle_around(entity, &mut commands);
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn command_raise_floating(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    active_display: ActiveDisplay,
+    window_manager: Res<WindowManager>,
+    focus_history: Res<FocusHistory>,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| matches!(op, Operation::RaiseFloating))
+        .next()
+        .is_none()
+    {
+        return;
+    }
+
+    let display_bounds = active_display.bounds();
+    let workspace_id = active_display.active_strip().id();
+    // Floats on other macOS Spaces share the display bounds, so without an
+    // explicit workspace-membership filter they leak into the float set.
+    let workspace_window_ids: std::collections::HashSet<_> = window_manager
+        .windows_in_workspace(workspace_id)
+        .ok()
+        .map(|ids| ids.into_iter().collect())
+        .unwrap_or_default();
+
+    let is_visible_float = |entity: Entity| -> bool {
+        let Some((window, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
+            return false;
+        };
+        if !workspace_window_ids.contains(&window.id()) {
+            return false;
+        }
+        let Some(frame) = windows.frame(entity) else {
+            return false;
+        };
+        !display_bounds.intersect(frame).is_empty()
+    };
+
+    let target = focus_history
+        .last_floating(workspace_id)
+        .filter(|entity| is_visible_float(*entity))
+        .or_else(|| windows.iter().find_map(|(_, e)| is_visible_float(e).then_some(e)));
+
+    for (window, entity) in windows.iter() {
+        if is_visible_float(entity) && Some(entity) != target {
+            window.raise_without_focus();
+        }
+    }
+
+    if let Some(entity) = target {
+        focus_entity(entity, true, &mut commands);
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -221,6 +221,56 @@ fn get_window_in_direction(
     }
 }
 
+/// 45° direction cone, closest by squared Euclidean distance.
+/// `First` / `Last` are strip-only and return `None`.
+fn pick_nearest_in_direction(
+    direction: &Direction,
+    focused_center: bevy::math::IVec2,
+    candidates: impl IntoIterator<Item = (Entity, bevy::math::IVec2)>,
+) -> Option<Entity> {
+    candidates
+        .into_iter()
+        .filter_map(|(entity, center)| {
+            let dx = center.x - focused_center.x;
+            let dy = center.y - focused_center.y;
+            let in_direction = match direction {
+                Direction::East => dx > 0 && dy.abs() <= dx.abs(),
+                Direction::West => dx < 0 && dy.abs() <= dx.abs(),
+                Direction::North => dy < 0 && dx.abs() <= dy.abs(),
+                Direction::South => dy > 0 && dx.abs() <= dy.abs(),
+                Direction::First | Direction::Last => return None,
+            };
+            in_direction.then_some((entity, dx * dx + dy * dy))
+        })
+        .min_by_key(|(_, dist_sq)| *dist_sq)
+        .map(|(entity, _)| entity)
+}
+
+fn nearest_float_in_direction(
+    direction: &Direction,
+    focused_entity: Entity,
+    windows: &Windows,
+    display_bounds: IRect,
+) -> Option<Entity> {
+    let focused_center = windows.frame(focused_entity)?.center();
+
+    let candidates = windows.iter().filter_map(|(_, entity)| {
+        if entity == focused_entity {
+            return None;
+        }
+        let (_, _, Some(Unmanaged::Floating)) = windows.get_managed(entity)? else {
+            return None;
+        };
+        let frame = windows.frame(entity)?;
+        if display_bounds.intersect(frame).is_empty() {
+            return None;
+        }
+        Some((entity, frame.center()))
+    });
+
+    pick_nearest_in_direction(direction, focused_center, candidates)
+}
+
 /// Handles the "focus" command, moving focus to a window in a specified direction.
 ///
 /// # Arguments
@@ -265,6 +315,15 @@ fn command_move_focus(
     let Some((_, focused_entity)) = windows.focused() else {
         return;
     };
+
+    if let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(focused_entity) {
+        if let Some(entity) =
+            nearest_float_in_direction(direction, focused_entity, &windows, active_display.bounds())
+        {
+            focus_entity(entity, true, &mut commands);
+        }
+        return;
+    }
 
     // At the right edge going East, enter the fullscreen workspaces.
     let candidate =
@@ -338,7 +397,11 @@ fn command_focus_unmanaged(
     let target = focus_history
         .last_floating(workspace_id)
         .filter(|entity| is_visible_float(*entity))
-        .or_else(|| windows.iter().find_map(|(_, e)| is_visible_float(e).then_some(e)));
+        .or_else(|| {
+            windows
+                .iter()
+                .find_map(|(_, e)| is_visible_float(e).then_some(e))
+        });
 
     if let Some(entity) = target {
         focus_entity(entity, true, &mut commands);
@@ -415,7 +478,11 @@ fn command_raise_floating(
     let target = focus_history
         .last_floating(workspace_id)
         .filter(|entity| is_visible_float(*entity))
-        .or_else(|| windows.iter().find_map(|(_, e)| is_visible_float(e).then_some(e)));
+        .or_else(|| {
+            windows
+                .iter()
+                .find_map(|(_, e)| is_visible_float(e).then_some(e))
+        });
 
     for (window, entity) in windows.iter() {
         if is_visible_float(entity) && Some(entity) != target {
@@ -1364,6 +1431,63 @@ mod tests {
         assert_eq!(
             get_window_in_direction(&west, entities[3], &strip),
             Some(entities[1])
+        );
+    }
+
+    #[test]
+    fn pick_nearest_in_direction_east_picks_closer() {
+        let mut world = World::new();
+        let near = world.spawn(()).id();
+        let far = world.spawn(()).id();
+        let focused = bevy::math::IVec2::new(0, 0);
+        let candidates = vec![
+            (near, bevy::math::IVec2::new(10, 0)),
+            (far, bevy::math::IVec2::new(50, 0)),
+        ];
+        assert_eq!(
+            pick_nearest_in_direction(&Direction::East, focused, candidates),
+            Some(near),
+        );
+    }
+
+    #[test]
+    fn pick_nearest_in_direction_respects_cone() {
+        let mut world = World::new();
+        let candidate = world.spawn(()).id();
+        let focused = bevy::math::IVec2::new(0, 0);
+        // y/x ratio > 1 → outside the 45° east cone.
+        let candidates = vec![(candidate, bevy::math::IVec2::new(10, 20))];
+        assert_eq!(
+            pick_nearest_in_direction(&Direction::East, focused, candidates),
+            None,
+        );
+    }
+
+    #[test]
+    fn pick_nearest_in_direction_ignores_wrong_side() {
+        let mut world = World::new();
+        let west_one = world.spawn(()).id();
+        let focused = bevy::math::IVec2::new(0, 0);
+        let candidates = vec![(west_one, bevy::math::IVec2::new(-10, 0))];
+        assert_eq!(
+            pick_nearest_in_direction(&Direction::East, focused, candidates),
+            None,
+        );
+    }
+
+    #[test]
+    fn pick_nearest_in_direction_first_last_return_none() {
+        let mut world = World::new();
+        let any = world.spawn(()).id();
+        let focused = bevy::math::IVec2::new(0, 0);
+        let candidates = vec![(any, bevy::math::IVec2::new(10, 0))];
+        assert_eq!(
+            pick_nearest_in_direction(&Direction::First, focused, candidates.clone()),
+            None,
+        );
+        assert_eq!(
+            pick_nearest_in_direction(&Direction::Last, focused, candidates),
+            None,
         );
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,6 +11,7 @@ use tracing::{debug, info};
 mod query;
 
 use crate::config::Config;
+use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
@@ -91,6 +92,10 @@ pub enum Operation {
     VirtualMove(Direction, MoveFocus),
     /// Moves the focused window to a virtual strip by its zero-based index.
     VirtualMoveNumber(u32, MoveFocus),
+    /// Focuses the workspace's last-focused floating window.
+    FocusUnmanaged,
+    /// Focuses the workspace's last-focused managed (tiled) window.
+    FocusManaged,
 }
 
 /// Defines operations that can be performed on the mouse.
@@ -128,6 +133,8 @@ pub fn register_commands(app: &mut bevy::app::App) {
             manage_window,
             stack_windows_handler,
             command_move_focus,
+            command_focus_unmanaged,
+            command_focus_managed,
             command_swap_focus,
             snap_window,
         ),
@@ -288,6 +295,71 @@ fn command_move_focus(
         commands.trigger(SendMessageTrigger(Event::Command {
             command: Command::Mouse(MouseMove::ToNextDisplay),
         }));
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn command_focus_unmanaged(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    active_display: ActiveDisplay,
+    focus_history: Res<FocusHistory>,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| matches!(op, Operation::FocusUnmanaged))
+        .next()
+        .is_none()
+    {
+        return;
+    }
+
+    let display_bounds = active_display.bounds();
+    let workspace_id = active_display.active_strip().id();
+    let is_visible_float = |entity: Entity| -> bool {
+        let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
+            return false;
+        };
+        let Some(frame) = windows.frame(entity) else {
+            return false;
+        };
+        !display_bounds.intersect(frame).is_empty()
+    };
+
+    let target = focus_history
+        .last_floating(workspace_id)
+        .filter(|entity| is_visible_float(*entity))
+        .or_else(|| windows.iter().find_map(|(_, e)| is_visible_float(e).then_some(e)));
+
+    if let Some(entity) = target {
+        focus_entity(entity, true, &mut commands);
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn command_focus_managed(
+    mut messages: MessageReader<Event>,
+    active_display: ActiveDisplay,
+    focus_history: Res<FocusHistory>,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| matches!(op, Operation::FocusManaged))
+        .next()
+        .is_none()
+    {
+        return;
+    }
+
+    let active_strip = active_display.active_strip();
+    let workspace_id = active_strip.id();
+
+    let target = focus_history
+        .last_managed(workspace_id)
+        .filter(|entity| active_strip.contains(*entity))
+        .or_else(|| active_strip.all_columns().into_iter().next());
+
+    if let Some(entity) = target {
+        focus_entity(entity, true, &mut commands);
+        reshuffle_around(entity, &mut commands);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,6 +192,7 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "focus_unmanaged" => Operation::FocusUnmanaged,
         "focus_managed" => Operation::FocusManaged,
         "raise_floating" => Operation::RaiseFloating,
+        "togglefloatlayer" => Operation::ToggleFloatingLayer,
         "swap" => Operation::Swap(parse_direction(argv.get(1).ok_or(err)?)?),
         "center" => Operation::Center,
         "resize" => Operation::Resize(

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,6 +191,7 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "focus" => Operation::Focus(parse_direction(argv.get(1).ok_or(err)?)?),
         "focus_unmanaged" => Operation::FocusUnmanaged,
         "focus_managed" => Operation::FocusManaged,
+        "raise_floating" => Operation::RaiseFloating,
         "swap" => Operation::Swap(parse_direction(argv.get(1).ok_or(err)?)?),
         "center" => Operation::Center,
         "resize" => Operation::Resize(

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,8 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
 
     let out = match cmd {
         "focus" => Operation::Focus(parse_direction(argv.get(1).ok_or(err)?)?),
+        "focus_unmanaged" => Operation::FocusUnmanaged,
+        "focus_managed" => Operation::FocusManaged,
         "swap" => Operation::Swap(parse_direction(argv.get(1).ok_or(err)?)?),
         "center" => Operation::Center,
         "resize" => Operation::Resize(

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,10 +188,17 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
     let err = Error::InvalidConfig(format!("{}: Invalid command '{argv:?}'", function_name!()));
 
     let out = match cmd {
-        "focus" => Operation::Focus(parse_direction(argv.get(1).ok_or(err)?)?),
-        "focus_unmanaged" => Operation::FocusUnmanaged,
-        "focus_managed" => Operation::FocusManaged,
-        "raise_floating" => Operation::RaiseFloating,
+        // The bindings key splits on `_`, so `window_focus_unmanaged` arrives
+        // here as ["focus", "unmanaged"] and the suffix tells us the variant.
+        "focus" => match *argv.get(1).ok_or(err.clone())? {
+            "unmanaged" => Operation::FocusUnmanaged,
+            "managed" => Operation::FocusManaged,
+            dir => Operation::Focus(parse_direction(dir)?),
+        },
+        "raise" => match *argv.get(1).ok_or(err.clone())? {
+            "floating" => Operation::RaiseFloating,
+            _ => return Err(err),
+        },
         "togglefloatlayer" => Operation::ToggleFloatingLayer,
         "swap" => Operation::Swap(parse_direction(argv.get(1).ok_or(err)?)?),
         "center" => Operation::Center,

--- a/src/ecs/display.rs
+++ b/src/ecs/display.rs
@@ -1,4 +1,5 @@
 use bevy::app::{App, Plugin, Update};
+use bevy::ecs::component::Component;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::lifecycle::Add;
@@ -287,8 +288,27 @@ fn reparent_existing_workspaces(
                 origin.clone(),
                 LayoutStrip::new(id, 0),
                 SelectedVirtualMarker,
+                FloatingLayer::default(),
                 ChildOf(display_entity),
             ));
+        }
+    }
+}
+
+/// Tracks whether floating windows on a workspace sit above or behind tiled
+/// ones in the OS z-order. Default is `Front` (floats above tiles).
+#[derive(Component, Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FloatingLayer {
+    #[default]
+    Front,
+    Behind,
+}
+
+impl FloatingLayer {
+    pub fn flipped(self) -> Self {
+        match self {
+            Self::Front => Self::Behind,
+            Self::Behind => Self::Front,
         }
     }
 }

--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use bevy::app::{App, Plugin, PostUpdate};
@@ -6,13 +7,14 @@ use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::lifecycle::{Add, Remove};
 use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With};
+use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::system::{Commands, Populated, Query, Res, Single};
 use bevy::prelude::Event as BevyEvent;
 use bevy::time::common_conditions::on_timer;
 use tracing::{Level, debug, error, instrument, trace, warn};
 
-use super::{FocusedMarker, MouseHeldMarker, SystemTheme};
+use super::{FocusedMarker, MouseHeldMarker, SystemTheme, Unmanaged};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
@@ -22,12 +24,73 @@ use crate::ecs::{
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Window, WindowManager};
+use crate::platform::WorkspaceId;
 
 const REFRESH_WINDOW_CHECK_FREQ_MS: u64 = 1000;
+
+#[derive(Default)]
+pub struct TierMemory {
+    pub last_managed: Option<Entity>,
+    pub last_floating: Option<Entity>,
+}
+
+/// Keyed by `WorkspaceId` so toggling on one Space can't reach a window last
+/// focused on another. Cleared on entity despawn (`forget`) so recycled
+/// Entity IDs can't resolve to the wrong window, and on workspace despawn
+/// (`forget_workspace`) to bound the map.
+#[derive(Default, Resource)]
+pub struct FocusHistory {
+    by_workspace: HashMap<WorkspaceId, TierMemory>,
+}
+
+impl FocusHistory {
+    pub fn record(
+        &mut self,
+        workspace: WorkspaceId,
+        entity: Entity,
+        unmanaged: Option<&Unmanaged>,
+    ) {
+        let slot = self.by_workspace.entry(workspace).or_default();
+        match unmanaged {
+            None => slot.last_managed = Some(entity),
+            Some(Unmanaged::Floating) => slot.last_floating = Some(entity),
+            Some(_) => {}
+        }
+    }
+
+    pub fn last_managed(&self, workspace: WorkspaceId) -> Option<Entity> {
+        self.by_workspace
+            .get(&workspace)
+            .and_then(|t| t.last_managed)
+    }
+
+    pub fn last_floating(&self, workspace: WorkspaceId) -> Option<Entity> {
+        self.by_workspace
+            .get(&workspace)
+            .and_then(|t| t.last_floating)
+    }
+
+    pub fn forget(&mut self, entity: Entity) {
+        for slot in self.by_workspace.values_mut() {
+            if slot.last_managed == Some(entity) {
+                slot.last_managed = None;
+            }
+            if slot.last_floating == Some(entity) {
+                slot.last_floating = None;
+            }
+        }
+    }
+
+    pub fn forget_workspace(&mut self, workspace: WorkspaceId) {
+        self.by_workspace.remove(&workspace);
+    }
+}
+
 pub struct FocusEventsPlugin;
 
 impl Plugin for FocusEventsPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<FocusHistory>();
         app.add_systems(
             PostUpdate,
             (
@@ -284,4 +347,81 @@ pub(super) fn stray_focus_observer(
             commands.trigger(SendMessageTrigger(Event::WindowFocused { window_id }));
             commands.entity(timeout_entity).despawn();
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::world::World;
+
+    #[test]
+    fn record_and_read_per_tier() {
+        let mut world = World::new();
+        let managed = world.spawn(()).id();
+        let floating = world.spawn(()).id();
+        let mut history = FocusHistory::default();
+
+        history.record(1, managed, None);
+        history.record(1, floating, Some(&Unmanaged::Floating));
+
+        assert_eq!(history.last_managed(1), Some(managed));
+        assert_eq!(history.last_floating(1), Some(floating));
+    }
+
+    #[test]
+    fn record_ignores_minimized_and_hidden() {
+        let mut world = World::new();
+        let entity = world.spawn(()).id();
+        let mut history = FocusHistory::default();
+
+        history.record(1, entity, Some(&Unmanaged::Minimized));
+        history.record(1, entity, Some(&Unmanaged::Hidden));
+
+        assert_eq!(history.last_managed(1), None);
+        assert_eq!(history.last_floating(1), None);
+    }
+
+    #[test]
+    fn per_workspace_isolation() {
+        let mut world = World::new();
+        let a = world.spawn(()).id();
+        let b = world.spawn(()).id();
+        let mut history = FocusHistory::default();
+
+        history.record(1, a, None);
+        history.record(2, b, None);
+
+        assert_eq!(history.last_managed(1), Some(a));
+        assert_eq!(history.last_managed(2), Some(b));
+    }
+
+    #[test]
+    fn forget_clears_entity_across_workspaces() {
+        let mut world = World::new();
+        let target = world.spawn(()).id();
+        let other = world.spawn(()).id();
+        let mut history = FocusHistory::default();
+
+        history.record(1, target, None);
+        history.record(2, target, Some(&Unmanaged::Floating));
+        history.record(2, other, None);
+
+        history.forget(target);
+
+        assert_eq!(history.last_managed(1), None);
+        assert_eq!(history.last_floating(2), None);
+        assert_eq!(history.last_managed(2), Some(other));
+    }
+
+    #[test]
+    fn forget_workspace_drops_entry() {
+        let mut world = World::new();
+        let entity = world.spawn(()).id();
+        let mut history = FocusHistory::default();
+
+        history.record(1, entity, None);
+        history.forget_workspace(1);
+
+        assert_eq!(history.last_managed(1), None);
+    }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -23,6 +23,7 @@ use super::{
 };
 
 use crate::config::{Config, decorations::BorderRadiusOption};
+use crate::ecs::display::FloatingLayer;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
@@ -131,6 +132,7 @@ pub fn gather_displays(window_manager: Res<WindowManager>, mut commands: Command
                     origin.clone(),
                     ActiveWorkspaceMarker,
                     SelectedVirtualMarker,
+                    FloatingLayer::default(),
                     ChildOf(entity),
                 ));
             } else {
@@ -138,6 +140,7 @@ pub fn gather_displays(window_manager: Res<WindowManager>, mut commands: Command
                     strip,
                     origin.clone(),
                     SelectedVirtualMarker,
+                    FloatingLayer::default(),
                     ChildOf(entity),
                 ));
             }

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -20,6 +20,7 @@ use super::{
     StrayFocusEvent, SystemTheme, Timeout, Unmanaged,
 };
 use crate::config::{Config, WindowParams};
+use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
@@ -181,6 +182,7 @@ pub(super) fn window_focused_trigger(
     applications: Query<&Application>,
     windows: Windows,
     mut workspaces: Query<(Entity, &mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    mut focus_history: ResMut<FocusHistory>,
     config: Res<Config>,
     mut commands: Commands,
 ) {
@@ -232,18 +234,24 @@ pub(super) fn window_focused_trigger(
         // Handle tab switching: if the focused window is a tab, make it the leader.
         // Also reactivate the owning virtual strip before treating duplicate
         // focus as a no-op; the focus marker can be stale on a hidden strip.
+        // Track the active workspace as a fallback so focus_history can record
+        // a workspace id even when the entity hasn't been routed into a strip.
         let mut owner = None;
+        let mut owning_workspace_id = None;
+        let mut active_workspace_id = None;
         for (strip_entity, mut strip, active) in &mut workspaces {
-            if !strip.contains(entity) {
-                continue;
+            if active {
+                active_workspace_id = Some(strip.id());
             }
-            if let Ok(index) = strip.index_of(entity)
-                && let Some(column) = strip.get_column_mut(index)
-            {
-                column.move_to_front(entity);
+            if owner.is_none() && strip.contains(entity) {
+                if let Ok(index) = strip.index_of(entity)
+                    && let Some(column) = strip.get_column_mut(index)
+                {
+                    column.move_to_front(entity);
+                }
+                owning_workspace_id = Some(strip.id());
+                owner = Some((strip_entity, active));
             }
-            owner = Some((strip_entity, active));
-            break;
         }
 
         if let Some((strip_entity, active)) = owner
@@ -253,6 +261,14 @@ pub(super) fn window_focused_trigger(
             entity_commands
                 .try_insert(ActiveWorkspaceMarker)
                 .try_insert(SelectedVirtualMarker);
+        }
+
+        // Record before the already-focused short-circuit below: focus_entity
+        // sets FocusedMarker synchronously, so OS-confirmed events for the
+        // same entity would otherwise skip the write.
+        if let Some(workspace_id) = owning_workspace_id.or(active_workspace_id) {
+            let unmanaged = windows.get_managed(entity).and_then(|(_, _, u)| u);
+            focus_history.record(workspace_id, entity, unmanaged);
         }
 
         if already_focused {
@@ -720,6 +736,7 @@ pub(super) fn window_destroyed_trigger(
     active_display: ActiveDisplay,
     mut apps: Query<&mut Application>,
     mut config: GlobalState,
+    mut focus_history: ResMut<FocusHistory>,
     mut commands: Commands,
 ) {
     for event in messages.read() {
@@ -750,6 +767,7 @@ pub(super) fn window_destroyed_trigger(
             &mut config,
             &mut commands,
         );
+        focus_history.forget(entity);
 
         if let Ok(mut entity_commands) = commands.get_entity(entity) {
             entity_commands.try_despawn();

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -17,6 +17,7 @@ use tracing::{Level, debug, error, instrument, warn};
 use super::{ActiveDisplayMarker, SpawnWindowTrigger};
 use crate::commands::{Direction, MoveFocus, Operation, filter_window_operations};
 use crate::config::Config;
+use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
@@ -335,6 +336,7 @@ fn workspace_created_trigger(
             strip,
             origin,
             SelectedVirtualMarker,
+            FloatingLayer::default(),
             ChildOf(display_entity),
         ));
     }
@@ -629,6 +631,7 @@ fn handle_virtual_window_moves(
                 new_strip,
                 Position(origin),
                 SelectedVirtualMarker,
+                FloatingLayer::default(),
                 ChildOf(display_entity),
             ));
             if stay {
@@ -732,6 +735,7 @@ fn switch_virtual_workspace_bind(
                     Position(active_display.bounds().min),
                     ChildOf(active_display.entity()),
                     SelectedVirtualMarker,
+                    FloatingLayer::default(),
                     ActiveWorkspaceMarker,
                 ));
                 flash_message(format!("{}", *target_virtual_index + 1), 1.0, &mut commands);

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -8,7 +8,7 @@ use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
-use bevy::ecs::system::{Commands, Local, Populated, Query, Res, Single};
+use bevy::ecs::system::{Commands, Local, Populated, Query, Res, ResMut, Single};
 use bevy::time::common_conditions::on_timer;
 use std::collections::HashSet;
 use std::time::Duration;
@@ -17,6 +17,7 @@ use tracing::{Level, debug, error, instrument, warn};
 use super::{ActiveDisplayMarker, SpawnWindowTrigger};
 use crate::commands::{Direction, MoveFocus, Operation, filter_window_operations};
 use crate::config::Config;
+use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
@@ -265,12 +266,14 @@ fn detect_moved_windows(
 fn workspace_destroyed_trigger(
     mut messages: MessageReader<Event>,
     mut workspaces: Populated<(&mut LayoutStrip, Entity, Option<&NativeFullscreenMarker>)>,
+    mut focus_history: ResMut<FocusHistory>,
     mut commands: Commands,
 ) {
     for event in messages.read() {
         let Event::SpaceDestroyed { space_id } = event else {
             continue;
         };
+        focus_history.forget_workspace(*space_id);
 
         let Some((entity, fullscreen)) =
             workspaces.iter().find_map(|(strip, entity, fullscreen)| {

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -65,7 +65,7 @@ pub trait WindowApi: Send + Sync {
     fn focus_with_raise(&self, psn: ProcessSerialNumber);
     /// Raises the window in the OS z-order without changing focus. Used to
     /// shuffle the floating-vs-tiled tier order. Best-effort: AX raise can't
-    /// lift a window above another app's frontmost window — that's PR 2's job.
+    /// lift a window above another app's frontmost window.
     fn raise_without_focus(&self);
     fn pid(&self) -> Result<Pid>;
     fn set_padding(&mut self, padding: WindowPadding);

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -63,6 +63,10 @@ pub trait WindowApi: Send + Sync {
         focused_psn: ProcessSerialNumber,
     );
     fn focus_with_raise(&self, psn: ProcessSerialNumber);
+    /// Raises the window in the OS z-order without changing focus. Used to
+    /// shuffle the floating-vs-tiled tier order. Best-effort: AX raise can't
+    /// lift a window above another app's frontmost window — that's PR 2's job.
+    fn raise_without_focus(&self);
     fn pid(&self) -> Result<Pid>;
     fn set_padding(&mut self, padding: WindowPadding);
     fn horizontal_padding(&self) -> i32;
@@ -549,6 +553,13 @@ impl WindowApi for WindowOS {
             _SLPSSetFrontProcessWithOptions(&psn, window_id, CPS_USER_GENERATED);
         }
         self.make_key_window(&psn);
+        let element_ref = self.ax_element.as_ptr();
+        let action = CFString::from_static_str(kAXRaiseAction);
+        unsafe { AXUIElementPerformAction(element_ref, &action) };
+    }
+
+    #[instrument(level = Level::DEBUG)]
+    fn raise_without_focus(&self) {
         let element_ref = self.ax_element.as_ptr();
         let action = CFString::from_static_str(kAXRaiseAction);
         unsafe { AXUIElementPerformAction(element_ref, &action) };

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,8 +1,10 @@
 use bevy::prelude::*;
+use bevy::ecs::query::With;
 
 use crate::commands::{Command, Direction, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::SpawnWindowTrigger;
+use crate::ecs::display::FloatingLayer;
 use crate::ecs::{ActiveWorkspaceMarker, layout::LayoutStrip};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
@@ -495,6 +497,42 @@ fn mouse_outside_corner_still_changes_focus() {
             // In the mock, find_window_at_point always returns window 0, so window 0
             // should now be focused (changed from window 2).
             assert_focused!(world, 0);
+        })
+        .run(commands);
+}
+
+#[test]
+fn toggle_floating_layer_flips_state() {
+    fn current_layer(world: &mut World) -> FloatingLayer {
+        let mut query = world.query_filtered::<&FloatingLayer, With<ActiveWorkspaceMarker>>();
+        *query
+            .single(world)
+            .expect("active workspace has FloatingLayer")
+    }
+
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::ToggleFloatingLayer),
+        },
+        Event::Command {
+            command: Command::Window(Operation::ToggleFloatingLayer),
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(Config::default())
+        .with_windows(3)
+        .on_iteration(0, |world| {
+            assert_eq!(current_layer(world), FloatingLayer::Front);
+        })
+        .on_iteration(1, |world| {
+            assert_eq!(current_layer(world), FloatingLayer::Behind);
+        })
+        .on_iteration(2, |world| {
+            assert_eq!(current_layer(world), FloatingLayer::Front);
         })
         .run(commands);
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,11 +1,11 @@
-use bevy::prelude::*;
 use bevy::ecs::query::With;
+use bevy::prelude::*;
 
 use crate::commands::{Command, Direction, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::SpawnWindowTrigger;
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, layout::LayoutStrip};
+use crate::ecs::{ActiveWorkspaceMarker, Unmanaged, layout::LayoutStrip};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
 use crate::{assert_focused, assert_window_at, assert_window_size};
@@ -533,6 +533,71 @@ fn toggle_floating_layer_flips_state() {
         })
         .on_iteration(2, |world| {
             assert_eq!(current_layer(world), FloatingLayer::Front);
+        })
+        .run(commands);
+}
+
+#[test]
+fn focus_unmanaged_ignores_floats_from_other_workspaces() {
+    let mut harness = TestHarness::new();
+    let mock_app = setup_process(harness.app.world_mut());
+    let internal_queue = harness.internal_queue.clone();
+
+    let active_queue = internal_queue.clone();
+    let other_queue = internal_queue.clone();
+    let active_app = mock_app.clone();
+    let other_app = mock_app;
+    let windows: TestWindowSpawner = Box::new(move |workspace_id| {
+        let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+        if workspace_id == TEST_WORKSPACE_ID {
+            let origin = Origin::new(0, 0);
+            vec![Window::new(Box::new(MockWindow::new(
+                0,
+                IRect::from_corners(origin, origin + size),
+                active_queue.clone(),
+                active_app.clone(),
+            )))]
+        } else {
+            let origin = Origin::new(600, 0);
+            vec![Window::new(Box::new(MockWindow::new(
+                99,
+                IRect::from_corners(origin, origin + size),
+                other_queue.clone(),
+                other_app.clone(),
+            )))]
+        }
+    });
+    let wm = MockWindowManager {
+        windows,
+        workspaces: vec![TEST_WORKSPACE_ID, TEST_WORKSPACE_ID + 1],
+    };
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::FocusUnmanaged),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    harness
+        .with_wm(wm)
+        .on_iteration(0, |world| {
+            let off_workspace_float = find_window_entity(99, world);
+            world
+                .entity_mut(off_workspace_float)
+                .insert(Unmanaged::Floating);
+            assert_focused!(world, 0);
+        })
+        .on_iteration(1, |world| {
+            let active_float = find_window_entity(0, world);
+            world.entity_mut(active_float).insert(Unmanaged::Floating);
+            assert_focused!(world, 0);
+        })
+        .on_iteration(2, |world| {
+            assert_focused!(world, 0);
         })
         .run(commands);
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -435,6 +435,11 @@ impl WindowApi for MockWindow {
         self.app.inner.force_write().focused_id = Some(self.id);
     }
 
+    #[instrument(level = Level::DEBUG, skip(self))]
+    fn raise_without_focus(&self) {
+        debug!("{}: id {}", function_name!(), self.id);
+    }
+
     #[instrument(level = Level::TRACE, skip(self), ret)]
     fn pid(&self) -> Result<Pid> {
         Ok(TEST_PROCESS_ID)


### PR DESCRIPTION
Hey, took a stab at #220 and #194. First time submitting anything this size here, so apologies up front if I've gone a direction you weren't planning on. Totally fine if this isn't the shape you'd want it in.

Would close #220, #194.

The approach borrows the floating-tier focus model from `Fjx-dylanZ/paneru` and ports the pieces I thought fit cleanly here. Three primitives, four commands.

**Primitives**
- `FocusHistory`: per-workspace `Resource` that remembers the last-focused window in each tier (managed and floating). Forgets on entity despawn and workspace destroy.
- `FloatingLayer`: per-workspace `Component` tracking whether floats sit in front of or behind the tiles. Defaults to `Front`.
- `raise_without_focus()`: trait method on `WindowApi`, implemented via `AXUIElementPerformAction(kAXRaiseAction)`.

**Commands**
- `window_focus_unmanaged`: focus the workspace's last-focused float.
- `window_focus_managed`: focus the workspace's last-focused tile.
- `window_raise_floating`: raise every visible float on the workspace, focus the last one. Idempotent on repeat presses.
- `window_togglefloatlayer`: flip the tier order, raise the new top tier, focus that tier's last-focused window.

`Focus(Direction)` now branches on the focused window. If it's a float, navigation stays in the float tier using a 45-degree cone, Euclidean nearest. Floats and tiles don't share a directional graph.

**Out of scope**

I didn't try to fix #242 here. The FFM oscillation traces back to `_SLPSSetFrontProcessWithOptions` bringing the target app frontmost on every cross-app focus, which reshuffles z-order in the overlap zones. The cleanest path I've found needs SLS-level z-order control via a `dlopen`/`dlsym` SkyLight wrapper (the pattern OmniWM uses). That feels like it deserves its own review, so I'd rather come back with it as a follow-up if you're open to it.

**Commits**

Eight feature slices plus a parser fix on top. Each one compiles and tests on its own.

**Tests**
- 5 unit tests for `FocusHistory` (record/forget/per-workspace isolation, Minimized/Hidden ignored)
- 4 unit tests for `pick_nearest_in_direction` (cone, wrong-side, First/Last return None)
- 1 integration test for the layer flip across three iterations, plus a workspace-isolation test for `window_focus_unmanaged`
- 113 tests pass. `cargo clippy --all-targets -- -D warnings` is clean apart from one `duration_suboptimal_units` at `src/config.rs:1864` that already exists on `main`.

I ran a live session of around 30 rapid toggles of `window_togglefloatlayer` across two apps and four windows. No state drift, no warnings, no regression on tile-to-tile focus. The other three commands and the float directional branch I tested less aggressively, so they might benefit from a longer soak before they ship.

No hard feelings if you'd rather close it, or if it needs reworking before it fits. Credit to `Fjx-dylanZ/paneru` for the original implementation I borrowed from.
