### PR TITLE
feat: Fix false-positive native tab detection + add opt-out

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,6 +31,7 @@ General behavior settings for the window manager.
 | `window_resize_cycle` | Boolean | `true` | If disabled, `window_resize` and `window_shrink` stop at the largest/smallest preset instead of cycling back. |
 | `mouse_resize_modifier` | String | *None* | If enabled allows window resizing using mouse movement. For example `cmd + shift` will allow resizing of the window when holding those keys. Proximity of the pointer to left or right window edge determines which side will be adjusted. |
 | `reap_empty_workspaces` | String | `false` | If enabled, a virtual workspace without any windows will be removed. |
+| `disable_native_tabs` | Boolean | `false` | If enabled, Paneru will not auto-merge a newly-spawned window into a tab group with an existing same-app sibling that shares its frame. Use this if you find unrelated windows being grouped together. |
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -767,6 +767,14 @@ impl Config {
             .is_some_and(|reap| reap)
     }
 
+    pub fn native_tabs_enabled(&self) -> bool {
+        // Default is enabled.
+        !self
+            .options()
+            .disable_native_tabs
+            .is_some_and(|disabled| disabled)
+    }
+
     pub fn workspace_menu_status(&self) -> bool {
         self.inner()
             .decorations
@@ -1036,6 +1044,11 @@ pub struct MainOptions {
     /// If enabled, an empty virtual workspace will be removed.
     /// Default: true.
     pub reap_empty_workspaces: Option<bool>,
+
+    /// Disable detection of native macOS tabs. When set, newly-spawned windows are
+    /// never auto-merged into a tab group with an existing same-app sibling.
+    /// Default: false.
+    pub disable_native_tabs: Option<bool>,
 }
 
 /// Returns a default set of column widths.

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -68,6 +68,8 @@ pub fn register_systems(app: &mut bevy::app::App) {
     };
     let workspace_menu_status =
         |config: Option<Res<Config>>| config.is_some_and(|config| config.workspace_menu_status());
+    let native_tabs_enabled =
+        |config: Option<Res<Config>>| config.is_none_or(|config| config.native_tabs_enabled());
 
     app.add_systems(
         Startup,
@@ -77,7 +79,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
         PreUpdate,
         (
             systems::window_creation_event,
-            systems::detect_tabbed_windows,
+            systems::detect_tabbed_windows.run_if(native_tabs_enabled),
             systems::pump_events,
         ),
     );

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1049,23 +1049,29 @@ pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut comm
 
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn detect_tabbed_windows(
-    created: Populated<(Entity, &Bounds, &ChildOf), Added<Window>>,
+    created: Populated<(Entity, &Position, &Bounds, &ChildOf), Added<Window>>,
     windows: Query<(Entity, &Window, &Position, &Bounds, &ChildOf), With<Window>>,
     apps: Query<Entity, With<Application>>,
     mut workspaces: Query<&mut LayoutStrip>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
-    for (entity, Bounds(bounds), child) in created {
+    for (entity, Position(position), Bounds(bounds), child) in created {
         let Ok(app_entity) = apps.get(child.parent()) else {
             continue;
         };
 
-        // Overlapping Frame Strategy: check if this window overlaps exactly with an existing
-        // window from the same application. If so, it's likely a native tab.
+        // Overlapping Frame Strategy: native macOS tabs share an *exact* frame with their
+        // leader — same origin and same size. Matching on width alone yields false
+        // positives whenever an app re-opens with its default geometry while a same-app
+        // sibling happens to be off-screen (scrolled out of the strip, on another
+        // workspace, behind a fullscreen window), so we require the full frame to agree.
         let tabbed = windows.iter().find_map(
             |(leader, window, Position(leader_position), Bounds(leader_bounds), parent)| {
-                (leader != entity && parent.parent() == app_entity && leader_bounds.x == bounds.x)
+                (leader != entity
+                    && parent.parent() == app_entity
+                    && leader_bounds == bounds
+                    && leader_position == position)
                     .then_some((leader, window.id(), leader_position))
             },
         );

--- a/src/tests/tabs.rs
+++ b/src/tests/tabs.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 use crate::assert_window_size;
 use crate::commands::{Command, MoveFocus, Operation};
+use crate::config::{Config, MainOptions};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::{ActiveWorkspaceMarker, Bounds, SpawnWindowTrigger};
 use crate::events::Event;
@@ -168,6 +169,99 @@ fn test_native_tab_removal_keeps_remaining_window_column() {
             assert_eq!(strip.len(), 1, "removing a tab should not empty the column");
             assert_eq!(strip.tab_group(tab_zero), None);
             assert_eq!(strip.index_of(tab_zero).unwrap(), 0);
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_offscreen_same_app_same_width_different_frame_not_tabbed() {
+    // Regression: a same-app sibling that happens to be off-screen (scrolled out of
+    // the strip, on another space, etc.) with merely the same width as the new
+    // window must not be misidentified as a native tab. Real native tabs share the
+    // leader's full frame; partial matches must not trigger conversion.
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(0, move |world, state| {
+            let leader = find_window_entity(0, world);
+            let leader_frame = world
+                .get::<Window>(leader)
+                .map(|window| window.frame())
+                .expect("frame should exist");
+
+            // Same width as the leader, but a different origin and a different
+            // height — what a freshly-spawned same-app window typically looks like.
+            let mut frame = leader_frame;
+            frame.min.y += 50;
+            frame.max.y = frame.min.y + leader_frame.height() / 2;
+
+            let window = state.spawn_window(TEST_PROCESS_ID, TEST_WORKSPACE_ID, 1, frame);
+            // Pretend the existing window is off-screen so the only thing preventing
+            // a false positive is the frame check.
+            state.window_visible(0, false);
+            world.trigger(SpawnWindowTrigger(vec![window]));
+        })
+        .on_iteration(1, move |world, _state| {
+            let leader = find_window_entity(0, world);
+            let new_window = find_window_entity(1, world);
+            let strip = world
+                .query::<&LayoutStrip>()
+                .single(world)
+                .expect("getting layout strip");
+            assert!(!strip.tabbed(leader));
+            assert!(!strip.tabbed(new_window));
+            assert_eq!(
+                strip.len(),
+                2,
+                "non-matching frames must get their own column"
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_disable_native_tabs_skips_detection() {
+    // Setting `disable_native_tabs = true` must short-circuit the detector even
+    // when the new window's frame matches the leader exactly.
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    let options = MainOptions {
+        disable_native_tabs: Some(true),
+        ..MainOptions::default()
+    };
+    let config: Config = (options, vec![]).into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .on_iteration(0, move |world, state| {
+            spawn_matching_native_tab(world, state, 0);
+        })
+        .on_iteration(1, move |world, _state| {
+            let leader = find_window_entity(0, world);
+            let new_window = find_window_entity(1, world);
+            let strip = world
+                .query::<&LayoutStrip>()
+                .single(world)
+                .expect("getting layout strip");
+            assert!(!strip.tabbed(leader));
+            assert!(!strip.tabbed(new_window));
+            assert_eq!(
+                strip.len(),
+                2,
+                "detector must be disabled — windows stay in separate columns"
+            );
         })
         .run(commands);
 }


### PR DESCRIPTION
### Problem
Spawning a new window of an app (e.g. `kitty`) sometimes left it visually stuck on top
of an existing same-app window. Root cause: `detect_tabbed_windows` matched on width
only, plus a "leader not in `windows_on_screen()`" signal — but in a sliding tiler "not
 on screen" is a normal state (scrolled out of the strip, other workspace, behind a
fullscreen window). Any new window with the same default width as an off-screen sibling
 got absorbed into a tab group.

### Fix
- **Tighten the heuristic** (`src/ecs/systems.rs`): require the new window's full frame
 (`Position` *and* `Bounds`) to match the leader's. Real native macOS tabs always share
 the leader's frame exactly; partial matches are now rejected.
- **Add opt-out**: new `disable_native_tabs` boolean in `[options]` (default `false`).
Gates the detector via a `run_if` on system registration.

### Config
```toml
[options]
disable_native_tabs = true
```

Tests

- test_offscreen_same_app_same_width_different_frame_not_tabbed — regression for the
kitty case.
- test_disable_native_tabs_skips_detection — verifies the opt-out short-circuits
detection even on an exact frame match.
- Existing tab tests unchanged and still passing (the helper already spawns with the
leader's full frame).