### PR TITLE
fix: re-enter active strip when focused window is off-strip

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -353,9 +353,15 @@ fn command_move_focus(
         return;
     }
 
-    // At the right edge going East, enter the fullscreen workspaces.
-    let candidate =
+    // If focus is on a window that no longer lives in the active strip
+    // (e.g. it just became floating, was minimised on another row, or
+    // the OS handed focus to a window we don't track on this strip),
+    // `get_window_in_direction` would return None and the user would
+    // be unable to leave that window. Enter the active strip from the
+    // appropriate side so subsequent presses behave normally.
+    let candidate = if active_strip.contains(focused_entity) {
         get_window_in_direction(direction, focused_entity, active_strip).or_else(|| {
+            // At the right edge going East, enter the fullscreen workspaces.
             (matches!(direction, Direction::East)
                 && active_strip.right_neighbour(focused_entity).is_none())
             .then(|| {
@@ -367,7 +373,16 @@ fn command_move_focus(
                     .and_then(|(strip, _)| strip.get(0).ok().and_then(|col| col.top()))
             })
             .flatten()
-        });
+        })
+    } else {
+        match direction {
+            Direction::East | Direction::First => {
+                active_strip.first().ok().and_then(|col| col.top())
+            }
+            Direction::West | Direction::Last => active_strip.last().ok().and_then(|col| col.top()),
+            Direction::North | Direction::South => None,
+        }
+    };
 
     if let Some(entity) = candidate {
         focus_entity(entity, true, &mut commands);

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -480,6 +480,129 @@ fn test_external_focus_reactivates_hidden_virtual_strip_when_marker_is_stale() {
         .run(commands);
 }
 
+// When the focused window leaves the active strip (e.g. it just became
+// floating, or the OS handed focus to an off-strip window), window_focus
+// east/west must enter the strip from the appropriate side rather than
+// silently doing nothing.
+fn focused_window_id(world: &mut World) -> i32 {
+    let mut q = world.query::<(&Window, Has<crate::ecs::FocusedMarker>)>();
+    q.iter(world)
+        .find_map(|(w, f)| f.then_some(w.id()))
+        .expect("a focused window")
+}
+
+fn entity_to_window_id(world: &mut World, entity: Entity) -> i32 {
+    let mut q = world.query::<(&Window, Entity)>();
+    q.iter(world)
+        .find_map(|(w, e)| (e == entity).then_some(w.id()))
+        .expect("entity must be a Window")
+}
+
+fn active_strip_first_id(world: &mut World) -> i32 {
+    let entity = {
+        let mut q = world.query_filtered::<&LayoutStrip, With<ActiveWorkspaceMarker>>();
+        let strip = q.single(world).expect("a single active strip");
+        strip
+            .first()
+            .expect("strip should have a column")
+            .top()
+            .expect("column should have a top entity")
+    };
+    entity_to_window_id(world, entity)
+}
+
+fn active_strip_last_id(world: &mut World) -> i32 {
+    let entity = {
+        let mut q = world.query_filtered::<&LayoutStrip, With<ActiveWorkspaceMarker>>();
+        let strip = q.single(world).expect("a single active strip");
+        strip
+            .last()
+            .expect("strip should have a column")
+            .top()
+            .expect("column should have a top entity")
+    };
+    entity_to_window_id(world, entity)
+}
+
+// Strip the currently focused entity out of every LayoutStrip so the
+// "focused window not in active strip" condition is reproduced regardless
+// of how the harness happened to populate the strip. Without this, the
+// init-time duplicate-insertion in the test scheduler keeps the entity in
+// the strip and the bug is masked.
+fn remove_focused_from_all_strips(world: &mut World) {
+    let entity = {
+        let mut q = world.query_filtered::<Entity, With<crate::ecs::FocusedMarker>>();
+        q.single(world).expect("a single focused entity")
+    };
+    let mut q = world.query::<&mut LayoutStrip>();
+    for mut strip in q.iter_mut(world) {
+        while strip.contains(entity) {
+            strip.remove(entity);
+        }
+    }
+}
+
+#[test]
+fn test_focus_recovers_when_focused_window_is_outside_strip() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(0, |world, _state| {
+            // Make the focused entity genuinely live outside any strip,
+            // mirroring the state the user reported: the OS handed focus
+            // to a window Paneru doesn't track on its active strip.
+            remove_focused_from_all_strips(world);
+        })
+        .on_iteration(1, |world, _state| {
+            // Before the fix: get_window_in_direction returns None because
+            // active_strip.index_of(focused) fails for a window that's not
+            // in the strip, so East is a silent no-op and focus stays on 0.
+            let focused = focused_window_id(world);
+            assert_ne!(
+                focused, 0,
+                "focus must leave the off-strip window 0 when pressing East",
+            );
+            let expected = active_strip_first_id(world);
+            assert_eq!(
+                focused, expected,
+                "East from outside the strip enters at the first (leftmost) column",
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_focus_west_from_outside_strip_enters_at_last_column() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::West)),
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(0, |world, _state| {
+            remove_focused_from_all_strips(world);
+        })
+        .on_iteration(1, |world, _state| {
+            let focused = focused_window_id(world);
+            let expected = active_strip_last_id(world);
+            assert_ne!(focused, 0);
+            assert_eq!(
+                focused, expected,
+                "West from outside the strip enters at the last (rightmost) column",
+            );
+        })
+        .run(commands);
+}
+
 #[test]
 fn test_external_focus_restores_app_hidden_window_to_original_virtual_strip() {
     let commands = vec![


### PR DESCRIPTION
## Summary

`command_move_focus` would silently no-op when the focused entity left the active strip — e.g. after going floating, after being minimised on another workspace, or when the OS handed focus to a window Paneru doesn't track. Pressing East/West/First/Last in that state did nothing because `active_strip.index_of(focused)` returned `None` and the function bailed out.

This patch makes off-strip focus a *recoverable* state for directional commands:
- **East / First** enter the strip at its first (leftmost) column.
- **West / Last** enter the strip at its last (rightmost) column.

## Test plan

- [x] New regression tests `test_focus_recovers_when_focused_window_is_outside_strip` and `test_focus_west_from_outside_strip_enters_at_last_column` cover both directions
- [x] Existing focus tests still pass