### PR TITLE
fix: re-insert orphaned floating window when toggling back to managed

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -858,7 +858,12 @@ fn full_width_window(
 /// * `windows` - A mutable query for `Window` components, their `Entity`, and whether they have the `Unmanaged` marker.
 /// * `commands` - Bevy commands to modify entities.
 #[allow(clippy::needless_pass_by_value)]
-fn manage_window(mut messages: MessageReader<Event>, windows: Windows, mut commands: Commands) {
+fn manage_window(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    mut commands: Commands,
+) {
     if filter_window_operations(&mut messages, |op| matches!(op, Operation::Manage))
         .next()
         .is_none()
@@ -877,12 +882,30 @@ fn manage_window(mut messages: MessageReader<Event>, windows: Windows, mut comma
         window.id(),
         unmanaged.is_some()
     );
+    let was_unmanaged = unmanaged.is_some();
     if let Ok(mut entity_commands) = commands.get_entity(entity) {
-        if unmanaged.is_some() {
+        if was_unmanaged {
             entity_commands.try_remove::<Unmanaged>();
         } else {
             entity_commands.try_insert(Unmanaged::Floating);
         }
+    }
+
+    // Going floating -> managed only flips the component. Nothing else in
+    // the pipeline reinserts the window into a strip, so if it had been
+    // stripped of membership (spawn-floating path in window_unmanaged_trigger
+    // strip.removes; orphan rescue in find_orphaned_workspaces despawns the
+    // strip) the toggle is invisible — the window stays where it floated
+    // and the user thinks the keybind is broken. Append to the active
+    // strip and reshuffle so the layout pipeline tiles it.
+    if was_unmanaged
+        && !workspaces.iter().any(|(strip, _)| strip.contains(entity))
+        && let Some(mut strip) = workspaces
+            .iter_mut()
+            .find_map(|(strip, active)| active.then_some(strip))
+    {
+        strip.append(entity);
+        reshuffle_around(entity, &mut commands);
     }
 }
 


### PR DESCRIPTION
## Summary

Toggling a window from floating → managed only flipped the \`Unmanaged\` component — nothing else in the pipeline reinserted the window into a strip. So if the window had been **stripped of membership** while it was floating, the toggle had no visible effect:

- The **spawn-floating path** in \`window_unmanaged_trigger\` calls \`strip.remove(entity)\` so newly-floated windows have no column.
- The **orphan rescue** in \`find_orphaned_workspaces\` can despawn the entire strip the window once belonged to.

Either path leaves the window with no home in the layout, so toggling \"Manage\" appeared broken — the user thinks the keybind is dead, but the component flag *did* flip.

This fix appends the window to the active strip and calls \`reshuffle_around\` whenever a managed-toggle has no current strip membership, so the layout pipeline tiles it again.

## Test plan

- [x] Existing test suite passes
- [x] Manually verified: float a window, kill its source strip via workspace switching, then toggle back to managed — the window now lands in the active strip instead of staying as a stuck float