### PR TITLE
fix: consider widest window as the column width

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -801,7 +801,7 @@ fn resize_window(
         .ok()
         .and_then(|idx| strip.get(idx).ok())
     {
-        for sibling in stack.iter().flat_map(StackItem::all_windows) {
+        for sibling in stack.iter().flat_map(StackItem::window_iter) {
             if sibling != entity
                 && let Some(size) = windows.size(sibling)
             {
@@ -1108,7 +1108,7 @@ fn equalize_column(
         let equal_height = active_display.bounds().height() / i32::try_from(stack.len()).unwrap();
 
         for item in &stack {
-            for entity in item.all_windows() {
+            for entity in item.window_iter() {
                 if let Some(size) = windows.size(entity) {
                     commands.resize_entity(entity, size.with_y(equal_height));
                 }

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -108,6 +108,30 @@ impl Column {
         }
     }
 
+    pub fn width<W>(&self, get_window_frame: &W) -> Option<i32>
+    where
+        W: Fn(Entity) -> Option<IRect>,
+    {
+        match self {
+            Column::Single(entity) | Column::Fullscren(entity) => {
+                get_window_frame(*entity).as_ref().map(IRect::width)
+            }
+            Column::Stack(items) => items
+                .iter()
+                .filter_map(StackItem::top)
+                .filter_map(get_window_frame)
+                .map(|frame| frame.width())
+                .max(),
+            Column::Tabs(tabs) => tabs
+                .first()
+                .copied()
+                .map(get_window_frame)
+                .flatten()
+                .as_ref()
+                .map(IRect::width),
+        }
+    }
+
     /// Returns the entity at the given index, or the last entity if the index exceeds the size.
     pub fn at_or_last(&self, index: usize) -> Option<Entity> {
         match self {
@@ -599,10 +623,7 @@ impl LayoutStrip {
                 let heights =
                     binpack_heights(&current_heights, MIN_WINDOW_HEIGHT, layout_strip_height)?;
 
-                let column_width = items
-                    .first()
-                    .and_then(|item| item.top().and_then(get_window_frame))
-                    .map(|frame| frame.width())?;
+                let column_width = column.width(get_window_frame)?;
 
                 let mut next_y = 0;
                 let frames = items
@@ -642,21 +663,15 @@ impl LayoutStrip {
     {
         let mut left_edge = 0;
 
-        self.all_columns()
-            .into_iter()
-            .filter_map(|entity| {
-                let frame = get_window_frame(entity);
-                let column = self
-                    .index_of(entity)
-                    .ok()
-                    .and_then(|index| self.columns.get(index));
-                column.zip(frame)
-            })
-            .map(move |(column, frame)| {
+        self.columns().filter_map(move |column| {
+            let width = column.width(get_window_frame);
+
+            width.map(|width| {
                 let temp = left_edge;
-                left_edge += frame.width();
+                left_edge += width;
                 (column, temp)
             })
+        })
     }
 
     pub fn above(&self, entity: Entity) -> Option<Entity> {

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -10,6 +10,8 @@ use bevy::ecs::system::{Commands, ParamSet, Populated, Query, Res};
 use bevy::ecs::world::Ref;
 use bevy::math::IRect;
 use std::collections::{HashMap, VecDeque};
+use std::iter::FusedIterator;
+use std::marker::PhantomData;
 use stdext::function_name;
 use tracing::{Level, instrument, trace};
 
@@ -75,11 +77,46 @@ impl StackItem {
         }
     }
 
-    /// Returns all window entities within the item.
-    pub fn all_windows(&self) -> Vec<Entity> {
+    /// Returns an iterator over all window entities in this stack item.
+    pub fn window_iter(&self) -> StackItemIter<'_> {
         match self {
-            StackItem::Single(id) => vec![*id],
-            StackItem::Tabs(tabs) => tabs.clone(),
+            StackItem::Single(entity) => {
+                StackItemIter::Single(std::iter::once(*entity), PhantomData::default())
+            }
+            StackItem::Tabs(tabs) => StackItemIter::Tabs(tabs.iter().copied()),
+        }
+    }
+}
+
+pub enum StackItemIter<'a> {
+    Single(std::iter::Once<Entity>, PhantomData<&'a Column>),
+    Tabs(std::iter::Copied<std::slice::Iter<'a, Entity>>),
+}
+
+impl<'a> Iterator for StackItemIter<'a> {
+    type Item = Entity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            StackItemIter::Single(iter, _) => iter.next(),
+            StackItemIter::Tabs(iter) => iter.next(),
+        }
+    }
+}
+impl<'a> FusedIterator for StackItemIter<'a> {}
+impl<'a> DoubleEndedIterator for StackItemIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            StackItemIter::Single(iter, _) => iter.next_back(),
+            StackItemIter::Tabs(iter) => iter.next_back(),
+        }
+    }
+}
+impl<'a> ExactSizeIterator for StackItemIter<'a> {
+    fn len(&self) -> usize {
+        match self {
+            StackItemIter::Single(_, _) => 1,
+            StackItemIter::Tabs(iter) => iter.len(),
         }
     }
 }
@@ -108,28 +145,27 @@ impl Column {
         }
     }
 
+    /// Returns an iterator over all window entities in this column
+    pub fn window_iter(&self) -> ColumnWindowIter<'_> {
+        match self {
+            Column::Single(entity) | Column::Fullscren(entity) => {
+                ColumnWindowIter::Single(std::iter::once(*entity), PhantomData::default())
+            }
+            Column::Tabs(tabs) => ColumnWindowIter::Tabs(tabs.iter().copied()),
+            Column::Stack(items) => {
+                ColumnWindowIter::Stack(items.iter().flat_map(StackItem::window_iter))
+            }
+        }
+    }
+
     pub fn width<W>(&self, get_window_frame: &W) -> Option<i32>
     where
         W: Fn(Entity) -> Option<IRect>,
     {
-        match self {
-            Column::Single(entity) | Column::Fullscren(entity) => {
-                get_window_frame(*entity).as_ref().map(IRect::width)
-            }
-            Column::Stack(items) => items
-                .iter()
-                .filter_map(StackItem::top)
-                .filter_map(get_window_frame)
-                .map(|frame| frame.width())
-                .max(),
-            Column::Tabs(tabs) => tabs
-                .first()
-                .copied()
-                .map(get_window_frame)
-                .flatten()
-                .as_ref()
-                .map(IRect::width),
-        }
+        self.window_iter()
+            .filter_map(get_window_frame)
+            .map(|frame| frame.width())
+            .max()
     }
 
     /// Returns the entity at the given index, or the last entity if the index exceeds the size.
@@ -161,6 +197,49 @@ impl Column {
             Column::Stack(stack) => stack.iter().any(|item| item.contains(entity)),
             Column::Tabs(tabs) => tabs.contains(&entity),
         });
+    }
+}
+
+pub enum ColumnWindowIter<'a> {
+    Single(std::iter::Once<Entity>, PhantomData<&'a Column>),
+    Tabs(std::iter::Copied<std::slice::Iter<'a, Entity>>),
+    Stack(
+        std::iter::FlatMap<
+            std::slice::Iter<'a, StackItem>,
+            StackItemIter<'a>,
+            fn(&'a StackItem) -> StackItemIter<'a>,
+        >,
+    ),
+}
+
+impl<'a> Iterator for ColumnWindowIter<'a> {
+    type Item = Entity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Single(iter, _) => iter.next(),
+            Self::Tabs(iter) => iter.next(),
+            Self::Stack(iter) => iter.next(),
+        }
+    }
+}
+impl<'a> FusedIterator for ColumnWindowIter<'a> {}
+impl<'a> DoubleEndedIterator for ColumnWindowIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Single(iter, _) => iter.next_back(),
+            Self::Tabs(iter) => iter.next_back(),
+            Self::Stack(iter) => iter.next_back(),
+        }
+    }
+}
+impl<'a> ExactSizeIterator for ColumnWindowIter<'a> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Single(_, _) => 1,
+            Self::Tabs(iter) => iter.len(),
+            Self::Stack(iter) => iter.size_hint().0,
+        }
     }
 }
 
@@ -571,7 +650,7 @@ impl LayoutStrip {
             .iter()
             .flat_map(|column| match column {
                 Column::Single(entity) | Column::Fullscren(entity) => vec![*entity],
-                Column::Stack(items) => items.iter().flat_map(StackItem::all_windows).collect(),
+                Column::Stack(items) => items.iter().flat_map(StackItem::window_iter).collect(),
                 Column::Tabs(ids) => ids.clone(),
             })
             .collect()
@@ -641,11 +720,7 @@ impl LayoutStrip {
                         next_y = frame.max.y;
 
                         // Return ALL windows in the item with the same frame
-                        let results = item
-                            .all_windows()
-                            .into_iter()
-                            .map(|e| (e, frame))
-                            .collect::<Vec<_>>();
+                        let results = item.window_iter().map(|e| (e, frame)).collect::<Vec<_>>();
                         Some(results)
                     })
                     .flatten()

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -702,8 +702,6 @@ impl LayoutStrip {
                 let heights =
                     binpack_heights(&current_heights, MIN_WINDOW_HEIGHT, layout_strip_height)?;
 
-                let column_width = column.width(get_window_frame)?;
-
                 let mut next_y = 0;
                 let frames = items
                     .into_iter()
@@ -711,8 +709,9 @@ impl LayoutStrip {
                     .filter_map(|(item, height)| {
                         let entity = item.top()?;
                         let mut frame = get_window_frame(entity)?;
+                        let width = frame.width();
                         frame.min.x = position;
-                        frame.max.x = frame.min.x + column_width;
+                        frame.max.x = frame.min.x + width;
 
                         frame.min.y = next_y;
                         frame.max.y = frame.min.y + height;


### PR DESCRIPTION
fixes columns overlapping due to considering only the first window as the column width

<img width="1372" height="703" alt="Screenshot 2026-06-01 at 14 14 46" src="https://github.com/user-attachments/assets/0df320a4-d1cb-462f-befc-44fe658073ca" />

--------------------

unrelated: auto center is broken at testing after `5d959bd`(don't know exactly when) only for _some_ columns. my initial guess is that it's about tabs.