### PR TITLE
docs: Match the documented `togglefloatlayer` binding name to the parser

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -142,7 +142,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 | `mouse_nextdisplay` | Warp mouse cursor to the next monitor. |
 | `window_snap` | Snap an overflowing window into the viewport. |
 | `window_raise_floating` | Make the floating windows layer visible on the current workspace. |
-| `window_togglefloatinglayer` | Selectively move the floating windows in front or behind of the workspace windows. |
+| `window_togglefloatlayer` | Selectively move the floating windows in front or behind of the workspace windows. |
 | `quit` | Exit Paneru. |
 
 **Example:**


### PR DESCRIPTION
This change updates the docs to use the existing parser keyword. No code changes.

`parse_operation` in `src/config.rs` has matched `togglefloatlayer` since 9d7acff (May 2026). `CONFIGURATION.md`, added in 7bb38f9 three days later, listed the same operation as `window_togglefloatinglayer`. Configs written verbatim from the docs failed to load with:
```
Invalid configuration: parse_operation: Invalid command '["togglefloatinglayer"]'
```

#### Alternative
#263 makes the parser accept `togglefloatinglayer` (as documented) while keeping `togglefloatlayer` as an alias.
Pick whichever PR you prefer
this is the smaller, docs-only path.