### PR TITLE
fix: Accept the documented `togglefloatinglayer` binding name

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,11 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
             "floating" => Operation::RaiseFloating,
             _ => return Err(err),
         },
-        "togglefloatlayer" => Operation::ToggleFloatingLayer,
+        // The documented binding key in CONFIGURATION.md is
+        // `window_togglefloatinglayer`, which the underscore-splitter delivers
+        // here as a single `togglefloatinglayer` token. Accept both spellings
+        // so existing configs using either form continue to work.
+        "togglefloatlayer" | "togglefloatinglayer" => Operation::ToggleFloatingLayer,
         "swap" => Operation::Swap(parse_direction(argv.get(1).ok_or(err)?)?),
         "center" => Operation::Center,
         "resize" => Operation::Resize(
@@ -1752,6 +1756,21 @@ fn test_parse_resize_commands() {
     assert!(matches!(
         parse_command(&["window", "shrink"]).unwrap(),
         Command::Window(Operation::Resize(ResizeDirection::Shrink))
+    ));
+}
+
+#[test]
+fn test_parse_togglefloatinglayer_command_aliases() {
+    // `window_togglefloatinglayer` is the binding name documented in
+    // CONFIGURATION.md; it splits to a single token. The original parser
+    // keyword is `togglefloatlayer`. Both must resolve to the same op.
+    assert!(matches!(
+        parse_command(&["window", "togglefloatinglayer"]).unwrap(),
+        Command::Window(Operation::ToggleFloatingLayer)
+    ));
+    assert!(matches!(
+        parse_command(&["window", "togglefloatlayer"]).unwrap(),
+        Command::Window(Operation::ToggleFloatingLayer)
     ));
 }
 


### PR DESCRIPTION
This change accepts both keybind spellings so configs written from the docs work, and any existing configs using the parser-form keyword continue to parse.

`parse_operation` in `src/config.rs` has matched `togglefloatlayer` since 9d7acff (May 2026). `CONFIGURATION.md`, added in 7bb38f9 three days later, listed the same operation as `window_togglefloatinglayer`. Configs written verbatim from the docs failed to load with:
```
Invalid configuration: parse_operation: Invalid command '["togglefloatinglayer"]'
```

Adds a parser test pinning both `togglefloatlayer` and `togglefloatinglayer` to `Operation::ToggleFloatingLayer`.


#### Alternative

#262 updates docs in `CONFIGURATION.md` to use the existing `togglefloatlayer` parser keyword.
Pick whichever PR you prefer