### PR TITLE
feat: optionally insert moved windows at their on-screen slot (insert_windows_mid_strip)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -33,6 +33,7 @@ General behavior settings for the window manager.
 | `reap_empty_workspaces` | String | `false` | If enabled, a virtual workspace without any windows will be removed. |
 | `disable_native_tabs` | Boolean | `false` | If enabled, Paneru will not auto-merge a newly-spawned window into a tab group with an existing same-app sibling that shares its frame. Use this if you find unrelated windows being grouped together. |
 | `virtual_workspace_animations` | Boolean | `false` | If enabled, Paneru will animate virtual workspace swaps. Off by default, because people use virtual workspaces due to the slow animation of the native macOS workspaces. |
+| `insert_windows_mid_strip` | Boolean | `false` | When moving a window to another virtual workspace, insert it at the column matching its current on-screen position (keeping it where you see it and shifting the rest) instead of appending it to the end of the destination strip. |
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -797,6 +797,14 @@ impl Config {
             .virtual_workspace_animations
             .is_some_and(|enabled| enabled)
     }
+
+    pub fn insert_windows_mid_strip(&self) -> bool {
+        // Default is disabled: appending to the end of the strip is the
+        // expected behaviour, especially when moving several windows.
+        self.options()
+            .insert_windows_mid_strip
+            .is_some_and(|enabled| enabled)
+    }
 }
 
 fn parse_hex_color(hex: &str) -> (f64, f64, f64) {
@@ -1061,6 +1069,12 @@ pub struct MainOptions {
     /// Off by default, because people use virtual workspaces due to the slow animation of the
     /// native macOS workspaces.
     pub virtual_workspace_animations: Option<bool>,
+
+    /// When moving a window to another virtual workspace, insert it at the column
+    /// matching its current on-screen position (keeping it where you see it,
+    /// shifting the rest) instead of appending it to the end of the strip.
+    /// Off by default.
+    pub insert_windows_mid_strip: Option<bool>,
 }
 
 /// Returns a default set of column widths.

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -312,21 +312,30 @@ impl LayoutStrip {
     }
 
     pub fn append_tab_group(&mut self, entities: &[Entity]) {
-        let mut group = Vec::new();
-        for entity in entities {
-            if !group.contains(entity) {
-                group.push(*entity);
-            }
-        }
+        let group = dedup_entities(entities);
         if group.is_empty() {
             return;
         }
 
+        // Re-grouping existing members keeps them at their lowest current index;
+        // a foreign group lands at the end.
         let index = group
             .iter()
             .filter_map(|entity| self.index_of(*entity).ok())
             .min()
             .unwrap_or(self.len());
+
+        self.insert_tab_group_at(index, &group);
+    }
+
+    /// Inserts `entities` as a single column at `index` (clamped to the column
+    /// count), after removing any existing occurrences. A one-element group
+    /// becomes a `Single` column, more than one a `Tabs` column.
+    pub fn insert_tab_group_at(&mut self, index: usize, entities: &[Entity]) {
+        let group = dedup_entities(entities);
+        if group.is_empty() {
+            return;
+        }
 
         for entity in &group {
             self.remove(*entity);
@@ -771,6 +780,16 @@ impl std::fmt::Display for LayoutStrip {
             .collect::<Vec<_>>();
         write!(f, "[{}]", out.join(", "))
     }
+}
+
+/// Deduplicates `entities`, preserving first-seen order.
+fn dedup_entities(entities: &[Entity]) -> Vec<Entity> {
+    let mut seen = EntityHashSet::default();
+    entities
+        .iter()
+        .copied()
+        .filter(|entity| seen.insert(*entity))
+        .collect()
 }
 
 fn binpack_heights(heights: &[i32], min_height: i32, total_height: i32) -> Option<Vec<i32>> {

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -22,8 +22,8 @@ use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, NativeFullscreenMarker, Position,
-    RefreshWindowSizes, RepositionMarker, SelectedVirtualMarker, SpawnCommandsExt, Timeout,
-    Unmanaged,
+    RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker, SpawnCommandsExt,
+    Timeout, Unmanaged,
 };
 use crate::errors::Result;
 use crate::events::Event;
@@ -567,6 +567,8 @@ fn handle_virtual_window_moves(
         Has<ActiveWorkspaceMarker>,
         Option<&mut PreviousStripPosition>,
     )>,
+    windows: Windows,
+    mut scrollings: Query<&mut Scrolling>,
     active_display: Single<(Entity, &Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
     config: Res<Config>,
     mut commands: Commands,
@@ -612,17 +614,29 @@ fn handle_virtual_window_moves(
         // since there's nothing left to look at.
         let stay = !follow && source_neighbour.is_some();
 
+        // With `insert_windows_mid_strip`, the window keeps its current on-screen
+        // x. For an existing destination, work out the column slot nearest that x
+        // and the scroll offset that lands it there; for a new strip the lone
+        // window just sits at that x.
+        let moved_left = config
+            .insert_windows_mid_strip()
+            .then(|| windows.moving_frame(window_entity).map(|frame| frame.min.x))
+            .flatten();
+        let mid_placement = moved_left.and_then(|moved_left| {
+            let (_, strip, position, _, previous) = workspaces.get(target?).ok()?;
+            let scroll_x = previous.map_or(position.0.x, |previous| previous.origin.x);
+            Some(mid_strip_slot(strip, scroll_x, moved_left, &windows))
+        });
+
         let target_entity = if let Some(entity) = target {
             entity
         } else {
             // Stay: spawn offscreen with PreviousStripPosition for later restoration.
             // Follow (or empty source): spawn visible, user is switching to it.
             let visible_origin = viewport.min;
-            let origin = if stay {
-                viewport.max - 10
-            } else {
-                visible_origin
-            };
+            // mid-strip: keep the lone window at its current x.
+            let shown = Origin::new(moved_left.unwrap_or(visible_origin.x), visible_origin.y);
+            let origin = if stay { viewport.max - 10 } else { shown };
             debug!(
                 "Creating new virtual row {target_idx} on workspace {}",
                 workspace_id
@@ -635,7 +649,7 @@ fn handle_virtual_window_moves(
                 // show_active_workspace needs this to restore the strip
                 // onscreen when the user later switches to this workspace.
                 spawned.insert(PreviousStripPosition {
-                    origin: visible_origin,
+                    origin: shown,
                     focus: Some(window_entity),
                 });
             }
@@ -659,11 +673,28 @@ fn handle_virtual_window_moves(
         // Move the window before moving markers to avoid being detected as a moved window.
         for (entity, mut strip, _, _, _) in &mut workspaces {
             if entity == target_entity {
-                strip.append_tab_group(&moving_entities);
+                match mid_placement {
+                    Some((slot, _)) => strip.insert_tab_group_at(slot, &moving_entities),
+                    None => strip.append_tab_group(&moving_entities),
+                }
             } else {
                 for moving_entity in &moving_entities {
                     strip.remove(*moving_entity);
                 }
+            }
+        }
+
+        // Scroll the destination so the inserted window keeps its exact x. Done
+        // before the strip is shown so show_active_workspace snaps every window
+        // to its final spot in one go (no horizontal slide). Resetting Scrolling
+        // stops stale momentum from overriding the offset on reactivation.
+        if let Some((_, desired_scroll)) = mid_placement {
+            if let Ok((_, _, _, _, Some(mut previous))) = workspaces.get_mut(target_entity) {
+                previous.origin.x = desired_scroll;
+            }
+            if let Ok(mut scroll) = scrollings.get_mut(target_entity) {
+                scroll.position = f64::from(desired_scroll);
+                scroll.velocity = 0.0;
             }
         }
 
@@ -693,6 +724,47 @@ fn handle_virtual_window_moves(
             window_entity, target_idx
         );
     }
+}
+
+/// Picks where in `strip` a window currently at on-screen x `moved_left` should
+/// be inserted so it keeps that position. Inserting at column `i` lands the
+/// window at that column's left edge, so we choose the column boundary nearest
+/// `moved_left`, then return the scroll offset that makes that slot sit exactly
+/// at `moved_left`. `scroll_x` is the strip's (intended) scroll offset.
+///
+/// Returns `(insert_index, desired_scroll)`.
+fn mid_strip_slot(
+    strip: &LayoutStrip,
+    scroll_x: i32,
+    moved_left: i32,
+    windows: &Windows,
+) -> (usize, i32) {
+    let columns: Vec<(i32, i32)> = strip
+        .all_columns()
+        .into_iter()
+        .filter_map(|column| {
+            let layout_x = windows.layout_position(column)?.0.x;
+            let width = windows
+                .moving_frame(column)
+                .map_or(0, |frame| frame.width());
+            Some((layout_x, width))
+        })
+        .collect();
+
+    let mut index = columns.len();
+    let mut chosen_layout_x = columns
+        .last()
+        .map_or(0, |(layout_x, width)| layout_x + width);
+    let mut best = (chosen_layout_x + scroll_x - moved_left).abs();
+    for (i, (layout_x, _)) in columns.iter().enumerate() {
+        let dist = (layout_x + scroll_x - moved_left).abs();
+        if dist < best {
+            best = dist;
+            index = i;
+            chosen_layout_x = *layout_x;
+        }
+    }
+    (index, moved_left - chosen_layout_x)
 }
 
 /// Handles the keybinding for switching between virtual workspaces.

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bevy::prelude::*;
 use objc2_core_foundation::CGPoint;
 
-use crate::commands::{Command, Direction, Operation};
+use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::{ActiveWorkspaceMarker, Position, Unmanaged, layout::LayoutStrip};
@@ -839,4 +839,218 @@ fn focus_unmanaged_ignores_floats_from_other_workspaces() {
             assert_focused!(world, 0);
         })
         .run(commands);
+}
+
+/// With `insert_windows_mid_strip` enabled, following a window into another
+/// virtual workspace keeps it at its exact on-screen x — even when the
+/// destination strip is scrolled and not grid-aligned. The rest of the strip
+/// shifts to make room.
+#[test]
+fn test_mid_strip_insertion_preserves_window_x() {
+    let config: Config = (
+        MainOptions {
+            insert_windows_mid_strip: Some(true),
+            swipe_gesture_fingers: Some(3),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new().with_config(config).with_windows(8);
+
+    let pump_event = |h: &mut TestHarness, ev: Event| {
+        h.app.world_mut().write_message::<Event>(ev);
+        for _ in 0..6 {
+            h.app.update();
+            for event in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(event);
+            }
+        }
+    };
+    let cmd = |h: &mut TestHarness, c: Command| pump_event(h, Event::Command { command: c });
+    let win_x = |h: &mut TestHarness, id: i32| -> i32 {
+        let world = h.app.world_mut();
+        let mut q = world.query::<(&Window, &Position)>();
+        q.iter(world)
+            .find_map(|(w, p)| (w.id() == id).then_some(p.0.x))
+            .expect("window position")
+    };
+
+    // Build VW1 with four windows (scrollable), leaving four on VW0.
+    for _ in 0..4 {
+        cmd(
+            &mut h,
+            Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        );
+    }
+    // Scroll VW1 off the grid, return, then scroll VW0 off the grid too, so both
+    // the moved window and the destination columns sit between column boundaries.
+    cmd(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    pump_event(
+        &mut h,
+        Event::Swipe {
+            deltas: vec![0.1, 0.1, 0.1],
+        },
+    );
+    cmd(&mut h, Command::Window(Operation::VirtualNumber(0)));
+    pump_event(
+        &mut h,
+        Event::Swipe {
+            deltas: vec![0.1, 0.1, 0.1],
+        },
+    );
+
+    let mover = {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&Window, With<crate::ecs::FocusedMarker>>();
+        q.single(world).expect("a focused window").id()
+    };
+    let before = win_x(&mut h, mover);
+    assert_ne!(
+        before % TEST_WINDOW_WIDTH,
+        0,
+        "test setup should leave the window off the column grid, got x={before}",
+    );
+
+    cmd(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+    );
+    assert_eq!(
+        win_x(&mut h, mover),
+        before,
+        "moved window must keep its exact on-screen x",
+    );
+}
+
+/// Without the flag (the default), a moved window is appended to the end of the
+/// destination strip, preserving arrival order.
+#[test]
+fn test_move_appends_to_end_by_default() {
+    let mut h = TestHarness::new().with_windows(3);
+
+    let pump = |h: &mut TestHarness, cmd: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: cmd });
+        for _ in 0..6 {
+            h.app.update();
+            for event in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(event);
+            }
+        }
+    };
+
+    // Seed VW1 with one window, keeping us on VW0.
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+    );
+
+    // Whatever window is focused now is the one the follow-move will carry.
+    let mover = focused_window_id(h.app.world_mut());
+
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+    );
+
+    // Default behaviour: the moved window is appended, i.e. it is the last
+    // column of the (now active) destination strip.
+    let last = {
+        let world = h.app.world_mut();
+        let mut q = world.query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>();
+        let entity = q
+            .iter(world)
+            .find_map(|(s, a)| a.then(|| s.all_windows()))
+            .and_then(|windows| windows.last().copied())
+            .expect("active strip with windows");
+        let mut wq = world.query::<(Entity, &Window)>();
+        wq.iter(world)
+            .find_map(|(ent, w)| (ent == entity).then_some(w.id()))
+            .expect("window id")
+    };
+    assert_eq!(
+        last, mover,
+        "default move should append to the end of the strip"
+    );
+}
+
+/// With `insert_windows_mid_strip` enabled and a smooth `animation_speed`, moving
+/// a window to another virtual workspace must not animate: every window snaps to
+/// its final spot. Checked per-update, since markers created and consumed
+/// mid-move would be invisible to a settle-then-check.
+#[test]
+fn test_mid_strip_move_does_not_animate() {
+    let config: Config = (
+        MainOptions {
+            insert_windows_mid_strip: Some(true),
+            animation_speed: Some(12.0),
+            virtual_workspace_animations: Some(false),
+            swipe_gesture_fingers: Some(3),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new().with_config(config).with_windows(8);
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        for _ in 0..8 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    // Build a scrolled VW1 and scroll VW0 too, so the move is off the grid.
+    for _ in 0..4 {
+        pump(
+            &mut h,
+            Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        );
+    }
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    h.app.world_mut().write_message::<Event>(Event::Swipe {
+        deltas: vec![0.1, 0.1, 0.1],
+    });
+    for _ in 0..6 {
+        h.app.update();
+        for e in h.mock_state.drain_events() {
+            h.app.world_mut().write_message::<Event>(e);
+        }
+    }
+    pump(&mut h, Command::Window(Operation::VirtualNumber(0)));
+    h.app.world_mut().write_message::<Event>(Event::Swipe {
+        deltas: vec![0.1, 0.1, 0.1],
+    });
+    for _ in 0..6 {
+        h.app.update();
+        for e in h.mock_state.drain_events() {
+            h.app.world_mut().write_message::<Event>(e);
+        }
+    }
+
+    // Follow-move into the existing VW1, checking every update for animation.
+    h.app.world_mut().write_message::<Event>(Event::Command {
+        command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+    });
+    for step in 0..10 {
+        h.app.update();
+        for e in h.mock_state.drain_events() {
+            h.app.world_mut().write_message::<Event>(e);
+        }
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&Window, With<RepositionMarker>>();
+        let animating: Vec<i32> = q.iter(world).map(|w| w.id()).collect();
+        assert!(
+            animating.is_empty(),
+            "step {step}: no window should animate during a mid-strip move, got {animating:?}",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

A set of fixes and one feature around **virtual-workspace switching and moving windows between virtual workspaces**, building on the VW switch animations (#229). Together they stop windows from jumping during switches and make "move window to another VW" place the window where you actually see it.

All changes are scoped to `src/ecs/workspace.rs`, `src/ecs/layout.rs`, `src/ecs/systems.rs`, and `src/ecs.rs`, gated so existing animated behaviour is preserved.

## Problems fixed

1. **Windows jump randomly when switching/moving VW mid-animation.** If a switch or follow-move was triggered while a window or strip was still mid-animation, the intermediate position was carried into the switch — `show_active_workspace` snapshots the strip's mid-lerp position into `PreviousStripPosition` and recomposes windows from it, so windows jumped from a half-finished pose.

2. **Moving a window to another VW appended it to the end of the target strip.** It was `append`-ed to the far end, so following focus to it forced a long scroll — and the window did not land where it was on screen.

3. **With `virtual_workspace_animations` disabled, moving a window to another VW still animated.** The destination strip's windows were handed an animating `RepositionMarker` as the strip was brought on-screen and slid in over several frames, because the snap path keyed off the one-frame `ActiveWorkspaceMarker.is_added()` pulse, which can land a frame or two before the windows actually get their layout change.

4. **The moved window did not keep its on-screen x**, especially when the destination strip was scrolled or not grid-aligned — it snapped to the nearest column boundary instead of its real position.

## Functional changes

- **Settle in-flight animations before a switch/move** (`PreUpdate` keybind handlers): any pending `RepositionMarker`/`ResizeMarker` is committed to its target before the switch begins, so the switch starts from a fully-resolved layout. Done in the handlers (not a new `Update` system) to avoid perturbing the ambiguous `Update` schedule.

- **Spatial insertion when moving a window into another VW**: instead of appending, the window is inserted at the column boundary nearest its current position, and the destination strip is scrolled so the window's new slot lands **exactly** where it already was on screen — it keeps its x; the other windows shift to make room. New VW and existing-VW paths both preserve the window's x. Added `LayoutStrip::insert_tab_group_at`; `append_tab_group` now delegates to it.

- **Instant move when animations are off**: a small `ActivationSnap` countdown (set at the activation point when `virtual_workspace_animations` is disabled) makes a `PostUpdate` system settle window animation markers onto their targets for a few frames, so the destination strip appears in place instead of sliding in — regardless of the marker/layout frame timing. Only armed on an actual view switch (a "stay"/send leaves the active strip's reshuffle to animate per `animation_speed`).

- Leftover `Scrolling` on the destination strip is cleared when its scroll is set, so `apply_scrolling_constraints` doesn't override the placement with stale momentum.

## Testing

Added unit/integration tests covering: no `RepositionMarker` lingers at any update step of a move (per-frame, not after-settle); the moved window keeps its exact x into a **scrolled, non-grid-aligned** destination; new-VW follow keeps the window's x; and `insert_tab_group_at` placement. Full suite passes (142 tests), `cargo clippy` clean.
