### PR TITLE
fix: focus overlay on multi-monitor + stale outline on empty workspace

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -5,8 +5,9 @@ use bevy::MinimalPlugins;
 use bevy::app::App as BevyApp;
 use bevy::app::{PostUpdate, PreUpdate, Startup};
 use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::lifecycle::RemovedComponents;
 use bevy::ecs::message::Messages;
-use bevy::ecs::query::With;
+use bevy::ecs::query::{Added, Changed, With};
 use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
 use bevy::ecs::system::{Commands, EntityCommands, Query, Res, SystemId};
@@ -68,6 +69,17 @@ pub fn register_systems(app: &mut bevy::app::App) {
     let dimming_enabled = |config: Option<Res<Config>>| {
         config
             .is_some_and(|config| config.has_dim_inactive_color() || config.border_active_window())
+    };
+    // The overlay must refresh not just when the active strip's layout changes,
+    // but also whenever focus moves — including focus *loss* (e.g. switching to
+    // an empty virtual workspace), which otherwise leaves a stale outline.
+    let overlay_dirty = |strip_changed: Query<
+        (),
+        (With<ActiveWorkspaceMarker>, Changed<LayoutStrip>),
+    >,
+                         focus_gained: Query<(), Added<FocusedMarker>>,
+                         mut focus_lost: RemovedComponents<FocusedMarker>| {
+        !strip_changed.is_empty() || !focus_gained.is_empty() || focus_lost.read().next().is_some()
     };
     let workspace_menu_status =
         |config: Option<Res<Config>>| config.is_some_and(|config| config.workspace_menu_status());
@@ -136,7 +148,8 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 systems::update_overlays
                     .after(systems::animate_entities)
                     .after(systems::animate_resize_entities)
-                    .run_if(dimming_enabled),
+                    .run_if(dimming_enabled)
+                    .run_if(overlay_dirty),
                 systems::update_flash_messages,
             )
                 .chain(),

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -763,10 +763,9 @@ pub(super) struct OverlayWindowConfigCache {
 
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 pub(super) fn update_overlays(
-    active_workspace: Populated<
-        (Has<Scrolling>, &LayoutStrip),
-        (With<ActiveWorkspaceMarker>, Changed<LayoutStrip>),
-    >,
+    // Gating lives in the `overlay_dirty` run condition (strip change *or*
+    // focus change); this query just resolves the current active workspace.
+    active_workspace: Populated<(Has<Scrolling>, &LayoutStrip), With<ActiveWorkspaceMarker>>,
     windows: Windows,
     applications: Query<&Application>,
     overlay_mgr: Option<NonSendMut<OverlayManager>>,

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -177,35 +177,35 @@ fn cg_abs_to_cocoa(frame: NSRect, primary_screen_height: f64) -> NSRect {
     NSRect::new(NSPoint::new(frame.origin.x, cocoa_y), frame.size)
 }
 
+/// Height of the display at the global origin (the main display, whose Cocoa
+/// frame origin is `(0, 0)`). The CG↔Cocoa Y-flip is anchored to this display,
+/// so it must be *that* screen — `NSScreen::screens()[0]` is NOT reliably the
+/// main display, and using the wrong one offsets the overlay (and, when
+/// displays are stacked, lands it on the wrong monitor).
 fn primary_screen_height(mtm: MainThreadMarker) -> f64 {
     let screens = NSScreen::screens(mtm);
-    if screens.is_empty() {
-        return 0.0;
+    let mut fallback = 0.0;
+    let mut first = true;
+    for screen in &screens {
+        let frame = screen.frame();
+        if first {
+            fallback = frame.size.height;
+            first = false;
+        }
+        if frame.origin.x == 0.0 && frame.origin.y == 0.0 {
+            return frame.size.height;
+        }
     }
-    screens.objectAtIndex(0).frame().size.height
+    fallback
 }
 
-/// Get the full Cocoa screen rect covering all displays.
-fn full_screen_rect(mtm: MainThreadMarker) -> NSRect {
-    let screens = NSScreen::screens(mtm);
-    if screens.is_empty() {
-        return NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0));
-    }
-    let mut min_x = f64::MAX;
-    let mut min_y = f64::MAX;
-    let mut max_x = f64::MIN;
-    let mut max_y = f64::MIN;
-    for screen in &screens {
-        let f = screen.frame();
-        min_x = min_x.min(f.origin.x);
-        min_y = min_y.min(f.origin.y);
-        max_x = max_x.max(f.origin.x + f.size.width);
-        max_y = max_y.max(f.origin.y + f.size.height);
-    }
-    NSRect::new(
-        NSPoint::new(min_x, min_y),
-        NSSize::new(max_x - min_x, max_y - min_y),
-    )
+/// Do two Cocoa rects overlap? Used to decide which displays a focused window
+/// touches (a window straddling a seam touches both).
+fn rects_intersect(a: NSRect, b: NSRect) -> bool {
+    a.origin.x < b.origin.x + b.size.width
+        && b.origin.x < a.origin.x + a.size.width
+        && a.origin.y < b.origin.y + b.size.height
+        && b.origin.y < a.origin.y + a.size.height
 }
 
 // ── Overlay window factory ──────────────────────────────────────────────
@@ -239,8 +239,11 @@ fn make_overlay_window(mtm: MainThreadMarker, cocoa_frame: NSRect) -> Retained<N
 
 pub struct OverlayManager {
     mtm: MainThreadMarker,
-    /// Single fullscreen overlay window (dim + cutout + border).
-    overlay: Option<(Retained<NSWindow>, DimParams)>,
+    /// One overlay window per display. macOS will not reliably let a single
+    /// window span multiple displays (with "Displays have separate Spaces" it
+    /// renders on only one), so each screen gets its own overlay drawn in that
+    /// screen's local coordinates. Indexed in lockstep with `NSScreen::screens`.
+    overlays: Vec<(Retained<NSWindow>, DimParams)>,
     hidden: bool,
 }
 
@@ -248,12 +251,12 @@ impl OverlayManager {
     pub fn new(mtm: MainThreadMarker) -> Self {
         Self {
             mtm,
-            overlay: None,
+            overlays: Vec::new(),
             hidden: false,
         }
     }
 
-    /// Update the single fullscreen overlay.
+    /// Update the per-display overlays.
     /// `focused_abs_cg` is the focused window rect in absolute CG coords,
     /// or `None` if no window is focused.
     pub fn update(
@@ -264,57 +267,69 @@ impl OverlayManager {
         border: Option<&BorderParams>,
     ) {
         let screen_h = primary_screen_height(self.mtm);
-        let screen_rect = full_screen_rect(self.mtm);
+        let screens = NSScreen::screens(self.mtm);
 
-        // Convert the focused window rect from absolute CG to Cocoa coords,
-        // then to the overlay window's local coordinate system.
-        let cutout_local = focused_abs_cg.map(|cg_frame| {
-            let cocoa = cg_abs_to_cocoa(cg_frame, screen_h);
-            // Convert from screen coords to local (window-relative) coords.
-            NSRect::new(
-                NSPoint::new(
-                    cocoa.origin.x - screen_rect.origin.x,
-                    // The view is flipped (isFlipped=true), so y goes top-down.
-                    // screen_rect top in Cocoa = screen_rect.origin.y + screen_rect.size.height
-                    // We need: local_y = screen_top - cocoa_top
-                    (screen_rect.origin.y + screen_rect.size.height)
-                        - (cocoa.origin.y + cocoa.size.height),
-                ),
-                cocoa.size,
-            )
-        });
+        // The focused window in Cocoa global coords (shared across all screens).
+        let focused_cocoa = focused_abs_cg.map(|cg| cg_abs_to_cocoa(cg, screen_h));
 
-        let params = DimParams {
-            opacity: dim_opacity,
-            color: dim_color,
-            cutout: cutout_local,
-            border: border.cloned(),
-        };
-
-        if let Some((window, stored)) = &mut self.overlay {
-            if *stored != params {
-                // Recreate the content view with new params.
-                let view = DimView::new(self.mtm, screen_rect, &params);
-                window.setContentView(Some(&view));
-                window.setFrame_display(screen_rect, true);
+        // A display was added/removed — tear down and rebuild from scratch.
+        if self.overlays.len() != screens.len() {
+            for (window, _) in self.overlays.drain(..) {
+                window.orderOut(None::<&AnyObject>);
             }
-            if self.hidden {
-                window.orderFront(None::<&AnyObject>);
-                self.hidden = false;
-            }
-            *stored = params;
-        } else {
-            let window = make_overlay_window(self.mtm, screen_rect);
-            let view = DimView::new(self.mtm, screen_rect, &params);
-            window.setContentView(Some(&view));
-            window.orderFront(None::<&AnyObject>);
-            self.overlay = Some((window, params));
-            self.hidden = false;
         }
+
+        for (i, screen) in (&screens).into_iter().enumerate() {
+            let frame = screen.frame();
+
+            // Cut out the focused window on every display it touches, each in
+            // that display's local (flipped, top-left origin) coordinates. A
+            // window straddling a seam draws on both, clipped to each.
+            let cutout_local = focused_cocoa
+                .filter(|wc| rects_intersect(*wc, frame))
+                .map(|wc| {
+                    NSRect::new(
+                        NSPoint::new(
+                            wc.origin.x - frame.origin.x,
+                            (frame.origin.y + frame.size.height) - (wc.origin.y + wc.size.height),
+                        ),
+                        wc.size,
+                    )
+                });
+
+            let params = DimParams {
+                opacity: dim_opacity,
+                color: dim_color,
+                cutout: cutout_local,
+                border: border.cloned(),
+            };
+
+            if let Some((window, stored)) = self.overlays.get_mut(i) {
+                if *stored == params {
+                    // Keep geometry in sync cheaply (no forced redraw).
+                    window.setFrame_display(frame, false);
+                } else {
+                    let view = DimView::new(self.mtm, frame, &params);
+                    window.setContentView(Some(&view));
+                    window.setFrame_display(frame, true);
+                    *stored = params;
+                }
+                if self.hidden {
+                    window.orderFront(None::<&AnyObject>);
+                }
+            } else {
+                let window = make_overlay_window(self.mtm, frame);
+                let view = DimView::new(self.mtm, frame, &params);
+                window.setContentView(Some(&view));
+                window.orderFront(None::<&AnyObject>);
+                self.overlays.push((window, params));
+            }
+        }
+        self.hidden = false;
     }
 
     pub fn remove_all(&mut self) {
-        if let Some((window, _)) = self.overlay.take() {
+        for (window, _) in self.overlays.drain(..) {
             window.orderOut(None::<&AnyObject>);
         }
         self.hidden = false;
@@ -324,7 +339,7 @@ impl OverlayManager {
         if self.hidden {
             return;
         }
-        if let Some((window, _)) = &self.overlay {
+        for (window, _) in &self.overlays {
             window.orderOut(None::<&AnyObject>);
         }
         self.hidden = true;


### PR DESCRIPTION
closes #257 #153

## Summary

Two fixes to the focus dim/outline overlay, both surfacing on multi-monitor setups.

### 1. Overlay rendered on the wrong monitor / offset

The overlay used a **single window sized to the union of all displays**. macOS won't reliably let one window span multiple displays — with *"Displays have separate Spaces"* (on by default) it renders on only one — so the (correctly computed) cutout for a window on the secondary display landed on the **main** display, offset by the main↔secondary delta.

Now there is **one overlay window per display**, each sized to its screen and drawing the cutout/border in that screen's local coordinates. A window straddling a seam is cut out on every display it intersects, clipped to each. The CG↔Cocoa Y-flip is also anchored to the actual main display (Cocoa origin `(0,0)`) rather than `NSScreen::screens()[0]`, which is not reliably the main display.

### 2. Stale outline when switching to an empty workspace

`update_overlays` only ran when the active workspace's `LayoutStrip` changed. Switching to an empty virtual workspace loses focus *without* mutating that strip, so the system was skipped and the previous window's outline stayed on screen.

The system is now gated on a run condition that also fires on focus changes — including focus **loss** (`RemovedComponents<FocusedMarker>`) — and the `Changed<LayoutStrip>` filter is dropped from the query so it resolves the active workspace whenever the condition fires. With no focused managed window it reaches `hide_all()` and clears the overlay.

## Testing

- `cargo build --release`, `cargo clippy` (pedantic), `cargo fmt` — clean.
- `cargo test` — 134 passed.
- Manually verified on a 2-monitor setup: outline lands correctly on each display, and is cleared when switching to an empty workspace.

Based on `testing`.