### PR TITLE
feat: reconcile displays against the OS on wake / resize / configure

### DIFF
--- a/src/ecs/display.rs
+++ b/src/ecs/display.rs
@@ -16,7 +16,8 @@ use tracing::{Level, debug, error, instrument};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::{
-    ActiveDisplayMarker, RefreshWindowSizes, SendMessageTrigger, SpawnCommandsExt, Timeout,
+    ActiveDisplayMarker, ActiveWorkspaceMarker, RefreshWindowSizes, SendMessageTrigger,
+    SpawnCommandsExt, Timeout,
 };
 use crate::events::Event;
 use crate::manager::{Display, WindowManager};
@@ -28,8 +29,15 @@ pub struct DisplayEventsPlugin;
 
 impl Plugin for DisplayEventsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (displays_rearranged, display_change_trigger))
-            .add_observer(cleanup_active_display_marker);
+        app.add_systems(
+            Update,
+            (
+                displays_rearranged,
+                reconcile_displays,
+                display_change_trigger,
+            ),
+        )
+        .add_observer(cleanup_active_display_marker);
     }
 }
 
@@ -124,6 +132,90 @@ pub(crate) fn displays_rearranged(
         }
         commands.trigger(SendMessageTrigger(Event::DisplayChanged));
     }
+}
+
+/// Full reconciliation of the ECS display set against the OS truth.
+///
+/// Runs on events where the per-display add/remove/move flags are unreliable or
+/// absent: waking from sleep, resolution / arrangement changes, and configuration
+/// events. Rather than trust a single `display_id` flag, it diffs the live
+/// `present_displays()` list against the spawned `Display` entities and applies
+/// the same add / remove / move primitives the event handlers use. It also
+/// forces the active workspace to re-tile, because macOS relocates windows while
+/// asleep even when the display set is unchanged.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub(crate) fn reconcile_displays(
+    mut messages: MessageReader<Event>,
+    workspaces: Query<(&LayoutStrip, Entity, Option<&ChildOf>)>,
+    mut displays: Query<(&mut Display, Entity)>,
+    active_strips: Query<Entity, (With<LayoutStrip>, With<ActiveWorkspaceMarker>)>,
+    window_manager: Res<WindowManager>,
+    config: Res<Config>,
+    mut retries: Local<HashSet<CGDirectDisplayID>>,
+    mut commands: Commands,
+) {
+    let needs_reconcile = messages.read().any(|event| {
+        matches!(
+            event,
+            Event::SystemWoke { .. }
+                | Event::DisplayResized { .. }
+                | Event::DisplayConfigured { .. }
+        )
+    });
+    if !needs_reconcile {
+        return;
+    }
+
+    debug!("reconciling displays against OS after wake / resize / configure");
+
+    let present_ids: HashSet<CGDirectDisplayID> = window_manager
+        .0
+        .present_displays()
+        .iter()
+        .map(|(display, _)| display.id())
+        .collect();
+    let existing_ids: HashSet<CGDirectDisplayID> =
+        displays.iter().map(|(display, _)| display.id()).collect();
+
+    // Displays that vanished while we were away (e.g. unplugged during sleep).
+    for display_id in existing_ids.difference(&present_ids).copied() {
+        remove_display(display_id, &workspaces, &mut displays, &mut commands);
+    }
+
+    // Displays that appeared while we were away.
+    for display_id in present_ids.difference(&existing_ids).copied() {
+        add_display(
+            display_id,
+            &workspaces,
+            &window_manager,
+            &config,
+            &mut retries,
+            &mut commands,
+        );
+    }
+
+    // Displays that are still present: refresh their bounds (resolution or
+    // menubar may have changed) and re-home any workspaces that drifted.
+    for display_id in present_ids.intersection(&existing_ids).copied() {
+        move_display(
+            display_id,
+            &mut displays,
+            &window_manager,
+            &workspaces,
+            &config,
+            &mut commands,
+        );
+    }
+
+    // Re-tile the active workspace even when the topology is unchanged — the OS
+    // shuffles window frames across a sleep/wake cycle.
+    for entity in active_strips {
+        if let Ok(mut cmd) = commands.get_entity(entity) {
+            cmd.insert(RefreshWindowSizes::default());
+        }
+    }
+
+    commands.trigger(SendMessageTrigger(Event::DisplayChanged));
 }
 
 #[instrument(level = Level::DEBUG, skip_all, fields(display_id))]

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -6,7 +6,7 @@ use bevy::time::TimeUpdateStrategy;
 use crate::commands::{Command, MouseMove, MoveFocus, Operation};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
-use crate::ecs::{DockPosition, Timeout};
+use crate::ecs::{ActiveWorkspaceMarker, DockPosition, RefreshWindowSizes, Timeout};
 use crate::events::Event;
 use crate::manager::{Display, Origin, Size};
 use crate::{assert_not_on_workspace, assert_on_workspace, assert_window_at, assert_window_size};
@@ -389,6 +389,93 @@ fn test_init_keeps_windows_on_their_real_displays() {
             // display's vertical bounds (negative y); if init moved it
             // onto the active display the frame would land at y >= 0.
             assert_window_at!(world, 100, ext_origin.x, ext_origin.y);
+        })
+        .run(commands);
+}
+
+/// Waking from sleep (or a resolution/configuration change) with a monitor
+/// gone should reconcile the ECS display set against the OS even though no
+/// per-display `DisplayRemoved` flag arrives: the vanished display is removed
+/// and its workspace is orphaned.
+#[test]
+fn test_wake_reconciles_unplugged_display() {
+    let mut harness = TestHarness::new().with_display(
+        EXT_DISPLAY_ID,
+        IRect::new(0, -EXT_DISPLAY_HEIGHT, EXT_DISPLAY_WIDTH, 0),
+        vec![EXT_WORKSPACE_ID],
+    );
+
+    // A window on the external display so its workspace strip actually exists.
+    let ext_origin = Origin::new(0, -EXT_DISPLAY_HEIGHT + TEST_MENUBAR_HEIGHT);
+    let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+    let ext_frame = IRect::from_corners(ext_origin, ext_origin + size);
+    harness
+        .mock_state
+        .spawn_window(TEST_PROCESS_ID, EXT_WORKSPACE_ID, 100, ext_frame);
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 100 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::SystemWoke { msg: String::new() },
+    ];
+
+    harness
+        .on_iteration(1, |world, state| {
+            let displays = world
+                .query_filtered::<Entity, With<Display>>()
+                .iter(world)
+                .count();
+            assert_eq!(displays, 2, "should start with two displays");
+
+            // Unplug the external display behind paneru's back — no
+            // DisplayRemoved event is sent, mimicking a wake-from-sleep.
+            state.remove_display(EXT_DISPLAY_ID);
+        })
+        .on_iteration(2, |world, _state| {
+            let displays = world
+                .query_filtered::<Entity, With<Display>>()
+                .iter(world)
+                .count();
+            assert_eq!(displays, 1, "reconcile should despawn the vanished display");
+
+            // The external display's workspace must be orphaned, not lost.
+            let orphan = world
+                .query::<(&LayoutStrip, Option<&ChildOf>, Has<Timeout>)>()
+                .iter(world)
+                .find(|(strip, _, _)| strip.id() == EXT_WORKSPACE_ID)
+                .map(|(_, child, timeout)| (child.is_some(), timeout));
+            let (has_parent, has_timeout) =
+                orphan.expect("external workspace strip should still exist");
+            assert!(!has_parent, "orphaned workspace should have no parent");
+            assert!(has_timeout, "orphaned workspace should carry a timeout");
+        })
+        .run(commands);
+}
+
+/// Even when the display set is unchanged, waking from sleep must force the
+/// active workspace to re-tile, because macOS relocates window frames across a
+/// sleep/wake cycle.
+#[test]
+fn test_wake_refreshes_active_workspace() {
+    let harness = TestHarness::new().with_windows(1);
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::SystemWoke { msg: String::new() },
+    ];
+
+    harness
+        .on_iteration(1, |world, _state| {
+            let refreshed = world
+                .query_filtered::<Has<RefreshWindowSizes>, With<ActiveWorkspaceMarker>>()
+                .iter(world)
+                .any(|has| has);
+            assert!(
+                refreshed,
+                "wake should mark the active workspace for a window-size refresh"
+            );
         })
         .run(commands);
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -185,6 +185,15 @@ impl MockState {
         );
     }
 
+    #[allow(unused)]
+    pub fn remove_display(&self, id: u32) {
+        let mut inner = self.inner.force_write();
+        inner.displays.remove(&id);
+        if inner.active_display_id == id {
+            inner.active_display_id = inner.displays.keys().copied().next().unwrap_or(0);
+        }
+    }
+
     pub fn active_display(&self) -> CGDirectDisplayID {
         self.inner.force_read().active_display_id
     }


### PR DESCRIPTION
## Summary

Window positioning drifted after monitor changes — switching between 1 and 2 monitors, and waking from sleep — because display handling was driven entirely by per-display `DisplayAdded`/`Removed`/`Moved` flags. Those flags are unreliable or absent on wake, and `DisplayResized` / `DisplayConfigured` / `SystemWoke` were **never handled** (they fell through the `_ => continue` arm or had no consumer at all). The ECS display set and window layout could therefore fall out of sync with reality.

## Change

Adds a `reconcile_displays` system that runs on `SystemWoke`, `DisplayResized`, and `DisplayConfigured`. Rather than trust a single `display_id` flag, it **diffs the live `present_displays()` list against the spawned `Display` entities** and applies the existing add / remove / move primitives:

- vanished display → removed (its workspace orphaned via the existing timeout mechanism),
- new display → added,
- surviving displays → bounds refreshed (resolution / menubar changes).

It then forces the active workspace to re-tile, because macOS relocates window frames across a sleep/wake cycle even when the display set is unchanged. The diff is idempotent, so a wake-time event burst that briefly flickers a monitor won't corrupt state — the orphan's grace window absorbs the transient and the next reconcile re-homes.

The existing orphan + 30s-timeout path (for transient removal mid-Space-switch) is unchanged.

## Tests

- `test_wake_reconciles_unplugged_display` — a monitor unplugged with no `DisplayRemoved` event (mimicking wake) is reconciled: the vanished display is despawned and its workspace orphaned.
- `test_wake_refreshes_active_workspace` — wake marks the active workspace for a window-size refresh even when the display set is unchanged.
- Adds a `MockState::remove_display` helper.

`cargo build --release`, `cargo clippy` (pedantic), `cargo fmt`, `cargo test` (136 passed) all clean.

## Known follow-up

When a monitor is removed *permanently*, its workspace strip is orphaned rather than re-tiled onto the surviving display. Whether windows are stranded depends on whether macOS migrates the removed display's spaces onto the survivor (if it does, reconcile re-homes them for free). Pending hardware confirmation before adding explicit re-homing.

Based on `testing`.