### PR TITLE
Forced window management

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -218,14 +218,12 @@ structured `paneru query` responses and `paneru subscribe` event stream.
 
 ## 6. Window Rules (`[windows]`)
 
-Define specific behaviors for applications based on their Title, Bundle ID, and/or Accessibility role/subrole.
+Define specific behaviors for applications based on their Title or Bundle ID.
 
 | Option | Type | Description |
 | :--- | :--- | :--- |
 | `title` | Regex | **(Required)** Regex pattern to match the window title. |
 | `bundle_id` | String | Optional Bundle ID to match (e.g., `com.apple.Terminal`). |
-| `role` | Regex | Optional regex to match the window's accessibility role (e.g., `AXWindow`). |
-| `subrole` | Regex | Optional regex to match the window's accessibility subrole (e.g., `AXStandardWindow`). |
 | `floating` | Boolean | Force the window to be floating/unmanaged. |
 | `manage` | Boolean | Force Paneru to manage this app/window even if macOS reports the app as unobservable or the window has a non-standard role/subrole. |
 | `index` | Integer | Preferred position in the strip when spawned. |
@@ -250,14 +248,12 @@ bindings_passthrough = ["ctrl-h", "ctrl-l"]
 Some applications (e.g., BetterTouchTool, ProtonVPN) are flagged as background apps
 (`LSUIElement`) or expose windows with unusual accessibility roles such as `AXTable`
 or `AXTextField`. Paneru normally ignores these processes and windows. Use `manage = true`
-to opt in, and narrow the match with `role`/`subrole` so that only the intended window
-is managed.
+to opt in and forcibly manage the matching windows.
 
 ```toml
 [windows.btt_main]
 bundle_id = "com.hegenberg.BetterTouchTool"
 title = "BetterTouchTool"
-role = "AXTable|AXTextField"
 manage = true
 
 [windows.btt_screenshot]

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -139,6 +139,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 | `window_stack` | Stack the current window into the column on the left. |
 | `window_unstack` | Pull a window out of a stack into its own column. |
 | `window_equalize` | Make all windows in a stack equal height. |
+| `window_balance` | Make all columns in the strip the same width as the focused window. |
 | `window_nextdisplay` | Move focused window to the next monitor and follow it. |
 | `window_nextdisplaysend` | Move focused window to the next monitor but stay on current. |
 | `mouse_nextdisplay` | Warp mouse cursor to the next monitor. |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -218,13 +218,16 @@ structured `paneru query` responses and `paneru subscribe` event stream.
 
 ## 6. Window Rules (`[windows]`)
 
-Define specific behaviors for applications based on their Title or Bundle ID.
+Define specific behaviors for applications based on their Title, Bundle ID, and/or Accessibility role/subrole.
 
 | Option | Type | Description |
 | :--- | :--- | :--- |
 | `title` | Regex | **(Required)** Regex pattern to match the window title. |
 | `bundle_id` | String | Optional Bundle ID to match (e.g., `com.apple.Terminal`). |
+| `role` | Regex | Optional regex to match the window's accessibility role (e.g., `AXWindow`). |
+| `subrole` | Regex | Optional regex to match the window's accessibility subrole (e.g., `AXStandardWindow`). |
 | `floating` | Boolean | Force the window to be floating/unmanaged. |
+| `manage` | Boolean | Force Paneru to manage this app/window even if macOS reports the app as unobservable or the window has a non-standard role/subrole. |
 | `index` | Integer | Preferred position in the strip when spawned. |
 | `dont_focus` | Boolean | Prevent the window from taking focus when spawned. |
 | `width` | Float (0.0–1.0) | Initial width ratio for the window. |
@@ -240,6 +243,27 @@ title = ".*"
 bundle_id = "com.apple.Terminal"
 horizontal_padding = 5
 bindings_passthrough = ["ctrl-h", "ctrl-l"]
+```
+
+### Forcing management of LSUIElement or non-standard windows
+
+Some applications (e.g., BetterTouchTool, ProtonVPN) are flagged as background apps
+(`LSUIElement`) or expose windows with unusual accessibility roles such as `AXTable`
+or `AXTextField`. Paneru normally ignores these processes and windows. Use `manage = true`
+to opt in, and narrow the match with `role`/`subrole` so that only the intended window
+is managed.
+
+```toml
+[windows.btt_main]
+bundle_id = "com.hegenberg.BetterTouchTool"
+title = "BetterTouchTool"
+role = "AXTable|AXTextField"
+manage = true
+
+[windows.btt_screenshot]
+bundle_id = "com.hegenberg.BetterTouchTool"
+title = "Screenshot.*"
+floating = true
 ```
 
 ### Session Restore

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ $ paneru send-cmd <command> [args...]
 | `window fullwidth`         | Toggle full-width mode for the focused window    |
 | `window manage`            | Toggle managed/floating state                    |
 | `window equalize`          | Distribute equal heights in the focused stack    |
+| `window balance`           | Make all columns match the focused window width  |
 | `window stack`             | Stack the focused window onto its left neighbour |
 | `window unstack`           | Unstack the focused window into its own column   |
 | `window nextdisplay`       | Move the focused window to the next display      |
@@ -249,6 +250,9 @@ $ paneru send-cmd window swap west
 
 # Center and resize in one shot (two separate calls).
 $ paneru send-cmd window center && paneru send-cmd window resize
+
+# Balance all columns to the focused window's width.
+$ paneru send-cmd window balance
 
 # Cycle backward through preset widths.
 $ paneru send-cmd window shrink
@@ -288,9 +292,9 @@ scripts, `cron` jobs, or other automation tools:
 
 - **Launch-and-arrange workflow.** Open an application and immediately position
   it: `open -a Safari && sleep 0.5 && paneru send-cmd window resize`.
-- **One-key layout reset.** Bind a script that focuses the first window, resizes
-  it, then moves east and resizes the next one — recreating a preferred layout
-  after windows get shuffled.
+- **One-key layout reset.** Use `paneru send-cmd window balance` to make every
+  column the same width as the focused window — great for resetting layouts
+  after unplugging a monitor or when windows get shuffled.
 - **Integration with other tools.** Pipe focus events from tools like
   [Hammerspoon](https://www.hammerspoon.org) or
   [skhd](https://github.com/koekeishiya/skhd) into `paneru send-cmd` for

--- a/nix/README.md
+++ b/nix/README.md
@@ -64,6 +64,7 @@ expose the same following options:
         window_focus_east = "cmd - l";
         window_resize = "alt - r";
         window_center = "alt - c";
+        window_balance = "alt - b";
         quit = "ctrl + alt - q";
       };
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -81,6 +81,8 @@ pub enum Operation {
     ToNextDisplay(MoveFocus),
     /// Distributes heights equally among windows in the focused stack.
     Equalize,
+    /// Makes all columns in the active strip the same width as the focused window.
+    Balance,
     /// Toggles the managed state of the focused window.
     Manage,
     /// Stacks or unstacks a window. The boolean indicates whether to stack (`true`) or unstack (`false`).
@@ -141,6 +143,7 @@ pub fn register_commands(app: &mut bevy::app::App) {
             full_width_window,
             to_next_display,
             equalize_column,
+            balance_strip,
             manage_window,
             stack_windows_handler,
             command_move_focus,
@@ -1134,6 +1137,51 @@ fn equalize_column(
             }
         }
     }
+}
+
+/// Makes all columns in the active strip the same width as the focused window.
+#[allow(clippy::needless_pass_by_value)]
+fn balance_strip(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    active_display: ActiveDisplay,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| matches!(op, Operation::Balance))
+        .next()
+        .is_none()
+    {
+        return;
+    }
+
+    let Some((_, focused_entity)) = windows.focused() else {
+        return;
+    };
+    let Some(focused_width) = windows.size(focused_entity).map(|s| s.x) else {
+        return;
+    };
+
+    let strip = active_display.active_strip();
+
+    for column in strip.columns() {
+        if matches!(column, Column::Fullscren(_)) {
+            continue;
+        }
+
+        for entity in column.window_iter() {
+            if windows.full_width(entity).is_some()
+                && let Ok(mut cmds) = commands.get_entity(entity)
+            {
+                cmds.try_remove::<FullWidthMarker>();
+            }
+
+            if let Some(size) = windows.size(entity) {
+                commands.resize_entity(entity, size.with_x(focused_width));
+            }
+        }
+    }
+
+    commands.reshuffle_around(focused_entity);
 }
 
 /// Slides the strip so the focused window is fully visible, snapping to the

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use bevy::app::PreUpdate;
 use bevy::ecs::entity::{Entity, EntityHashSet};
 use bevy::ecs::hierarchy::ChildOf;
@@ -16,8 +18,9 @@ use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
-    ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker, FullWidthMarker,
-    NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger, SpawnCommandsExt, Unmanaged,
+    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker,
+    FullWidthMarker, NativeFullscreenMarker, SelectedVirtualMarker, SendMessageTrigger,
+    SpawnCommandsExt, Timeout, Unmanaged,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Origin, Size, Window, WindowManager, origin_from};
@@ -924,13 +927,13 @@ fn manage_window(
 /// * `windows` - A mutable query for `Window` components, their `Entity`, and whether they have the `Unmanaged` marker.
 /// * `active_display` - A mutable reference to the `ActiveDisplayMut` resource.
 /// * `commands` - Bevy commands to modify entities and trigger events.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 fn to_next_display(
     mut messages: MessageReader<Event>,
     windows: Windows,
     mut active_display: ActiveDisplayMut,
     mut other_workspaces: Query<
-        &mut LayoutStrip,
+        (&mut LayoutStrip, &ChildOf),
         (With<SelectedVirtualMarker>, Without<ActiveWorkspaceMarker>),
     >,
     window_manager: Res<WindowManager>,
@@ -997,12 +1000,33 @@ fn to_next_display(
 
     // Insert into the target display's selected strip.
     if let Ok(target_space_id) = window_manager.active_display_space(target_display_id)
-        && let Some(mut target_strip) = other_workspaces
+        && let Some((mut target_strip, child)) = other_workspaces
             .iter_mut()
-            .find(|strip| strip.id() == target_space_id)
+            .find(|(strip, _)| strip.id() == target_space_id)
     {
         target_strip.append(entity);
         commands.reshuffle_around(entity);
+
+        // Add a delayed refresh of the window size - because the otehr display can have different bounds.
+        let display_entity = child.parent();
+        let moved_window = entity;
+        let refresh_size = move |windows: Query<&Bounds, With<Window>>,
+                                 displays: Query<(&Display, Option<&DockPosition>)>,
+                                 mut commands: Commands,
+                                 config: Res<Config>| {
+            let viewport = displays
+                .get(display_entity)
+                .ok()
+                .map(|(display, dock)| display.actual_display_bounds(dock, &config));
+            if let Some(viewport_bounds) = viewport
+                && let Ok(Bounds(bounds)) = windows.get(moved_window)
+            {
+                debug!("Refreshing size of window {entity}");
+                commands.resize_entity(moved_window, bounds.with_y(viewport_bounds.height()));
+            }
+        };
+        let system_id = commands.register_system(refresh_size);
+        Timeout::callback(Duration::from_secs(1), system_id, &mut commands);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -404,28 +404,19 @@ impl Config {
             })
     }
 
-    /// Finds window properties for a given `title`, `bundle_id`, `role`, and `subrole`.
+    /// Finds window properties for a given `title` and `bundle_id`.
     /// It iterates through configured window parameters and returns all matching rules.
-    /// A rule matches when its bundle ID (if any) and title regex match, and when any
-    /// optional `role`/`subrole` regexes also match.
+    /// A rule matches when its bundle ID (if any) and title regex match.
     ///
     /// # Arguments
     ///
     /// * `title` - The title of the window to match.
     /// * `bundle_id` - The bundle identifier of the application owning the window.
-    /// * `role` - The accessibility role of the window (optional).
-    /// * `subrole` - The accessibility subrole of the window (optional).
     ///
     /// # Returns
     ///
     /// A `Vec<WindowParams>` containing all matching window rules.
-    pub fn find_window_properties(
-        &self,
-        title: &str,
-        bundle_id: &str,
-        role: Option<&str>,
-        subrole: Option<&str>,
-    ) -> Vec<WindowParams> {
+    pub fn find_window_properties(&self, title: &str, bundle_id: &str) -> Vec<WindowParams> {
         self.inner()
             .windows
             .as_ref()
@@ -435,18 +426,7 @@ impl Config {
                     .filter(|params| {
                         let bundle_match =
                             params.bundle_id.as_ref().map(|id| id.as_str() == bundle_id);
-                        let role_match = params
-                            .role
-                            .as_ref()
-                            .is_none_or(|re| role.is_some_and(|r| re.is_match(r)));
-                        let subrole_match = params
-                            .subrole
-                            .as_ref()
-                            .is_none_or(|re| subrole.is_some_and(|s| re.is_match(s)));
-                        bundle_match.is_none_or(|m| m)
-                            && params.title.is_match(title)
-                            && role_match
-                            && subrole_match
+                        bundle_match.is_none_or(|m| m) && params.title.is_match(title)
                     })
                     .cloned()
                     .collect::<Vec<_>>()
@@ -1165,9 +1145,8 @@ impl<'de> Deserialize<'de> for Keybinding {
     }
 }
 
-/// `WindowParams` defines rules and properties for specific windows based on their title, bundle ID,
-/// and accessibility role/subrole. These parameters can override default window management behavior,
-/// such as forcing a window to float or setting its initial index.
+/// `WindowParams` defines rules and properties for specific windows based on their title or bundle ID.
+/// These parameters can override default window management behavior, such as forcing a window to float or setting its initial index.
 #[derive(Clone, Debug, Deserialize)]
 pub struct WindowParams {
     /// A regular expression to match against the window's title.
@@ -1175,12 +1154,6 @@ pub struct WindowParams {
     title: Regex,
     /// An optional bundle identifier to match against the application's bundle ID.
     bundle_id: Option<String>,
-    /// An optional regular expression to match against the window's accessibility role.
-    #[serde(default, deserialize_with = "deserialize_optional_regex")]
-    role: Option<Regex>,
-    /// An optional regular expression to match against the window's accessibility subrole.
-    #[serde(default, deserialize_with = "deserialize_optional_regex")]
-    subrole: Option<Regex>,
     /// If `true`, the window will be managed as a floating window (not tiled).
     pub floating: Option<bool>,
     /// If `true`, force the process/window to be managed even if macOS reports it as
@@ -1215,8 +1188,6 @@ impl WindowParams {
         Self {
             title: Regex::new(title).unwrap(),
             bundle_id,
-            role: None,
-            subrole: None,
             floating: None,
             manage: None,
             index: None,
@@ -1263,19 +1234,6 @@ where
 {
     let s = String::deserialize(deserializer)?;
     Regex::new(&s).map_err(de::Error::custom)
-}
-
-/// Deserializes an optional regular expression string.
-fn deserialize_optional_regex<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<Regex>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let Some(s) = Option::<String>::deserialize(deserializer)? else {
-        return Ok(None);
-    };
-    Regex::new(&s).map(Some).map_err(de::Error::custom)
 }
 
 fn deserialize_modifier<'de, D>(deserializer: D) -> std::result::Result<Option<Modifiers>, D::Error>
@@ -1779,8 +1737,7 @@ index = 1
         Some(Command::Window(Operation::Resize(ResizeDirection::Shrink)))
     ));
 
-    let props =
-        config.find_window_properties("picture in picture", "com.something.apple", None, None);
+    let props = config.find_window_properties("picture in picture", "com.something.apple");
     assert_eq!(props[0].floating, Some(true));
     assert_eq!(props[0].index, Some(1));
 
@@ -1877,8 +1834,6 @@ fn test_grid_ratios() {
     let make = |grid: Option<&str>| WindowParams {
         title: Regex::new(".*").unwrap(),
         bundle_id: None,
-        role: None,
-        subrole: None,
         floating: None,
         manage: None,
         index: None,
@@ -1978,7 +1933,7 @@ fn test_config_defaults() {
 }
 
 #[test]
-fn test_window_rules_match_role_and_subrole() {
+fn test_window_rules_manage() {
     let input = r#"
 [options]
 
@@ -1987,8 +1942,6 @@ fn test_window_rules_match_role_and_subrole() {
 [windows.btt_main]
 bundle_id = "com.hegenberg.BetterTouchTool"
 title = "BetterTouchTool"
-role = "AXTable|AXTextField"
-subrole = "AXUnknownSubrole"
 manage = true
 
 [windows.btt_floating]
@@ -1998,32 +1951,13 @@ floating = true
 "#;
     let config = Config::try_from(input).expect("config should parse");
 
-    // Non-standard window should match the manage rule.
-    let props = config.find_window_properties(
-        "BetterTouchTool",
-        "com.hegenberg.BetterTouchTool",
-        Some("AXTextField"),
-        Some("AXUnknownSubrole"),
-    );
+    // Main window should match the manage rule.
+    let props = config.find_window_properties("BetterTouchTool", "com.hegenberg.BetterTouchTool");
     assert_eq!(props.len(), 1);
     assert_eq!(props[0].manage, Some(true));
 
-    // Standard window should not match the manage rule (role differs).
-    let props = config.find_window_properties(
-        "BetterTouchTool",
-        "com.hegenberg.BetterTouchTool",
-        Some("AXWindow"),
-        Some("AXStandardWindow"),
-    );
-    assert!(props.is_empty());
-
-    // Screenshot window matches the floating rule, regardless of role.
-    let props = config.find_window_properties(
-        "Screenshot 1",
-        "com.hegenberg.BetterTouchTool",
-        Some("AXWindow"),
-        Some("AXFloatingWindow"),
-    );
+    // Screenshot window matches the floating rule.
+    let props = config.find_window_properties("Screenshot 1", "com.hegenberg.BetterTouchTool");
     assert_eq!(props.len(), 1);
     assert_eq!(props[0].floating, Some(true));
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -404,18 +404,28 @@ impl Config {
             })
     }
 
-    /// Finds window properties for a given `title` and `bundle_id`.
-    /// It iterates through configured window parameters and returns the first match.
+    /// Finds window properties for a given `title`, `bundle_id`, `role`, and `subrole`.
+    /// It iterates through configured window parameters and returns all matching rules.
+    /// A rule matches when its bundle ID (if any) and title regex match, and when any
+    /// optional `role`/`subrole` regexes also match.
     ///
     /// # Arguments
     ///
     /// * `title` - The title of the window to match.
     /// * `bundle_id` - The bundle identifier of the application owning the window.
+    /// * `role` - The accessibility role of the window (optional).
+    /// * `subrole` - The accessibility subrole of the window (optional).
     ///
     /// # Returns
     ///
-    /// `Some(WindowParams)` if matching window properties are found, otherwise `None`.
-    pub fn find_window_properties(&self, title: &str, bundle_id: &str) -> Vec<WindowParams> {
+    /// A `Vec<WindowParams>` containing all matching window rules.
+    pub fn find_window_properties(
+        &self,
+        title: &str,
+        bundle_id: &str,
+        role: Option<&str>,
+        subrole: Option<&str>,
+    ) -> Vec<WindowParams> {
         self.inner()
             .windows
             .as_ref()
@@ -425,12 +435,37 @@ impl Config {
                     .filter(|params| {
                         let bundle_match =
                             params.bundle_id.as_ref().map(|id| id.as_str() == bundle_id);
-                        bundle_match.is_none_or(|m| m) && params.title.is_match(title)
+                        let role_match = params
+                            .role
+                            .as_ref()
+                            .is_none_or(|re| role.is_some_and(|r| re.is_match(r)));
+                        let subrole_match = params
+                            .subrole
+                            .as_ref()
+                            .is_none_or(|re| subrole.is_some_and(|s| re.is_match(s)));
+                        bundle_match.is_none_or(|m| m)
+                            && params.title.is_match(title)
+                            && role_match
+                            && subrole_match
                     })
                     .cloned()
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default()
+    }
+
+    /// Returns `true` if any window rule for the given bundle ID requests that the
+    /// process be forcibly managed even when macOS reports it as unobservable.
+    pub fn should_force_manage_process(&self, bundle_id: &str) -> bool {
+        self.inner().windows.as_ref().is_some_and(|windows| {
+            windows.values().any(|params| {
+                params
+                    .bundle_id
+                    .as_ref()
+                    .is_some_and(|id| id.as_str() == bundle_id)
+                    && params.manage.is_some_and(|manage| manage)
+            })
+        })
     }
 
     pub fn sliver_height(&self) -> f64 {
@@ -1130,8 +1165,9 @@ impl<'de> Deserialize<'de> for Keybinding {
     }
 }
 
-/// `WindowParams` defines rules and properties for specific windows based on their title or bundle ID.
-/// These parameters can override default window management behavior, such as forcing a window to float or setting its initial index.
+/// `WindowParams` defines rules and properties for specific windows based on their title, bundle ID,
+/// and accessibility role/subrole. These parameters can override default window management behavior,
+/// such as forcing a window to float or setting its initial index.
 #[derive(Clone, Debug, Deserialize)]
 pub struct WindowParams {
     /// A regular expression to match against the window's title.
@@ -1139,8 +1175,17 @@ pub struct WindowParams {
     title: Regex,
     /// An optional bundle identifier to match against the application's bundle ID.
     bundle_id: Option<String>,
+    /// An optional regular expression to match against the window's accessibility role.
+    #[serde(default, deserialize_with = "deserialize_optional_regex")]
+    role: Option<Regex>,
+    /// An optional regular expression to match against the window's accessibility subrole.
+    #[serde(default, deserialize_with = "deserialize_optional_regex")]
+    subrole: Option<Regex>,
     /// If `true`, the window will be managed as a floating window (not tiled).
     pub floating: Option<bool>,
+    /// If `true`, force the process/window to be managed even if macOS reports it as
+    /// unobservable or the window does not look like a standard window.
+    pub manage: Option<bool>,
     /// An optional preferred index for the window's position in the window strip.
     pub index: Option<usize>,
     pub vertical_padding: Option<i32>,
@@ -1170,7 +1215,10 @@ impl WindowParams {
         Self {
             title: Regex::new(title).unwrap(),
             bundle_id,
+            role: None,
+            subrole: None,
             floating: None,
+            manage: None,
             index: None,
             vertical_padding: None,
             horizontal_padding: None,
@@ -1215,6 +1263,19 @@ where
 {
     let s = String::deserialize(deserializer)?;
     Regex::new(&s).map_err(de::Error::custom)
+}
+
+/// Deserializes an optional regular expression string.
+fn deserialize_optional_regex<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Regex>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(s) = Option::<String>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    Regex::new(&s).map(Some).map_err(de::Error::custom)
 }
 
 fn deserialize_modifier<'de, D>(deserializer: D) -> std::result::Result<Option<Modifiers>, D::Error>
@@ -1718,7 +1779,8 @@ index = 1
         Some(Command::Window(Operation::Resize(ResizeDirection::Shrink)))
     ));
 
-    let props = config.find_window_properties("picture in picture", "com.something.apple");
+    let props =
+        config.find_window_properties("picture in picture", "com.something.apple", None, None);
     assert_eq!(props[0].floating, Some(true));
     assert_eq!(props[0].index, Some(1));
 
@@ -1815,7 +1877,10 @@ fn test_grid_ratios() {
     let make = |grid: Option<&str>| WindowParams {
         title: Regex::new(".*").unwrap(),
         bundle_id: None,
+        role: None,
+        subrole: None,
         floating: None,
+        manage: None,
         index: None,
         vertical_padding: None,
         horizontal_padding: None,
@@ -1910,6 +1975,74 @@ fn test_config_defaults() {
     assert_eq!(config.border_width(), 2.0);
     assert_eq!(config.border_radius(), BorderRadiusOption::Auto);
     assert_eq!(config.menubar_height(), None);
+}
+
+#[test]
+fn test_window_rules_match_role_and_subrole() {
+    let input = r#"
+[options]
+
+[bindings]
+
+[windows.btt_main]
+bundle_id = "com.hegenberg.BetterTouchTool"
+title = "BetterTouchTool"
+role = "AXTable|AXTextField"
+subrole = "AXUnknownSubrole"
+manage = true
+
+[windows.btt_floating]
+bundle_id = "com.hegenberg.BetterTouchTool"
+title = "Screenshot.*"
+floating = true
+"#;
+    let config = Config::try_from(input).expect("config should parse");
+
+    // Non-standard window should match the manage rule.
+    let props = config.find_window_properties(
+        "BetterTouchTool",
+        "com.hegenberg.BetterTouchTool",
+        Some("AXTextField"),
+        Some("AXUnknownSubrole"),
+    );
+    assert_eq!(props.len(), 1);
+    assert_eq!(props[0].manage, Some(true));
+
+    // Standard window should not match the manage rule (role differs).
+    let props = config.find_window_properties(
+        "BetterTouchTool",
+        "com.hegenberg.BetterTouchTool",
+        Some("AXWindow"),
+        Some("AXStandardWindow"),
+    );
+    assert!(props.is_empty());
+
+    // Screenshot window matches the floating rule, regardless of role.
+    let props = config.find_window_properties(
+        "Screenshot 1",
+        "com.hegenberg.BetterTouchTool",
+        Some("AXWindow"),
+        Some("AXFloatingWindow"),
+    );
+    assert_eq!(props.len(), 1);
+    assert_eq!(props[0].floating, Some(true));
+}
+
+#[test]
+fn test_should_force_manage_process() {
+    let input = r#"
+[options]
+
+[bindings]
+
+[windows.btt_main]
+bundle_id = "com.hegenberg.BetterTouchTool"
+title = ".*"
+manage = true
+"#;
+    let config = Config::try_from(input).expect("config should parse");
+    assert!(config.should_force_manage_process("com.hegenberg.BetterTouchTool"));
+    assert!(!config.should_force_manage_process("com.apple.Terminal"));
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,6 +211,7 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "fullwidth" => Operation::FullWidth,
         "manage" => Operation::Manage,
         "equalize" => Operation::Equalize,
+        "balance" => Operation::Balance,
         "stack" => Operation::Stack(true),
         "unstack" => Operation::Stack(false),
         "nextdisplay" => Operation::ToNextDisplay(MoveFocus::Follow),

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -594,10 +594,7 @@ impl WindowProperties {
     pub fn new(app: &Application, window: &Window, config: &Config) -> Self {
         let bundle_id = app.bundle_id().unwrap_or_default();
         let title = window.title().unwrap_or_default();
-        let role = window.role().ok();
-        let subrole = window.subrole().ok();
-        let params =
-            config.find_window_properties(&title, &bundle_id, role.as_deref(), subrole.as_deref());
+        let params = config.find_window_properties(&title, &bundle_id);
         Self { params }
     }
 

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -594,7 +594,10 @@ impl WindowProperties {
     pub fn new(app: &Application, window: &Window, config: &Config) -> Self {
         let bundle_id = app.bundle_id().unwrap_or_default();
         let title = window.title().unwrap_or_default();
-        let params = config.find_window_properties(&title, &bundle_id);
+        let role = window.role().ok();
+        let subrole = window.subrole().ok();
+        let params =
+            config.find_window_properties(&title, &bundle_id, role.as_deref(), subrole.as_deref());
         Self { params }
     }
 

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -19,7 +19,8 @@ use crate::ecs::state::{
 };
 use crate::ecs::workspace::PreviousStripPosition;
 use crate::ecs::{
-    ActiveDisplayMarker, ActiveWorkspaceMarker, RestoreWindowState, SpawnCommandsExt, Unmanaged,
+    ActiveDisplayMarker, ActiveWorkspaceMarker, RefreshWindowSizes, RestoreWindowState,
+    SpawnCommandsExt, Unmanaged,
 };
 use crate::manager::{Application, Display, Window};
 use crate::platform::{Pid, WinID, WorkspaceId};
@@ -532,6 +533,7 @@ pub(super) fn restore_window_state(
 
         let mut spawned =
             commands.spawn_layout_strip(strip, origin, display_entity, is_global_active);
+        spawned.try_insert(RefreshWindowSizes::default());
         if !is_global_active {
             spawned.insert(previous);
         }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -121,6 +121,7 @@ pub(crate) fn add_existing_application(
     window_manager: Res<WindowManager>,
     workspaces: Query<&LayoutStrip>,
     fresh_apps: Populated<(&mut Application, Entity), With<ExistingMarker>>,
+    config: Res<Config>,
     mut commands: Commands,
 ) {
     let spaces = workspaces
@@ -134,7 +135,7 @@ pub(crate) fn add_existing_application(
 
         if app.observe().is_ok_and(|result| result)
             && let Ok((found_windows, offscreen)) = window_manager
-                .find_existing_application_windows(&mut app, &spaces)
+                .find_existing_application_windows(&mut app, &spaces, &config)
                 .inspect_err(|err| warn!("{err}"))
         {
             offscreen_windows.extend(offscreen);
@@ -144,8 +145,11 @@ pub(crate) fn add_existing_application(
 
         if !offscreen_windows.is_empty() {
             let pid = app.pid();
-            let bruteforce_task =
-                thread_pool.spawn(async move { bruteforce_windows(pid, offscreen_windows) });
+            let bundle_id = app.bundle_id();
+            let config = config.clone();
+            let bruteforce_task = thread_pool.spawn(async move {
+                bruteforce_windows(pid, bundle_id.as_deref(), offscreen_windows, &config)
+            });
             commands.spawn(BruteforceWindows(bruteforce_task));
         }
     }
@@ -256,6 +260,7 @@ pub(crate) fn finish_setup(
 pub(super) fn add_launched_process(
     window_manager: Res<WindowManager>,
     fresh_processes: Populated<(Entity, &mut BProcess, Has<Children>), With<FreshMarker>>,
+    config: Res<Config>,
     mut commands: Commands,
 ) {
     const APP_OBSERVABLE_TIMEOUT_SEC: u64 = 5;
@@ -266,6 +271,22 @@ pub(super) fn add_launched_process(
 
         if !already_seen.insert(process.psn()) {
             continue;
+        }
+
+        let bundle_id = process
+            .application()
+            .as_ref()
+            .and_then(|app| app.bundleIdentifier())
+            .map(|id| id.to_string());
+        let forced = bundle_id
+            .as_ref()
+            .is_some_and(|id| config.should_force_manage_process(id));
+        if forced {
+            debug!(
+                "Forcing management of launched process '{}' despite unobservable policy.",
+                process.name()
+            );
+            process.force_manage(true);
         }
 
         if !process.ready() {
@@ -312,13 +333,14 @@ pub(super) fn add_launched_process(
 pub(super) fn add_launched_application(
     app_query: Populated<(&mut Application, Entity, Has<Children>), With<FreshMarker>>,
     windows: Windows,
+    config: Res<Config>,
     mut commands: Commands,
 ) {
     // TODO: maybe refactor this with add_existing_application_windows()
     let find_window = |window_id| windows.find(window_id);
 
     for (app, entity, has_children) in app_query {
-        let mut create_windows = app.window_list();
+        let mut create_windows = app.window_list(&config);
         // Retain the non-existing windows, so they can be created.
         create_windows.retain(|window| find_window(window.id()).is_none());
 
@@ -737,13 +759,28 @@ pub(crate) fn gather_initial_processes(
             event => warn!("Stray event during initial process gathering: {event:?}"),
         }
     }
-    if let Some(config) = initial_config {
-        commands.insert_resource(config);
-    }
-
     while let Some(mut process) = initial_processes.pop() {
-        if process.is_observable() {
-            debug!("Adding existing process {}", process.name());
+        let bundle_id = process
+            .application()
+            .as_ref()
+            .and_then(|app| app.bundleIdentifier())
+            .map(|id| id.to_string());
+        let forced = initial_config.as_ref().is_some_and(|c| {
+            bundle_id
+                .as_ref()
+                .is_some_and(|id| c.should_force_manage_process(id))
+        });
+
+        if process.is_observable() || forced {
+            if forced {
+                debug!(
+                    "Forcing management of existing process '{}' despite unobservable policy.",
+                    process.name()
+                );
+                process.force_manage(true);
+            } else {
+                debug!("Adding existing process {}", process.name());
+            }
             commands.spawn((ExistingMarker, process));
         } else {
             debug!(
@@ -751,6 +788,10 @@ pub(crate) fn gather_initial_processes(
                 process.name(),
             );
         }
+    }
+
+    if let Some(config) = initial_config {
+        commands.insert_resource(config);
     }
 }
 

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -910,7 +910,7 @@ pub(super) fn spawn_window_trigger(
             continue;
         };
         let position = Position(frame.min);
-        let bounds = Bounds(Size::new(frame.width(), frame.height()));
+        let bounds = Bounds(frame.size());
         let width_ratio =
             WidthRatio(f64::from(frame.width()) / f64::from(active_display.bounds().width()));
         let layout_position = LayoutPosition::default();

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -172,7 +172,7 @@ fn workspace_change_trigger(
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 fn detect_moved_windows(
     activated_workspace: Single<Entity, Added<ActiveWorkspaceMarker>>,
@@ -180,6 +180,7 @@ fn detect_moved_windows(
     mut workspaces: Query<(&mut LayoutStrip, Entity, Has<NativeFullscreenMarker>)>,
     apps: Query<&mut Application>,
     window_manager: Res<WindowManager>,
+    config: Res<Config>,
     mut ignored_windows: Local<HashSet<WinID>>,
     mut commands: Commands,
 ) {
@@ -219,7 +220,7 @@ fn detect_moved_windows(
         let retry_windows = apps
             .into_iter()
             .flat_map(|app| {
-                app.window_list()
+                app.window_list(&config)
                     .into_iter()
                     .filter(|window| unresolved_ids.contains(&window.id()))
             })

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use stdext::function_name;
 use tracing::{Level, debug, error, instrument, trace, warn};
 
+use crate::config::Config;
 use crate::errors::{Error, Result};
 use crate::events::{Event, EventSender};
 use crate::manager::skylight::SLSSetWindowListBrightness;
@@ -133,7 +134,7 @@ pub trait WindowManagerApi: Send + Sync {
     ///
     /// * `app` - A mutable reference to the `Application` whose windows are to be added.
     /// * `spaces` - A slice of space IDs to query for windows.
-    /// * `refresh_index` - An integer indicating the refresh index (used internally for tracking).
+    /// * `config` - The current Paneru configuration, used to evaluate window rules.
     ///
     /// # Returns
     ///
@@ -142,6 +143,7 @@ pub trait WindowManagerApi: Send + Sync {
         &self,
         app: &mut Application,
         spaces: &[WorkspaceId],
+        config: &Config,
     ) -> Result<(Vec<Window>, Vec<WinID>)>;
     /// Finds the `WinID` of a window at a given screen point.
     ///
@@ -423,6 +425,7 @@ impl WindowManagerApi for WindowManagerOS {
         &self,
         app: &mut Application,
         spaces: &[WorkspaceId],
+        config: &Config,
     ) -> Result<(Vec<Window>, Vec<WinID>)> {
         let global_window_list = existing_application_window_list(self.main_cid, app, spaces)?;
         if global_window_list.is_empty() {
@@ -430,7 +433,7 @@ impl WindowManagerApi for WindowManagerOS {
         }
         debug!("{app} has global windows: {global_window_list:?}");
 
-        let found_windows = app.window_list();
+        let found_windows = app.window_list(config);
         if found_windows.len() == global_window_list.len() {
             debug!("All windows for {:?} are now resolved", app.psn());
             return Ok((found_windows, vec![]));
@@ -714,9 +717,16 @@ fn existing_application_window_list(
 ///
 /// # Arguments
 ///
-/// * `app` - A reference to the `Application` whose windows are to be brute-forced.
+/// * `pid` - The process ID of the application whose windows are to be brute-forced.
+/// * `bundle_id` - The bundle identifier of the application, if known.
 /// * `window_list` - A mutable vector of `WinID`s representing the expected global window list; found windows are removed from this list.
-pub fn bruteforce_windows(pid: Pid, mut window_list: Vec<WinID>) -> Vec<Window> {
+/// * `config` - The current Paneru configuration, used to evaluate window rules.
+pub fn bruteforce_windows(
+    pid: Pid,
+    bundle_id: Option<&str>,
+    mut window_list: Vec<WinID>,
+    config: &Config,
+) -> Vec<Window> {
     const MAGIC: u32 = 0x636f_636f;
     const BUFSIZE: isize = 0x14;
     let mut found_windows = Vec::new();
@@ -762,7 +772,9 @@ pub fn bruteforce_windows(pid: Pid, mut window_list: Vec<WinID>) -> Vec<Window> 
         if let Some(index) = window_list.iter().position(|&id| id == window_id) {
             window_list.remove(index);
             debug!("Found window {window_id:?}");
-            if let Ok(window) = WindowOS::new(&element_ref).inspect_err(|err| warn!("{err}")) {
+            if let Ok(window) = WindowOS::new_with_config(&element_ref, config, bundle_id)
+                .inspect_err(|err| warn!("{err}"))
+            {
                 found_windows.push(Window::new(Box::new(window)));
             }
         }

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error};
 
 use super::skylight::_SLPSGetFrontProcess;
 use super::{ProcessApi, Window, WindowOS, ax_window_id};
+use crate::config::Config;
 use crate::errors::{Error, Result};
 use crate::events::{Event, EventSender};
 use crate::platform::{
@@ -68,10 +69,14 @@ pub trait ApplicationApi: Send + Sync {
     fn focused_window_id(&self) -> Result<WinID>;
     /// Returns a list of all windows belonging to this application.
     ///
+    /// # Arguments
+    ///
+    /// * `config` - The current Paneru configuration, used to evaluate window rules.
+    ///
     /// # Errors
     ///
     /// Returns an `Error` if the window list cannot be retrieved.
-    fn window_list(&self) -> Vec<Window>;
+    fn window_list(&self, config: &Config) -> Vec<Window>;
     /// Starts observing application-level accessibility notifications.
     ///
     /// # Errors
@@ -237,14 +242,16 @@ impl ApplicationApi for ApplicationOS {
     /// # Returns
     ///
     /// `Ok(Vec<Result<Window>>)` containing the list of window objects if successful, otherwise `Err(Error)`.
-    fn window_list(&self) -> Vec<Window> {
+    fn window_list(&self, config: &Config) -> Vec<Window> {
+        let bundle_id = self.bundle_id.as_deref();
         self.element
             .windows()
             .map(|windows| {
                 windows
                     .into_iter()
                     .flat_map(|element| {
-                        WindowOS::new(&element).map(|window| Window::new(Box::new(window)))
+                        WindowOS::new_with_config(&element, config, bundle_id)
+                            .map(|window| Window::new(Box::new(window)))
                     })
                     .collect()
             })

--- a/src/manager/process.rs
+++ b/src/manager/process.rs
@@ -98,6 +98,14 @@ pub trait ProcessApi: Send + Sync {
     ///
     /// `true` if the process is ready, `false` otherwise.
     fn ready(&mut self) -> bool;
+    /// Forces the process to be treated as manageable even if macOS reports it as
+    /// unobservable. This is used for user-configured apps such as `LSUIElement`
+    /// background apps that still create standard windows.
+    ///
+    /// # Arguments
+    ///
+    /// * `force` - If `true`, skip the observable check in `ready()`.
+    fn force_manage(&mut self, force: bool);
 }
 
 /// `ProcessOS` is a concrete implementation of the `ProcessApi` trait for macOS.
@@ -137,6 +145,11 @@ impl ProcessApi for ProcessOS {
     fn ready(&mut self) -> bool {
         self.inner.ready()
     }
+
+    /// Sets the force-manage flag on the inner `Process`.
+    fn force_manage(&mut self, force: bool) {
+        self.inner.force_manage(force);
+    }
 }
 
 impl From<Pin<Box<Process>>> for BProcess {
@@ -167,6 +180,8 @@ pub struct Process {
     observing_launched: AtomicBool,
     /// Atomic boolean to track if "activationPolicy" is being observed.
     observing_activated: AtomicBool,
+    /// When `true`, the process is treated as manageable regardless of its activation policy.
+    force_manage: bool,
 }
 
 impl Drop for Process {
@@ -213,6 +228,7 @@ impl Process {
             observer,
             observing_launched: AtomicBool::new(false),
             observing_activated: AtomicBool::new(false),
+            force_manage: false,
         })
     }
 
@@ -230,6 +246,15 @@ impl Process {
             self.policy = NSApplicationActivationPolicy::Prohibited;
             false
         }
+    }
+
+    /// Forces the process to be treated as manageable regardless of its activation policy.
+    ///
+    /// # Arguments
+    ///
+    /// * `force` - If `true`, `ready()` will skip the observable check.
+    pub fn force_manage(&mut self, force: bool) {
+        self.force_manage = force;
     }
 
     /// Checks if the application associated with this process has finished launching.
@@ -361,7 +386,7 @@ impl Process {
         }
         self.unobserve_finished_launching();
 
-        if !self.is_observable() {
+        if !self.force_manage && !self.is_observable() {
             debug!(
                 "{} ({}) is not observable, subscribing to activationPolicy changes",
                 self.name, self.pid

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -26,6 +26,7 @@ use super::skylight::{
     AXUIElementPerformAction, AXUIElementSetAttributeValue, SLPSPostEventRecordTo,
     SLSWindowIteratorAdvance,
 };
+use crate::config::Config;
 use crate::errors::{Error, Result};
 use crate::manager::{Origin, Size, irect_from};
 use crate::platform::{Pid, ProcessSerialNumber, WinID, macos_major_version};
@@ -127,7 +128,8 @@ pub struct WindowOS {
 }
 
 impl WindowOS {
-    /// Creates a new `Window` instance.
+    /// Creates a new `Window` instance using an empty configuration.
+    /// Non-standard windows are rejected unless they match a `manage = true` rule.
     ///
     /// # Arguments
     ///
@@ -138,6 +140,26 @@ impl WindowOS {
     /// `Ok(Window)` if the window is created successfully, otherwise `Err(Error)`.
     #[instrument(level = Level::TRACE, ret)]
     pub fn new(element: &CFRetained<AXUIWrapper>) -> Result<Self> {
+        Self::new_with_config(element, &Config::default(), None)
+    }
+
+    /// Creates a new `Window` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `element` - A `CFRetained<AXUIWrapper>` reference to the Accessibility UI element.
+    /// * `config` - The current Paneru configuration, used to evaluate window rules.
+    /// * `bundle_id` - The bundle identifier of the owning application, if known.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Window)` if the window is created successfully, otherwise `Err(Error)`.
+    #[instrument(level = Level::TRACE, ret)]
+    pub fn new_with_config(
+        element: &CFRetained<AXUIWrapper>,
+        config: &Config,
+        bundle_id: Option<&str>,
+    ) -> Result<Self> {
         let id = ax_window_id(element.as_ptr())?;
         let window = Self {
             id,
@@ -150,7 +172,9 @@ impl WindowOS {
             app_reference: OnceLock::new(),
         };
 
-        if window.is_unknown() {
+        let forced = window.is_forced_manage(config, bundle_id);
+
+        if window.is_unknown() && !forced {
             return Err(Error::invalid_window(&format!(
                 "Ignoring AXUnknown window, id: {}, role {}, subrole {}",
                 window.id(),
@@ -159,7 +183,7 @@ impl WindowOS {
             )));
         }
 
-        if !window.is_real() {
+        if !window.is_real() && !forced {
             return Err(Error::invalid_window(&format!(
                 "Ignoring non-real window, id: {}, role {}, subrole {}",
                 window.id(),
@@ -176,6 +200,25 @@ impl WindowOS {
             window.subrole().unwrap_or_default(),
         );
         Ok(window)
+    }
+
+    /// Checks whether a configured window rule forces this window to be managed
+    /// despite having a non-standard role/subrole.
+    fn is_forced_manage(&self, config: &Config, bundle_id: Option<&str>) -> bool {
+        let Ok(title) = self.title() else {
+            return false;
+        };
+        let role = self.role().ok();
+        let subrole = self.subrole().ok();
+        config
+            .find_window_properties(
+                &title,
+                bundle_id.unwrap_or_default(),
+                role.as_deref(),
+                subrole.as_deref(),
+            )
+            .iter()
+            .any(|params| params.manage.is_some_and(|manage| manage))
     }
 
     /// Checks if the window's subrole is "`AXUnknownSubrole`".

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -208,15 +208,8 @@ impl WindowOS {
         let Ok(title) = self.title() else {
             return false;
         };
-        let role = self.role().ok();
-        let subrole = self.subrole().ok();
         config
-            .find_window_properties(
-                &title,
-                bundle_id.unwrap_or_default(),
-                role.as_deref(),
-                subrole.as_deref(),
-            )
+            .find_window_properties(&title, bundle_id.unwrap_or_default())
             .iter()
             .any(|params| params.manage.is_some_and(|manage| manage))
     }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -538,6 +538,7 @@ impl MockState {
         ma.expect_observe().returning(|| Ok(true));
         ma.expect_observe_window().returning(|_| Ok(true));
         ma.expect_unobserve_window().return_const(());
+        ma.expect_window_list().returning(|_| Vec::new());
 
         Application::new(Box::new(ma))
     }
@@ -576,7 +577,7 @@ impl MockState {
 
         let s = self.clone();
         wm.expect_find_existing_application_windows()
-            .returning(move |app, spaces| {
+            .returning(move |app, spaces, _config| {
                 let pid = app.pid();
                 let windows = s
                     .inner
@@ -652,6 +653,7 @@ impl MockState {
         mp.expect_is_observable().returning(|| true);
         mp.expect_application().return_const(None);
         mp.expect_ready().return_const(true);
+        mp.expect_force_manage().return_const(());
 
         mp
     }

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -109,6 +109,33 @@ fn test_window_shuffle() {
 }
 
 #[test]
+fn test_window_balance() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Resize(ResizeDirection::Grow)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Balance),
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(1, |world, _state| {
+            // After grow, window 0 should be 512 (50% of 1024).
+            assert_window_size!(world, 0, 512, 748);
+        })
+        .on_iteration(2, |world, _state| {
+            // After balance, all windows should match window 0's width.
+            assert_window_size!(world, 0, 512, 748);
+            assert_window_size!(world, 1, 512, 748);
+            assert_window_size!(world, 2, 512, 748);
+        })
+        .run(commands);
+}
+
+#[test]
 fn test_startup_windows() {
     let commands = vec![
         Event::MenuOpened { window_id: 0 },


### PR DESCRIPTION
Fixes #230 

Introduces a `manage` boolean option to force Paneru to manage background applications (`LSUIElement`) or non-standard windows that are normally ignored. This allows users to properly manage apps like BetterTouchTool, Chronoid or ProtonVPN by explicitly opting in.

Example:


```toml
[windows.bettertouchtool]
bundle_id = "com.hegenberg.BetterTouchTool"
title = ".*"
manage = true
```