### PR TITLE
fix: stop strip drifting sideways

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -75,18 +75,16 @@ pub fn register_systems(app: &mut bevy::app::App) {
     // an empty virtual workspace), which otherwise leaves a stale outline.
     // Position changes on the focused window also dirty the overlay so that
     // dragging a floating window moves the highlight with it.
-    let overlay_dirty = |strip_changed: Query<
-        (),
-        (With<ActiveWorkspaceMarker>, Changed<LayoutStrip>),
-    >,
-                         focus_gained: Query<(), Added<FocusedMarker>>,
-                         mut focus_lost: RemovedComponents<FocusedMarker>,
-                         focused_moved: Query<(), (With<FocusedMarker>, Changed<Position>)>| {
-        !strip_changed.is_empty()
-            || !focus_gained.is_empty()
-            || focus_lost.read().next().is_some()
-            || !focused_moved.is_empty()
-    };
+    let overlay_dirty =
+        |strip_changed: Query<(), (With<ActiveWorkspaceMarker>, Changed<LayoutStrip>)>,
+         focus_gained: Query<(), Added<FocusedMarker>>,
+         mut focus_lost: RemovedComponents<FocusedMarker>,
+         focused_moved: Query<(), (With<FocusedMarker>, Changed<Position>)>| {
+            !strip_changed.is_empty()
+                || !focus_gained.is_empty()
+                || focus_lost.read().next().is_some()
+                || !focused_moved.is_empty()
+        };
     let workspace_menu_status =
         |config: Option<Res<Config>>| config.is_some_and(|config| config.workspace_menu_status());
     let native_tabs_enabled =
@@ -226,6 +224,12 @@ pub struct ResizeMarker(pub Size);
 /// Marker component indicating that windows around the marked entity need to be reshuffled.
 #[derive(Component)]
 pub struct ReshuffleAroundMarker;
+
+/// Placed on a strip entity when its position was snapped directly (no animation) during a
+/// virtual workspace switch. Causes `reshuffle_layout_strip` to skip one frame so stale window
+/// positions (not yet recomputed by `position_layout_windows`) don't produce a spurious scroll.
+#[derive(Component)]
+pub struct SkipReshuffleMarker;
 
 /// Marker component requesting that the strip scroll *minimally* to keep the
 /// entity's NEW layout position inside the viewport. Unlike

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -16,7 +16,8 @@ use crate::config::Config;
 use crate::ecs::params::Windows;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, EnsureVisibleMarker, Initializing, LayoutPosition,
-    Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, SpawnCommandsExt,
+    Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, SkipReshuffleMarker,
+    SpawnCommandsExt,
 };
 use crate::errors::{Error, Result};
 use crate::manager::{Display, Origin, Window};
@@ -992,6 +993,7 @@ fn reshuffle_layout_strip(
         &Position,
         &ChildOf,
         Option<Ref<ActiveWorkspaceMarker>>,
+        Has<SkipReshuffleMarker>,
     )>,
     displays: Query<(&Display, Option<&DockPosition>)>,
     windows: Windows,
@@ -1002,11 +1004,19 @@ fn reshuffle_layout_strip(
         if let Ok(mut cmd) = commands.get_entity(entity) {
             cmd.try_remove::<ReshuffleAroundMarker>();
         }
-        let Some((_, strip_entity, active_strip, child, active_marker)) =
+        let Some((_, strip_entity, active_strip, child, active_marker, skip_reshuffle)) =
             strips.into_iter().find(|strip| strip.0.contains(entity))
         else {
             return;
         };
+
+        if skip_reshuffle {
+            trace!("reshuffle_layout_strip: skipping snap-repositioned strip {strip_entity}");
+            if let Ok(mut cmd) = commands.get_entity(strip_entity) {
+                cmd.remove::<SkipReshuffleMarker>();
+            }
+            return;
+        }
 
         if active_marker.is_some_and(|m| m.is_added()) {
             trace!("reshuffle_layout_strip: skipping newly active workspace {strip_entity}");

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -989,11 +989,12 @@ pub(crate) fn show_active_workspace(
         } else {
             position.0 = bounds.max - 10;
         }
-        // Drop any in-flight scroll state so the hidden strip's velocity
-        // does not accumulate while it is off-screen and corrupt the
-        // restored position when the strip is shown again.
+        // Stop any in-flight animation and scroll state so the hidden strip
+        // doesn't continue moving off-screen and doesn't corrupt the saved
+        // position when it is restored.
         if let Ok(mut cmd) = commands.get_entity(entity) {
-            cmd.try_remove::<Scrolling>();
+            cmd.try_remove::<Scrolling>()
+                .try_remove::<RepositionMarker>();
         }
     }
 

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -23,8 +23,8 @@ use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, NativeFullscreenMarker, Position,
-    RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker, SpawnCommandsExt,
-    Timeout, Unmanaged,
+    RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker, SkipReshuffleMarker,
+    SpawnCommandsExt, Timeout, Unmanaged,
 };
 use crate::errors::Result;
 use crate::events::Event;
@@ -989,6 +989,12 @@ pub(crate) fn show_active_workspace(
         } else {
             position.0 = bounds.max - 10;
         }
+        // Drop any in-flight scroll state so the hidden strip's velocity
+        // does not accumulate while it is off-screen and corrupt the
+        // restored position when the strip is shown again.
+        if let Ok(mut cmd) = commands.get_entity(entity) {
+            cmd.try_remove::<Scrolling>();
+        }
     }
 
     let Ok((_, mut position, strip, _, previous_position, _)) = workspaces.get_mut(*activated)
@@ -1015,6 +1021,9 @@ pub(crate) fn show_active_workspace(
             commands.reposition_entity(*activated, *origin);
         } else {
             position.0 = *origin;
+            if let Ok(mut cmd) = commands.get_entity(*activated) {
+                cmd.insert(SkipReshuffleMarker);
+            }
         }
 
         if let Some((_, current_focus)) = windows.focused()

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1061,3 +1061,104 @@ fn test_mid_strip_move_does_not_animate() {
         );
     }
 }
+
+/// Switching virtual workspaces with `virtual_workspace_animations = false` must
+/// never cause the active strip to slide left or right. The strip position must
+/// snap directly to its saved scroll position without any `RepositionMarker`
+/// animating it further. Regression test: after VW2 → VW1, a stale
+/// `reshuffle_layout_strip` was computing an incorrect strip target from
+/// un-updated window positions, inserting a `RepositionMarker` that animated
+/// the strip sideways.
+///
+/// Setup: VW0 has 5 windows (scrollable), scrolled so the focused window sits
+/// at a non-zero strip offset. We then switch to VW1 and back to VW0, and
+/// verify that no RepositionMarker is ever placed on the strip (which would
+/// cause horizontal sliding).
+#[test]
+fn test_virtual_workspace_switch_no_horizontal_slide_no_animations() {
+    let config: Config = (
+        MainOptions {
+            virtual_workspace_animations: Some(false),
+            animation_speed: Some(12.0),
+            swipe_gesture_fingers: Some(3),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    // 5 windows: strip width = 5 * 400 = 2000, display = 1024 → scrollable.
+    let mut h = TestHarness::new().with_config(config).with_windows(5);
+
+    let pump_event = |h: &mut TestHarness, ev: Event| {
+        h.app.world_mut().write_message::<Event>(ev);
+        for _ in 0..8 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+    let pump = |h: &mut TestHarness, c: Command| pump_event(h, Event::Command { command: c });
+
+    // Boot the strip and focus window 0.
+    pump(&mut h, Command::PrintState);
+
+    // Scroll the strip so it sits at a non-zero x offset.
+    pump_event(
+        &mut h,
+        Event::Swipe {
+            delta: 0.3,
+            fingers: 3,
+        },
+    );
+
+    // Remember the settled strip x after scrolling.
+    let strip_x_after_scroll = {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&crate::ecs::Position, With<ActiveWorkspaceMarker>>();
+        q.single(world)
+            .expect("exactly one active strip after scroll")
+            .0
+            .x
+    };
+    assert_ne!(
+        strip_x_after_scroll, 0,
+        "test setup: strip should be scrolled to a non-zero position, got 0"
+    );
+
+    // Switch to VW1 (spawned on the fly, empty).
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+
+    // Switch back to VW0. This is where the bug triggers: the strip should
+    // snap to `strip_x_after_scroll` with no RepositionMarker causing further
+    // horizontal motion.
+    h.app.world_mut().write_message::<Event>(Event::Command {
+        command: Command::Window(Operation::VirtualNumber(0)),
+    });
+
+    // After the VW switch back to VW0, pump frames and assert the active strip's
+    // x position settles exactly at the pre-switch scroll value. Any deviation
+    // means a stale reshuffle slid the strip sideways.
+    for _ in 0..10 {
+        h.app.update();
+        for e in h.mock_state.drain_events() {
+            h.app.world_mut().write_message::<Event>(e);
+        }
+    }
+
+    let strip_x_final = {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&crate::ecs::Position, With<ActiveWorkspaceMarker>>();
+        q.single(world)
+            .expect("exactly one active strip after switch-back")
+            .0
+            .x
+    };
+
+    assert_eq!(
+        strip_x_final, strip_x_after_scroll,
+        "strip x must equal the pre-switch scroll position after VW switch-back (no sideways slide). \
+         Expected {strip_x_after_scroll}, got {strip_x_final}"
+    );
+}

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1162,3 +1162,123 @@ fn test_virtual_workspace_switch_no_horizontal_slide_no_animations() {
          Expected {strip_x_after_scroll}, got {strip_x_final}"
     );
 }
+
+/// When a strip is mid-animation (has a `RepositionMarker`) at the moment the
+/// user switches to another virtual workspace, the animation must stop
+/// immediately. Previously the `RepositionMarker` was left on the hidden strip
+/// so `animate_entities` kept updating its position while it was off-screen,
+/// making the two strips briefly visible at the same time (the hidden one still
+/// sliding) and corrupting the saved restore position.
+#[test]
+fn test_virtual_workspace_switch_stops_in_flight_strip_animation() {
+    let config: Config = (
+        MainOptions {
+            virtual_workspace_animations: Some(false),
+            animation_speed: Some(12.0),
+            swipe_gesture_fingers: Some(3),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new().with_config(config).with_windows(5);
+
+    let pump_n = |h: &mut TestHarness, n: usize, ev: Event| {
+        h.app.world_mut().write_message::<Event>(ev);
+        for _ in 0..n {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+    let pump = |h: &mut TestHarness, c: Command| {
+        pump_n(h, 8, Event::Command { command: c });
+    };
+
+    pump(&mut h, Command::PrintState);
+
+    // Scroll and then switch to VW1 mid-animation (only 1 frame so animation
+    // is still in progress when the switch fires).
+    h.app.world_mut().write_message::<Event>(Event::Swipe {
+        delta: 0.3,
+        fingers: 3,
+    });
+    // One frame to start the animation.
+    h.app.update();
+    for e in h.mock_state.drain_events() {
+        h.app.world_mut().write_message::<Event>(e);
+    }
+
+    // Switch to VW1 while the strip may still have a RepositionMarker.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+
+    // VW0's strip must have no RepositionMarker (animation stopped on hide).
+    {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<Entity, (
+            With<crate::ecs::layout::LayoutStrip>,
+            Without<ActiveWorkspaceMarker>,
+        )>();
+        for entity in q.iter(world) {
+            assert!(
+                world.get::<RepositionMarker>(entity).is_none(),
+                "hidden strip {entity:?} must not have RepositionMarker after VW switch"
+            );
+        }
+    }
+
+    // Switch back to VW0. The strip should restore to the saved position,
+    // not to wherever the mid-flight animation would have taken it.
+    let saved_x = {
+        // The saved position is snapped to what it was at switch time; just
+        // record where VW0's strip ends up after restoring.
+        h.app.world_mut().write_message::<Event>(Event::Command {
+            command: Command::Window(Operation::VirtualNumber(0)),
+        });
+        for _ in 0..10 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&crate::ecs::Position, With<ActiveWorkspaceMarker>>();
+        q.single(world)
+            .expect("exactly one active strip after restore")
+            .0
+            .x
+    };
+
+    // After restoring the strip must also have no RepositionMarker — it
+    // should have snapped directly, not started a new animation.
+    {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<Entity, (
+            With<crate::ecs::layout::LayoutStrip>,
+            With<ActiveWorkspaceMarker>,
+        )>();
+        for entity in q.iter(world) {
+            assert!(
+                world.get::<RepositionMarker>(entity).is_none(),
+                "restored strip {entity:?} must not have RepositionMarker (no animation after no-anim VW switch)"
+            );
+        }
+    }
+
+    // The final position must be stable (no further drift).
+    for _ in 0..5 {
+        h.app.update();
+        for e in h.mock_state.drain_events() {
+            h.app.world_mut().write_message::<Event>(e);
+        }
+    }
+    let world = h.app.world_mut();
+    let mut q = world.query_filtered::<&crate::ecs::Position, With<ActiveWorkspaceMarker>>();
+    let final_x = q.single(world).expect("exactly one active strip").0.x;
+    assert_eq!(
+        final_x, saved_x,
+        "strip x drifted after restore: was {saved_x}, now {final_x}"
+    );
+}


### PR DESCRIPTION
## Summary

Two related bugs when switching virtual workspaces with `virtual_workspace_animations = false`:

**Bug 1 — strip drifts sideways after switching back**
The hidden strip kept its `Scrolling` component (with residual swipe velocity). `scrolling_integrator` kept updating `scroll.position` while the strip was off-screen; on restore, `apply_scrolling_constraints` applied the drifted value and overrode the correctly saved position.

**Bug 2 — in-flight strip animation continues after switching away**
If the strip had a live `RepositionMarker` (mid-animation) at the moment of switching, `animate_entities` kept moving the hidden strip every frame — making both strips briefly visible at the same time, and potentially corrupting the saved restore position.

**Fix** (`show_active_workspace`): remove both `Scrolling` and `RepositionMarker` from a strip when hiding it. The saved origin already captures the `RepositionMarker` destination (the intended final position), so restoring still lands in the right place.

**Defence-in-depth**: a `SkipReshuffleMarker` is inserted on the restored strip so `reshuffle_layout_strip` skips one frame — preventing stale window positions from computing a spurious strip target on the first frame after restore.
