### PR TITLE
Add restart command for config bindings and send-cmd

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -146,6 +146,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 | `window_raise_floating` | Make the floating windows layer visible on the current workspace. |
 | `window_togglefloatlayer` | Selectively move the floating windows in front or behind of the workspace windows. |
 | `quit` | Exit Paneru. |
+| `restart` | Restart the Paneru service (`paneru restart`). |
 
 **Example:**
 ```toml

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ $ paneru send-cmd <command> [args...]
 | `mouse nextdisplay`        | Warp the mouse pointer to the next display       |
 | `printstate`               | Print the internal ECS state to the debug log    |
 | `quit`                     | Quit Paneru                                      |
+| `restart`                  | Restart the Paneru service                         |
 
 Where `<direction>` is one of: `west`, `east`, `north`, `south`, `first`, `last`.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ use bevy::ecs::query::{Has, With, Without};
 use bevy::ecs::system::{Commands, Query, Res, Single};
 use bevy::math::IRect;
 use tracing::{Level, instrument};
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 mod query;
 
@@ -122,6 +122,8 @@ pub enum Command {
     Mouse(MouseMove),
     /// A command to quit the window manager application.
     Quit,
+    /// A command to restart the window manager service.
+    Restart,
     PrintState,
 }
 
@@ -131,6 +133,7 @@ pub fn register_commands(app: &mut bevy::app::App) {
         PreUpdate,
         (
             command_quit_handler,
+            command_restart_handler,
             print_internal_state_handler,
             mouse_to_next_display,
             resize_window,
@@ -1213,6 +1216,22 @@ pub fn command_quit_handler(
         )
     }) {
         _ = window_manager.quit();
+    }
+}
+
+#[instrument(level = Level::DEBUG, skip_all)]
+#[allow(clippy::needless_pass_by_value)]
+pub fn command_restart_handler(mut messages: MessageReader<Event>) {
+    if messages.read().any(|event| {
+        matches!(
+            event,
+            Event::Command {
+                command: Command::Restart
+            }
+        )
+    }) && let Err(err) = crate::platform::service::Service::request_restart()
+    {
+        error!("failed to restart service: {err}");
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -300,6 +300,7 @@ pub fn parse_command(argv: &[&str]) -> Result<Command> {
         "window" => Command::Window(parse_operation(&argv[1..])?),
         "mouse" => Command::Mouse(parse_mouse_move(&argv[1..])?),
         "quit" => Command::Quit,
+        "restart" => Command::Restart,
         _ => {
             return Err(Error::InvalidConfig(format!(
                 "{}: Unhandled command '{argv:?}'",
@@ -1778,6 +1779,14 @@ fn test_parse_resize_commands() {
     assert!(matches!(
         parse_command(&["window", "shrink"]).unwrap(),
         Command::Window(Operation::Resize(ResizeDirection::Shrink))
+    ));
+}
+
+#[test]
+fn test_parse_restart_command() {
+    assert!(matches!(
+        parse_command(&["restart"]).unwrap(),
+        Command::Restart
     ));
 }
 

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -2,6 +2,7 @@ use std::{
     env, fs,
     io::{Error, ErrorKind, Result, Write},
     path::{Path, PathBuf},
+    process::{Command, Stdio},
 };
 
 use tracing::{info, warn};
@@ -171,6 +172,23 @@ impl Service {
     pub fn restart(&self) -> Result<()> {
         self.stop()?;
         self.start()
+    }
+
+    /// Spawns a detached `paneru restart` subprocess.
+    /// Used by the in-daemon restart command so launchctl stop/start runs outside
+    /// the process being stopped.
+    pub fn request_restart() -> Result<()> {
+        let bin_path = exe_path().ok_or(Error::new(
+            ErrorKind::NotFound,
+            "Cannot find current executable path.",
+        ))?;
+        Command::new(bin_path)
+            .arg("restart")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(())
     }
 
     /// Generates the content of the launchd plist file for this service.


### PR DESCRIPTION
Closes #73.

Adds a top-level `restart` command alongside `quit`, wired through config bindings and `send-cmd`.

## Usage

```toml
[bindings]
restart = "ctrl+alt-r"
```

```shell
paneru send-cmd restart
```

## Implementation

The in-daemon handler spawns a detached `paneru restart` subprocess so `launchctl stop/start` runs outside the process being stopped (same semantics as the existing CLI subcommand).

## Testing

- `cargo test`
- `cargo clippy -- -D warnings`