### PR TITLE
[WIP / NOT READY] Oversized windows and native width controls

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -21,7 +21,7 @@ General behavior settings for the window manager.
 | `mouse_follows_focus` | Boolean | `true` | If enabled, the mouse cursor will warp to the center of the focused window when focus changes via keyboard. |
 | `horizontal_mouse_warp` | Integer ``(-1, 1)`` | Off | If enabled, the mouse will warp to another screen above or below, when touching the left or right edge. The direction depends on the direction - a negative value will cause the left edge to warp to a screen above and the right edge to a screen below. This allows having horizontal positioning of displays while having them aligned in a virtual layout in macOS settings. The cursor lands at the *opposite* edge of the target display (preserving cursor flow), with the source's relative Y position. Carries pre-warp horizontal velocity to avoid a "standing start", and skips the warp when the equivalent Y has no position on the target — matching macOS's native side-by-side behavior for displays of unequal height. (inspired by https://github.com/mogenson/WarpMouse.spoon) |
 | `horizontal_mouse_warp_offset` | Integer (px) | `0` | Vertical pixel offset applied to the `horizontal_mouse_warp` landing position, signed by warp direction. Positive values shift the cursor lower when warping to a display *below* (in macOS arrangement) and higher when warping to one *above*. Use to compensate for physical desk arrangement differing from the macOS arrangement (e.g. portrait monitor sitting physically higher or lower than the laptop). |
-| `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75]` | Ratios of the screen width used by the `window_resize` command to cycle sizes. |
+| `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75, 1.0, 1.5, 2.0]` | Ratios of the screen width used by the `window_resize` command and the menu bar width picker. Values above `1.0` create a horizontally scrollable oversized window. |
 | `animation_speed` | Float | *None* | Speed of window animations. Comfortable range is from 8 to 20. Unset or set to a very high value to effectively disable animations. |
 | `auto_center` | Boolean | `false` | Automatically center the focused window on the screen when switching focus. |
 | `sliver_height` | Float (0.1–1.0) | `1.0` | Vertical ratio of off-screen windows kept visible to prevent macOS from relocating them. |
@@ -230,7 +230,7 @@ Define specific behaviors for applications based on their Title or Bundle ID.
 | `manage` | Boolean | Force Paneru to manage this app/window even if macOS reports the app as unobservable or the window has a non-standard role/subrole. |
 | `index` | Integer | Preferred position in the strip when spawned. |
 | `dont_focus` | Boolean | Prevent the window from taking focus when spawned. |
-| `width` | Float (0.0–1.0) | Initial width ratio for the window. |
+| `width` | Positive Float | Initial width ratio for the window. Values above `1.0` create an oversized, horizontally scrollable window. |
 | `grid` | String | placement for floating windows: `"cols:rows:x:y:w:h"`. |
 | `horizontal_padding` | Integer | Gaps to the left/right of this window. |
 | `vertical_padding` | Integer | Gaps to the top/bottom of this window. |

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,7 @@ mod query;
 use crate::config::Config;
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::{Column, LayoutStrip, StackItem};
+use crate::ecs::layout::{Column, LayoutStrip, StackItem, clamp_origin_to_viewport};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker,
@@ -75,6 +75,8 @@ pub enum Operation {
     Center,
     /// Resizes the focused window in the given direction.
     Resize(ResizeDirection),
+    /// Resizes the focused window to an exact display-width ratio.
+    SetWidth(f64),
     /// Toggles the focused window to full width or a preset width.
     FullWidth,
     /// Moves the focused window to the next available display.
@@ -742,9 +744,10 @@ fn resize_window(
     config: Res<Config>,
     mut commands: Commands,
 ) {
-    let Some(Operation::Resize(direction)) =
-        filter_window_operations(&mut messages, |op| matches!(op, Operation::Resize(_))).next()
-    else {
+    let Some(operation) = filter_window_operations(&mut messages, |op| {
+        matches!(op, Operation::Resize(_) | Operation::SetWidth(_))
+    })
+    .next() else {
         return;
     };
 
@@ -765,8 +768,9 @@ fn resize_window(
     let widths = config.preset_column_widths();
     let fallback = *widths.first().unwrap_or(&0.5);
     let cycle = config.window_resize_cycle();
-    let next_ratio = match direction {
-        ResizeDirection::Grow => widths
+    let next_ratio = match operation {
+        Operation::SetWidth(ratio) if ratio.is_finite() && *ratio > 0.0 => *ratio,
+        Operation::Resize(ResizeDirection::Grow) => widths
             .iter()
             .copied()
             .find(|&r| r > current_ratio + 0.05)
@@ -777,7 +781,7 @@ fn resize_window(
                     *widths.last().unwrap_or(&fallback)
                 }
             }),
-        ResizeDirection::Shrink => widths
+        Operation::Resize(ResizeDirection::Shrink) => widths
             .iter()
             .rev()
             .copied()
@@ -789,13 +793,17 @@ fn resize_window(
                     fallback
                 }
             }),
+        _ => return,
     };
 
     let new_width = (next_ratio * f64::from(viewport.width())).round() as i32;
     let size = Size::new(new_width, frame.height());
 
-    let mut origin = IRect::from_center_size(frame.center(), size).min;
-    origin.x = origin.x.clamp(viewport.min.x, viewport.max.x - size.x);
+    let origin = clamp_origin_to_viewport(
+        IRect::from_center_size(frame.center(), size).min,
+        size,
+        viewport,
+    );
     commands.reposition_entity(entity, origin);
 
     // Resize all windows in the column so stacked siblings share the new width.
@@ -1223,9 +1231,7 @@ fn snap_window(
     // Clamp the frame into the display and reposition the *strip* (not the
     // window) so the layout stays consistent.
     let size = frame.size();
-    frame.min = frame
-        .min
-        .clamp(display_bounds.min, display_bounds.max - size);
+    frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
     frame.max = frame.min + size;
 
     let strip_position = frame.min - layout_position.0;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1150,7 +1150,7 @@ pub struct MainOptions {
 
 /// Returns a default set of column widths.
 pub fn default_preset_column_widths() -> Vec<f64> {
-    vec![0.25, 0.33333, 0.50, 0.66667, 0.75]
+    vec![0.25, 0.33333, 0.50, 0.66667, 0.75, 1.0, 1.5, 2.0]
 }
 
 /// `Keybinding` represents a keyboard shortcut and the command it triggers.
@@ -1219,7 +1219,8 @@ pub struct WindowParams {
     pub vertical_padding: Option<i32>,
     pub horizontal_padding: Option<i32>,
     pub dont_focus: Option<bool>,
-    /// An optional initial width ratio (0.0–1.0) relative to the display width.
+    /// An optional positive initial width ratio relative to the display width.
+    /// Values above 1.0 create an oversized, horizontally scrollable window.
     /// Overrides the default column width when the window is first managed.
     pub width: Option<f64>,
     /// Grid placement for floating windows: "cols:rows:x:y:w:h".

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -85,8 +85,6 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 || focus_lost.read().next().is_some()
                 || !focused_moved.is_empty()
         };
-    let workspace_menu_status =
-        |config: Option<Res<Config>>| config.is_some_and(|config| config.workspace_menu_status());
     let native_tabs_enabled =
         |config: Option<Res<Config>>| config.is_none_or(|config| config.native_tabs_enabled());
 
@@ -157,7 +155,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 systems::update_flash_messages,
             )
                 .chain(),
-            crate::menubar::update_virtual_workspace_status_item.run_if(workspace_menu_status),
+            crate::menubar::update_menu_bar,
         ),
     );
 }
@@ -566,12 +564,13 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         .add_plugins(display::DisplayEventsPlugin)
         .add_plugins((register_triggers, register_systems, register_commands));
 
+    let menu_events = sender.clone();
     let mut platform_callbacks = PlatformCallbacks::new(sender);
     platform_callbacks.setup_handlers()?;
     let mtm = platform_callbacks.main_thread_marker;
     let overlay_manager = OverlayManager::new(mtm);
     let flash_message_manager = FlashMessageManager::new(mtm);
-    let menu_bar_manager = MenuBarManager::new(mtm);
+    let menu_bar_manager = MenuBarManager::new(mtm, menu_events);
     app.insert_non_send_resource(platform_callbacks)
         .insert_non_send_resource(overlay_manager)
         .insert_non_send_resource(flash_message_manager)

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -19,10 +19,20 @@ use crate::ecs::{
     Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, SpawnCommandsExt,
 };
 use crate::errors::{Error, Result};
-use crate::manager::{Display, Origin, Window};
+use crate::manager::{Display, Origin, Size, Window};
 use crate::platform::WorkspaceId;
 
 pub struct LayoutEventsPlugin;
+
+/// Clamp a window origin to the range where it still touches both viewport
+/// edges. For an oversized window this range is reversed: from right-aligned
+/// to left-aligned, which lets the strip pan across the hidden content.
+pub(crate) fn clamp_origin_to_viewport(origin: Origin, size: Size, viewport: IRect) -> Origin {
+    let far_edge = viewport.max - size;
+    let minimum = viewport.min.min(far_edge);
+    let maximum = viewport.min.max(far_edge);
+    origin.clamp(minimum, maximum)
+}
 
 impl Plugin for LayoutEventsPlugin {
     fn build(&self, app: &mut App) {
@@ -1024,9 +1034,7 @@ fn reshuffle_layout_strip(
         let visible_width = display_bounds.intersect(frame).width();
 
         // Expose the window by clamping it into the viewport.
-        frame.min = frame
-            .min
-            .clamp(display_bounds.min, display_bounds.max - size);
+        frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
         frame.max = frame.min + size;
 
         let strip_position = (frame.min - layout_position.0).with_y(display_bounds.min.y);
@@ -1101,9 +1109,7 @@ fn ensure_visible_in_strip(
         let candidate_min = layout_position.0 + strip_position.0;
         // Clamp into the viewport. If already on-screen, this is a no-op and
         // the strip target equals its current position — no movement.
-        //let clamped_min = candidate_min.clamp(viewport.min, viewport.max - size);
-        let clamped_min =
-            candidate_min.clamp(viewport.min, (viewport.max - size).max(viewport.min));
+        let clamped_min = clamp_origin_to_viewport(candidate_min, size, viewport);
         if clamped_min == candidate_min {
             return;
         }
@@ -1356,6 +1362,36 @@ fn position_layout_windows(
 mod tests {
     use super::*;
     use bevy::prelude::*;
+
+    #[test]
+    fn clamp_origin_supports_oversized_windows() {
+        let viewport = IRect::new(0, 20, 1024, 768);
+        let size = Size::new(2048, 748);
+
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(300, 20), size, viewport),
+            Origin::new(0, 20)
+        );
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-1600, 20), size, viewport),
+            Origin::new(-1024, 20)
+        );
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-600, 20), size, viewport),
+            Origin::new(-600, 20)
+        );
+    }
+
+    #[test]
+    fn clamp_origin_keeps_regular_windows_inside_viewport() {
+        let viewport = IRect::new(0, 20, 1024, 768);
+        let size = Size::new(400, 300);
+
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-100, 900), size, viewport),
+            Origin::new(0, 468)
+        );
+    }
 
     fn setup_world_and_strip() -> (World, LayoutStrip, Vec<Entity>) {
         let mut world = World::new();

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -27,9 +27,9 @@ use crate::config::{Config, decorations::BorderRadiusOption};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, Initializing, LowPowerMode,
-    MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState, Scrolling,
-    SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
+    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, FocusedMarker, Initializing,
+    LowPowerMode, MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState,
+    Scrolling, SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -174,6 +174,7 @@ pub(crate) fn add_existing_application(
 pub(crate) fn finish_setup(
     process_query: Query<Entity, With<ExistingMarker>>,
     windows: Windows,
+    applications: Query<&Application>,
     mut bruteforce_tasks: Query<(Entity, &mut BruteforceWindows)>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>, &ChildOf)>,
     window_manager: Res<WindowManager>,
@@ -203,6 +204,7 @@ pub(crate) fn finish_setup(
         windows.iter().size_hint()
     );
 
+    let mut focused_managed_window = false;
     for (mut strip, active_strip, _) in &mut workspaces {
         debug!("space {}: before refresh {strip:?}", strip.id());
         let workspace_windows = window_manager
@@ -246,7 +248,22 @@ pub(crate) fn finish_setup(
 
         if active_strip && let Some(entity) = strip.first().ok().and_then(|column| column.top()) {
             commands.focus_entity(entity, true);
+            focused_managed_window = true;
         }
+    }
+
+    // An all-floating workspace has no strip member to receive the initial
+    // focus marker. Mirror the frontmost app's AX focus so menu actions such as
+    // Toggle Managed work immediately after launch.
+    if !focused_managed_window
+        && let Some(focused_window_id) = applications
+            .iter()
+            .find(|app| app.is_frontmost())
+            .and_then(|app| app.focused_window_id().ok())
+        && let Some((_, entity)) = windows.find(focused_window_id)
+        && let Ok(mut entity_commands) = commands.get_entity(entity)
+    {
+        entity_commands.try_insert(FocusedMarker);
     }
 
     commands.remove_resource::<Initializing>();

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -38,6 +38,25 @@ use crate::util::{AXUIAttributes, AXUIWrapper, MacResult};
 static ENHANCED_UI_REFCOUNT: LazyLock<Mutex<HashMap<Pid, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// macOS may partially apply an AX width increase when the requested right edge
+/// would be far outside the display. Moving the partial result left by the
+/// missing width before retrying gives `WindowServer` enough offscreen room.
+///
+/// Only retry when the first attempt actually grew the window. Fixed-size apps
+/// otherwise look identical to this failure mode and must not be moved offscreen.
+fn resize_staging_origin(
+    previous_frame: IRect,
+    actual_frame: IRect,
+    target_width: i32,
+) -> Option<Origin> {
+    let actual_width = actual_frame.width();
+    (actual_width > previous_frame.width() && actual_width < target_width).then(|| {
+        actual_frame
+            .min
+            .with_x(actual_frame.min.x - (target_width - actual_width))
+    })
+}
+
 #[derive(Debug)]
 pub enum WindowPadding {
     Vertical(i32),
@@ -313,6 +332,56 @@ impl WindowOS {
         }
     }
 
+    fn set_ax_position(&mut self, origin: Origin) {
+        let mut point = CGPoint::new(
+            f64::from(origin.x + self.horizontal_padding),
+            f64::from(origin.y + self.vertical_padding),
+        );
+        let position_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGPoint,
+                NonNull::from(&mut point).as_ptr().cast(),
+            )
+        };
+        if let Ok(position) = AXUIWrapper::retain(position_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
+                    position.as_ref(),
+                )
+            };
+            let size = self.frame.size();
+            self.frame.min = origin;
+            self.frame.max = origin + size;
+        }
+    }
+
+    fn set_ax_size(&mut self, size: Size) {
+        let width_padding = 2 * self.horizontal_padding;
+        let height_padding = 2 * self.vertical_padding;
+        let mut cgsize = CGSize::new(
+            f64::from(size.x - width_padding),
+            f64::from(size.y - height_padding),
+        );
+        let size_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGSize,
+                NonNull::from(&mut cgsize).as_ptr().cast(),
+            )
+        };
+        if let Ok(size_value) = AXUIWrapper::retain(size_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
+                    size_value.as_ref(),
+                )
+            };
+            self.frame.max = self.frame.min + size;
+        }
+    }
+
     /// Makes the window the key window for its application by sending synthesized events.
     ///
     /// # Arguments
@@ -424,28 +493,7 @@ impl WindowApi for WindowOS {
             return;
         }
         self.disable_enhanced_ui();
-        let mut point = CGPoint::new(
-            f64::from(origin.x + self.horizontal_padding),
-            f64::from(origin.y + self.vertical_padding),
-        );
-        let position_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGPoint,
-                NonNull::from(&mut point).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(position_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
-                    position.as_ref(),
-                )
-            };
-            let size = self.frame.size();
-            self.frame.min = origin;
-            self.frame.max = origin + size;
-        }
+        self.set_ax_position(origin);
         self.reenable_enhanced_ui();
     }
 
@@ -455,28 +503,44 @@ impl WindowApi for WindowOS {
             trace!("already correct size.");
             return;
         }
+        let previous_frame = self.frame;
+        let target_origin = previous_frame.min;
         self.disable_enhanced_ui();
-        let width_padding = 2 * self.horizontal_padding;
-        let height_padding = 2 * self.vertical_padding;
-        let mut cgsize = CGSize::new(
-            f64::from(size.x - width_padding),
-            f64::from(size.y - height_padding),
-        );
-        let size_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGSize,
-                NonNull::from(&mut cgsize).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(size_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
-                    position.as_ref(),
-                )
+        self.set_ax_size(size);
+
+        let mut previous_observed_frame = previous_frame;
+        let mut staged = false;
+        for attempt in 1..=3 {
+            let Ok(actual_frame) = self.update_frame() else {
+                break;
             };
-            self.frame.max = self.frame.min + size;
+            let Some(staging_origin) =
+                resize_staging_origin(previous_observed_frame, actual_frame, size.x)
+            else {
+                break;
+            };
+            debug!(
+                attempt,
+                requested_width = size.x,
+                actual_width = actual_frame.width(),
+                staging_x = staging_origin.x,
+                "retrying partially constrained AX resize from an offscreen origin"
+            );
+            staged = true;
+            previous_observed_frame = actual_frame;
+            self.set_ax_position(staging_origin);
+            self.set_ax_size(size);
+        }
+
+        if staged {
+            if let Ok(final_frame) = self.update_frame() {
+                debug!(
+                    requested_width = size.x,
+                    actual_width = final_frame.width(),
+                    "completed staged AX resize"
+                );
+            }
+            self.set_ax_position(target_origin);
         }
         self.reenable_enhanced_ui();
     }
@@ -664,5 +728,37 @@ impl WindowApi for WindowOS {
             // Get first corner radius (usually all corners are the same)
             radii.get(0)?.as_i64().map(|v| v as f64)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stages_partially_applied_width_growth() {
+        let previous = IRect::new(-400, 40, 400, 640);
+        let actual = IRect::new(-400, 40, 2416, 640);
+
+        assert_eq!(
+            resize_staging_origin(previous, actual, 4112),
+            Some(Origin::new(-1696, 40))
+        );
+
+        let nearly_complete = IRect::new(-2056, 40, 2016, 640);
+        assert_eq!(
+            resize_staging_origin(actual, nearly_complete, 4112),
+            Some(Origin::new(-2096, 40))
+        );
+    }
+
+    #[test]
+    fn does_not_stage_fixed_size_or_completed_resizes() {
+        let fixed = IRect::new(0, 40, 230, 448);
+        assert_eq!(resize_staging_origin(fixed, fixed, 4112), None);
+
+        let previous = IRect::new(0, 40, 800, 640);
+        let completed = IRect::new(0, 40, 4112, 640);
+        assert_eq!(resize_staging_origin(previous, completed, 4112), None);
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -80,13 +80,30 @@ pub struct MenuBarManager {
     menu: Retained<NSMenu>,
     action_target: Retained<MenuActionTarget>,
     width_items: Vec<(i32, Retained<NSMenuItem>)>,
-    window_items: Vec<Retained<NSMenuItem>>,
+    managed_window_items: Vec<Retained<NSMenuItem>>,
+    manage_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
     current_label: Option<String>,
 }
 
 const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
 const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
+
+#[derive(Debug, Eq, PartialEq)]
+struct WindowMenuEnablement {
+    managed_actions: bool,
+    toggle_managed: bool,
+}
+
+fn window_menu_enablement(
+    has_focused_window: bool,
+    focused_width_ratio: Option<f64>,
+) -> WindowMenuEnablement {
+    WindowMenuEnablement {
+        managed_actions: focused_width_ratio.is_some(),
+        toggle_managed: has_focused_window,
+    }
+}
 
 impl MenuBarManager {
     pub fn new(mtm: MainThreadMarker, events: EventSender) -> Self {
@@ -106,7 +123,8 @@ impl MenuBarManager {
             menu,
             action_target,
             width_items: Vec::new(),
-            window_items: Vec::new(),
+            managed_window_items: Vec::new(),
+            manage_item: None,
             configured_widths: Vec::new(),
             current_label: None,
         }
@@ -117,6 +135,7 @@ impl MenuBarManager {
         virtual_index: u32,
         show_virtual_workspace: bool,
         preset_widths: &[f64],
+        has_focused_window: bool,
         focused_width_ratio: Option<f64>,
     ) {
         let widths = normalized_width_percentages(preset_widths);
@@ -124,9 +143,12 @@ impl MenuBarManager {
             self.rebuild_menu(&widths);
         }
 
-        let has_focused_window = focused_width_ratio.is_some();
-        for item in &self.window_items {
-            item.setEnabled(has_focused_window);
+        let enablement = window_menu_enablement(has_focused_window, focused_width_ratio);
+        for item in &self.managed_window_items {
+            item.setEnabled(enablement.managed_actions);
+        }
+        if let Some(manage_item) = &self.manage_item {
+            manage_item.setEnabled(enablement.toggle_managed);
         }
         for (percentage, item) in &self.width_items {
             let selected = focused_width_ratio
@@ -149,7 +171,8 @@ impl MenuBarManager {
     fn rebuild_menu(&mut self, widths: &[i32]) {
         self.menu.removeAllItems();
         self.width_items.clear();
-        self.window_items.clear();
+        self.managed_window_items.clear();
+        self.manage_item = None;
 
         let status = self.add_item("Paneru — Running", None);
         status.setEnabled(false);
@@ -160,14 +183,15 @@ impl MenuBarManager {
         for &percentage in widths {
             let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
             item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
-            self.window_items.push(item.clone());
+            self.managed_window_items.push(item.clone());
             self.width_items.push((percentage, item));
         }
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
         let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
-        self.window_items.extend([center, manage]);
+        self.managed_window_items.push(center);
+        self.manage_item = Some(manage);
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
@@ -236,21 +260,21 @@ pub fn update_menu_bar(
         return;
     };
 
-    let focused_width_ratio = active_display
-        .iter()
-        .next()
-        .zip(focused.iter().next())
-        .and_then(|((display, dock), (bounds, unmanaged))| {
+    let focused_window = focused.iter().next();
+    let focused_width_ratio = active_display.iter().next().zip(focused_window).and_then(
+        |((display, dock), (bounds, unmanaged))| {
             (!unmanaged).then(|| {
                 f64::from(bounds.0.x)
                     / f64::from(display.actual_display_bounds(dock, &config).width())
             })
-        });
+        },
+    );
 
     menu_bar.update(
         strip.virtual_index,
         config.workspace_menu_status(),
         &config.preset_column_widths(),
+        focused_window.is_some(),
         focused_width_ratio,
     );
 }
@@ -274,7 +298,10 @@ fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_virtual_workspace_label, normalized_width_percentages};
+    use super::{
+        WindowMenuEnablement, format_virtual_workspace_label, normalized_width_percentages,
+        window_menu_enablement,
+    };
 
     #[test]
     fn label_is_one_based() {
@@ -287,6 +314,31 @@ mod tests {
         assert_eq!(
             normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
             vec![50, 150, 200]
+        );
+    }
+
+    #[test]
+    fn unmanaged_focus_only_enables_toggle_managed() {
+        assert_eq!(
+            window_menu_enablement(true, None),
+            WindowMenuEnablement {
+                managed_actions: false,
+                toggle_managed: true,
+            }
+        );
+        assert_eq!(
+            window_menu_enablement(false, None),
+            WindowMenuEnablement {
+                managed_actions: false,
+                toggle_managed: false,
+            }
+        );
+        assert_eq!(
+            window_menu_enablement(true, Some(1.0)),
+            WindowMenuEnablement {
+                managed_actions: true,
+                toggle_managed: true,
+            }
         );
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,20 +1,87 @@
 use bevy::ecs::entity::Entity;
-use bevy::ecs::query::With;
-use bevy::ecs::system::{Local, NonSendMut, Query};
-use objc2::MainThreadMarker;
+use bevy::ecs::query::{Has, With};
+use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
-use objc2_app_kit::{NSColor, NSStatusBar, NSStatusItem, NSVariableStatusItemLength};
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+use objc2_app_kit::{
+    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSStatusBar,
+    NSStatusItem, NSVariableStatusItemLength,
+};
 use objc2_core_foundation::CGFloat;
-use objc2_foundation::NSString;
+use objc2_foundation::{NSObject, NSString};
 use tracing::warn;
 
-use crate::ecs::ActiveWorkspaceMarker;
+use crate::commands::{Command, Operation};
+use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
+use crate::ecs::{
+    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Unmanaged,
+};
+use crate::events::{Event, EventSender};
+use crate::manager::Display;
+
+#[derive(Debug, Clone)]
+struct MenuActionTargetIvars {
+    events: EventSender,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PaneruMenuActionTarget"]
+    #[ivars = MenuActionTargetIvars]
+    #[derive(Debug)]
+    struct MenuActionTarget;
+
+    impl MenuActionTarget {
+        #[unsafe(method(setWidth:))]
+        fn set_width(&self, item: &NSMenuItem) {
+            let Ok(percentage) = i32::try_from(item.tag()) else {
+                return;
+            };
+            let ratio = f64::from(percentage) / 100.0;
+            self.send_command(Command::Window(Operation::SetWidth(ratio)));
+        }
+
+        #[unsafe(method(centerWindow:))]
+        fn center_window(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::Center));
+        }
+
+        #[unsafe(method(toggleManaged:))]
+        fn toggle_managed(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::Manage));
+        }
+
+        #[unsafe(method(quitPaneru:))]
+        fn quit_paneru(&self, _: &NSMenuItem) {
+            self.send_command(Command::Quit);
+        }
+    }
+);
+
+impl MenuActionTarget {
+    fn new(mtm: MainThreadMarker, events: EventSender) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(MenuActionTargetIvars { events });
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn send_command(&self, command: Command) {
+        if let Err(error) = self.ivars().events.send(Event::Command { command }) {
+            warn!(%error, "unable to send menu bar command");
+        }
+    }
+}
 
 pub struct MenuBarManager {
     mtm: MainThreadMarker,
     status_bar: Retained<NSStatusBar>,
     status_item: Retained<NSStatusItem>,
+    menu: Retained<NSMenu>,
+    action_target: Retained<MenuActionTarget>,
+    width_items: Vec<(i32, Retained<NSMenuItem>)>,
+    window_items: Vec<Retained<NSMenuItem>>,
+    configured_widths: Vec<i32>,
     current_label: Option<String>,
 }
 
@@ -22,27 +89,112 @@ const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
 const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
 
 impl MenuBarManager {
-    pub fn new(mtm: MainThreadMarker) -> Self {
+    pub fn new(mtm: MainThreadMarker, events: EventSender) -> Self {
         let status_bar = NSStatusBar::systemStatusBar();
         let status_item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
+        let menu = NSMenu::new(mtm);
+        let action_target = MenuActionTarget::new(mtm, events);
+
+        menu.setAutoenablesItems(false);
+        status_item.setMenu(Some(&menu));
         status_item.setVisible(true);
 
         Self {
             mtm,
             status_bar,
             status_item,
+            menu,
+            action_target,
+            width_items: Vec::new(),
+            window_items: Vec::new(),
+            configured_widths: Vec::new(),
             current_label: None,
         }
     }
 
-    pub fn show_virtual_workspace(&mut self, virtual_index: u32) {
-        let label = format_virtual_workspace_label(virtual_index);
+    pub fn update(
+        &mut self,
+        virtual_index: u32,
+        show_virtual_workspace: bool,
+        preset_widths: &[f64],
+        focused_width_ratio: Option<f64>,
+    ) {
+        let widths = normalized_width_percentages(preset_widths);
+        if self.configured_widths != widths {
+            self.rebuild_menu(&widths);
+        }
+
+        let has_focused_window = focused_width_ratio.is_some();
+        for item in &self.window_items {
+            item.setEnabled(has_focused_window);
+        }
+        for (percentage, item) in &self.width_items {
+            let selected = focused_width_ratio
+                .is_some_and(|ratio| (ratio.mul_add(100.0, -f64::from(*percentage))).abs() < 1.0);
+            item.setState(if selected {
+                NSControlStateValueOn
+            } else {
+                NSControlStateValueOff
+            });
+        }
+
+        let label = if show_virtual_workspace {
+            format_virtual_workspace_label(virtual_index)
+        } else {
+            "Paneru".to_owned()
+        };
+        self.show_label(label);
+    }
+
+    fn rebuild_menu(&mut self, widths: &[i32]) {
+        self.menu.removeAllItems();
+        self.width_items.clear();
+        self.window_items.clear();
+
+        let status = self.add_item("Paneru — Running", None);
+        status.setEnabled(false);
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+
+        let width_header = self.add_item("Window width", None);
+        width_header.setEnabled(false);
+        for &percentage in widths {
+            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
+            item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
+            self.window_items.push(item.clone());
+            self.width_items.push((percentage, item));
+        }
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
+        let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
+        self.window_items.extend([center, manage]);
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
+        self.configured_widths = widths.to_vec();
+    }
+
+    fn add_item(&self, title: &str, action: Option<objc2::runtime::Sel>) -> Retained<NSMenuItem> {
+        let item = unsafe {
+            self.menu.addItemWithTitle_action_keyEquivalent(
+                &NSString::from_str(title),
+                action,
+                &NSString::from_str(""),
+            )
+        };
+        if action.is_some() {
+            unsafe { item.setTarget(Some(&self.action_target)) };
+        }
+        item
+    }
+
+    fn show_label(&mut self, label: String) {
         if self.current_label.as_deref() == Some(label.as_str()) {
             return;
         }
 
         let title = NSString::from_str(&label);
-        let tooltip = NSString::from_str("Paneru virtual workspace");
+        let tooltip = NSString::from_str("Paneru window manager");
         let Some(button) = self.status_item.button(self.mtm) else {
             warn!("unable to update menu bar: status item has no button");
             return;
@@ -69,41 +221,72 @@ impl Drop for MenuBarManager {
     }
 }
 
-pub fn update_virtual_workspace_status_item(
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub fn update_menu_bar(
     active_workspace: Query<(Entity, &LayoutStrip), With<ActiveWorkspaceMarker>>,
+    active_display: Query<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
+    focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
+    config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
-    mut displayed_workspace: Local<Option<(Entity, u32)>>,
 ) {
     let Some(mut menu_bar) = menu_bar else {
         return;
     };
-    let Some((entity, strip)) = active_workspace.iter().next() else {
+    let Some((_, strip)) = active_workspace.iter().next() else {
         return;
     };
 
-    let next = (entity, strip.virtual_index);
-    if displayed_workspace
-        .as_ref()
-        .is_some_and(|displayed| *displayed == next)
-    {
-        return;
-    }
+    let focused_width_ratio = active_display
+        .iter()
+        .next()
+        .zip(focused.iter().next())
+        .and_then(|((display, dock), (bounds, unmanaged))| {
+            (!unmanaged).then(|| {
+                f64::from(bounds.0.x)
+                    / f64::from(display.actual_display_bounds(dock, &config).width())
+            })
+        });
 
-    menu_bar.show_virtual_workspace(strip.virtual_index);
-    *displayed_workspace = Some(next);
+    menu_bar.update(
+        strip.virtual_index,
+        config.workspace_menu_status(),
+        &config.preset_column_widths(),
+        focused_width_ratio,
+    );
 }
 
 pub(crate) fn format_virtual_workspace_label(virtual_index: u32) -> String {
     format!("VW {}", virtual_index + 1)
 }
 
+fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
+    let mut percentages = widths
+        .iter()
+        .copied()
+        .filter(|ratio| ratio.is_finite() && *ratio > 0.0)
+        .map(|ratio| ratio.mul_add(100.0, 0.0).round() as i32)
+        .filter(|percentage| *percentage > 0)
+        .collect::<Vec<_>>();
+    percentages.sort_unstable();
+    percentages.dedup();
+    percentages
+}
+
 #[cfg(test)]
 mod tests {
-    use super::format_virtual_workspace_label;
+    use super::{format_virtual_workspace_label, normalized_width_percentages};
 
     #[test]
     fn label_is_one_based() {
         assert_eq!(format_virtual_workspace_label(0), "VW 1");
         assert_eq!(format_virtual_workspace_label(4), "VW 5");
+    }
+
+    #[test]
+    fn menu_widths_are_sorted_deduplicated_and_valid() {
+        assert_eq!(
+            normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
+            vec![50, 150, 200]
+        );
     }
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -16,6 +16,24 @@ use crate::{assert_focused, assert_window_at, assert_window_size};
 use super::*;
 
 #[test]
+fn frontmost_floating_window_is_focused_after_setup() {
+    let mut params = WindowParams::new(".*", None);
+    params.floating = Some(true);
+    let config: Config = (MainOptions::default(), vec![params]).into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .with_focused_window(0)
+        .on_iteration(0, |world, _state| {
+            assert_focused!(world, 0);
+            let entity = find_window_entity(0, world);
+            assert!(world.entity(entity).contains::<Unmanaged>());
+        })
+        .run(vec![Event::MenuOpened { window_id: 0 }]);
+}
+
+#[test]
 fn test_dont_focus() {
     let commands = vec![
         Event::MenuOpened { window_id: 0 }, // 0

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -207,3 +207,60 @@ fn test_window_resize_grow_and_shrink_cycle() {
         })
         .run(commands);
 }
+
+#[test]
+fn test_window_can_resize_to_two_display_widths_and_scroll() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(2.0)),
+        },
+        Event::Swipe {
+            delta: 0.3,
+            fingers: 3,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Snap),
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            swipe_gesture_fingers: Some(3),
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .on_iteration(1, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .on_iteration(2, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .on_iteration(3, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .run(commands);
+}
+
+fn assert_oversized_window_is_pannable(world: &mut World, id: i32) {
+    let mut query = world.query::<&crate::manager::Window>();
+    let window = query
+        .iter(world)
+        .find(|window| window.id() == id)
+        .expect("window not found");
+    let x = window.frame().min.x;
+    assert!(
+        (-TEST_DISPLAY_WIDTH..=0).contains(&x),
+        "oversized window must stay within its pannable range, got x={x}"
+    );
+}


### PR DESCRIPTION
> [!CAUTION]
> **WIP — NOT READY FOR REVIEW OR MERGE**
>
> This branch has been rewritten into a focused upstream slice and retargeted to `testing`. The behavior is working, but the implementation still needs an upstream design decision and one cleanup pass.

## Intent

Allow Paneru-managed windows to be wider than the visible display, expose those widths through the native menu bar, and keep focused floating windows manageable.

## Current scope

- accepts width ratios above `1.0`
- exposes configured width presets in the menu bar
- retries oversized resizes when macOS initially constrains the requested frame
- allows the focused floating window to enter managed mode
- includes focused regression coverage for a two-display-width window

## Known blockers before ready

- decide whether the retry belongs only in the low-level resize path; the current upper-level retry may be redundant
- confirm the desired maximum width and configuration contract for upstream
- manually verify behavior across multiple displays and applications with strict resize constraints

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test tests::tiling::test_window_can_resize_to_two_display_widths_and_scroll -- --exact`
- `cargo test menubar::tests -- --test-threads=1`

## Explicitly excluded

- gesture/momentum changes
- sticky or paged scrolling
- event-driven runtime and persistence
- per-window opt-in management
- Accessibility onboarding
- Sparkle/release infrastructure

