### PR TITLE
Make the runtime event-driven and preserve oversized layouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, for example 0.5.0 or v0.5.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build universal app and publish release
+    runs-on: macos-15
+    environment: release
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="${RAW_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Invalid version: $RAW_VERSION"
+            echo "Use a release version like 0.5.0 or v0.5.0."
+            exit 1
+          fi
+
+          cargo_version="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+          if [[ "$version" != "$cargo_version" ]]; then
+            echo "Release version $version does not match Cargo.toml version $cargo_version."
+            exit 1
+          fi
+
+          echo "PANERU_VERSION=$version" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=v$version" >> "$GITHUB_ENV"
+          echo "APP_PATH=.build/release/Paneru.app" >> "$GITHUB_ENV"
+          echo "ZIP_PATH=dist/Paneru-$version.zip" >> "$GITHUB_ENV"
+          echo "DMG_PATH=dist/Paneru-$version.dmg" >> "$GITHUB_ENV"
+          echo "APPCAST_PATH=dist/appcast.xml" >> "$GITHUB_ENV"
+
+      - name: Show toolchain
+        run: |
+          rustup show active-toolchain
+          rustc --version --verbose
+          cargo --version
+          xcodebuild -version
+
+      - name: Install Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Verify updater configuration
+        run: |
+          plutil -lint assets/Info.plist
+          [[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' assets/Info.plist)" == "com.github.mrflashaccount.paneru" ]]
+          [[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' assets/Info.plist)" == "$PANERU_VERSION" ]]
+          [[ "$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' assets/Info.plist)" == "https://github.com/MrFlashAccount/paneru/releases/latest/download/appcast.xml" ]]
+          [[ "$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' assets/Info.plist)" == "8z1ChHWDW5rJJwCEZx6Q4cr7A7DLwpDWq5LYFCDhaVc=" ]]
+
+      - name: Download Sparkle
+        run: |
+          sparkle_dir="$(./scripts/download-sparkle.sh)"
+          echo "SPARKLE_DIR=$sparkle_dir" >> "$GITHUB_ENV"
+          echo "SPARKLE_BIN=$sparkle_dir/bin" >> "$GITHUB_ENV"
+
+      - name: Build universal app and DMG
+        env:
+          PANERU_BUILD_ARCHS: universal
+          PANERU_BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          ./scripts/build-app.sh "$PANERU_VERSION"
+          mkdir -p dist
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
+          ./scripts/build-dmg.sh "$PANERU_VERSION"
+
+      - name: Generate signed update feed
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$SPARKLE_PRIVATE_KEY" ]]; then
+            echo "SPARKLE_ED25519_PRIVATE_KEY is not configured in the release environment."
+            exit 1
+          fi
+
+          feed_dir="$RUNNER_TEMP/paneru-appcast"
+          rm -rf "$feed_dir"
+          mkdir -p "$feed_dir"
+          cp "$ZIP_PATH" "$feed_dir/"
+
+          printf '%s' "$SPARKLE_PRIVATE_KEY" \
+            | "$SPARKLE_BIN/generate_appcast" \
+                --ed-key-file - \
+                --download-url-prefix "https://github.com/MrFlashAccount/paneru/releases/download/$RELEASE_TAG/" \
+                --link "https://github.com/MrFlashAccount/paneru" \
+                --maximum-versions 1 \
+                "$feed_dir"
+          cp "$feed_dir/appcast.xml" "$APPCAST_PATH"
+
+          xmllint --noout "$APPCAST_PATH"
+          grep -q 'sparkle:edSignature=' "$APPCAST_PATH"
+          grep -q 'sparkle-signatures:' "$APPCAST_PATH"
+          printf '%s' "$SPARKLE_PRIVATE_KEY" \
+            | "$SPARKLE_BIN/sign_update" --ed-key-file - --verify "$APPCAST_PATH"
+
+      - name: Verify release artifacts
+        run: |
+          executable_archs="$(lipo -archs "$APP_PATH/Contents/MacOS/paneru")"
+          [[ "$executable_archs" == *arm64* && "$executable_archs" == *x86_64* ]]
+          framework_archs="$(lipo -archs "$APP_PATH/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle")"
+          [[ "$framework_archs" == *arm64* && "$framework_archs" == *x86_64* ]]
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          hdiutil verify "$DMG_PATH"
+          unzip -t "$ZIP_PATH"
+
+          if spctl --assess --type execute "$APP_PATH"; then
+            echo "Gatekeeper accepted Paneru.app."
+          else
+            echo "Paneru.app is ad-hoc signed and not notarized; a first-launch warning is expected."
+          fi
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Paneru-${{ env.PANERU_VERSION }}
+          path: |
+            ${{ env.ZIP_PATH }}
+            ${{ env.DMG_PATH }}
+            ${{ env.APPCAST_PATH }}
+          if-no-files-found: error
+
+      - name: Create release tag
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            tag_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [[ "$tag_commit" != "$GITHUB_SHA" ]]; then
+              echo "Tag $RELEASE_TAG already exists on $tag_commit, not $GITHUB_SHA."
+              exit 1
+            fi
+            echo "Tag $RELEASE_TAG already exists on this commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$RELEASE_TAG" -m "Paneru $RELEASE_TAG" "$GITHUB_SHA"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes="Paneru $RELEASE_TAG. The app is ad-hoc signed and not notarized, so macOS may show a warning on first launch."
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "$ZIP_PATH" "$DMG_PATH" "$APPCAST_PATH" --clobber
+            gh release edit "$RELEASE_TAG" --latest
+          else
+            gh release create "$RELEASE_TAG" "$ZIP_PATH" "$DMG_PATH" "$APPCAST_PATH" \
+              --title "Paneru $RELEASE_TAG" \
+              --notes "$notes" \
+              --latest
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+/.build
+/dist
 
 # Outputs from `nix build`
 /result

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,7 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 ### Event Ingestion (macOS -> ECS)
 1.  **Platform Layer:** `src/platform/` uses `objc2` and AppKit to interface with macOS. It runs a native event loop or hooks into OS notifications.
 2.  **Event Channel:** macOS events (mouse moves, window creations, space changes) are sent via a thread-safe `mpsc` channel.
-3.  **Pump System:** The `pump_events` system (in `src/ecs/systems.rs`) reads from this channel during the `PreUpdate` phase and writes Bevy `Message`s or triggers `Observer`s.
+3.  **Pump System:** The `pump_events` system (in `src/ecs/runtime.rs`) drains the channel before sleeping, then waits on a latched `CFRunLoopSource` until a native event or the nearest pending-work deadline. Producers signal that source after publishing, so queue-before-sleep races do not require a free-running idle tick.
 4.  **Observers:** Bevy Observers (primarily in `src/ecs/triggers.rs`, with focused domains such as session restore in `src/ecs/restore.rs`) react to these events to update the ECS World (e.g., spawning new `Window` entities or updating `FocusedMarker`).
 
 ### State Synchronization (ECS -> macOS)
@@ -33,10 +33,13 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 | Directory / Module | Responsibility Statement |
 | :--- | :--- |
 | `src/ecs/layout.rs` | Tiling algorithms, column management, and coordinate calculations. |
-| `src/ecs/systems.rs` | Bevy systems for lifecycle management, event pumping, and state syncing. |
+| `src/ecs/systems.rs` | Bevy systems for lifecycle management and state syncing. |
 | `src/ecs/params.rs` | High-level Bevy `SystemParam` abstractions for querying the World. |
 | `src/ecs/triggers.rs` | Reactive event handlers (Observers) for OS and internal events. |
 | `src/ecs/restore.rs` | Startup session restore planning and application, including window matching, layout rebuilding, and restore grace-period handling. |
+| `src/ecs/persistence.rs` | Dirty-domain tracking, trailing-debounced durable saves, shutdown flush, and bounded retry after save failures. |
+| `src/ecs/runtime.rs` | Event-loop pumping and deadline selection; it sleeps indefinitely only when neither frame work nor deferred jobs are pending. |
+| `src/ecs/observation.rs` | Main-thread AX application/window observer ownership and lifecycle reconciliation. |
 | `src/ecs/workspace.rs` | Management of virtual workspaces, display changes, and window movement between spaces. |
 | `src/ecs/scroll.rs` | Input handling for trackpad swipe gestures, inertia, and snapping. |
 | `src/ecs/focus.rs` | Focus management logic, including focus-follows-mouse and mouse-follows-focus. |
@@ -72,18 +75,20 @@ Bevy is typically used for games, so Paneru implements a custom bridge to intera
 
 ## 5. Architectural Invariants
 
-- **Main Thread Only:** Any interaction with `objc2`, `AppKit`, or `Accessibility` APIs **must** occur on the main thread.
+- **Main Thread Only:** Any interaction with `objc2`, `AppKit`, or `Accessibility` APIs **must** occur on the main thread. AX lifecycle systems require the non-send `AxMainThread` capability created from AppKit's `MainThreadMarker`.
 - **ECS as Source of Truth:** Tiling logic must operate on ECS components (`WidthRatio`, `LayoutStrip`). The physical macOS window state should be a reflection of the ECS state, not the other way around.
 - **Pure Layout:** Layout math (in `layout.rs`) should remain as pure as possible, operating on coordinates and ratios rather than directly calling OS APIs.
 - **Bounded Restore:** Saved session state is only consulted during startup restore. After `SessionRestore` expires, normal config and window-rule placement owns newly discovered windows.
-- **Reactive Power Saving:** Systems should use Bevy's reactive scheduling to avoid CPU usage when no windows are moving or events are occurring.
+- **Reactive Power Saving:** With no pending work, runtime waits indefinitely on a latched native source. Animation uses frame cadence; lifecycle polling, workspace refresh/recovery, persistence, restore, verification, retry, timeout, and updater jobs contribute monotonic nearest deadlines only while needed.
 
 ## 6. Session Restore
 
 `src/ecs/state.rs` extracts and persists the restart snapshot. The state file is
-written atomically to `paneru/state.json` in the XDG state directory
+written durably and atomically to `paneru/state.json` in the XDG state directory
 (`~/.local/state/paneru/state.json` on a default macOS setup) and is loaded
-during Bevy app setup.
+only after startup configuration confirms restore is enabled. Persisted-domain
+changes reset a 250 ms trailing debounce; failed writes remain dirty and retry
+with bounded backoff. Disabling restore performs no state-file read or write.
 
 `src/ecs/restore.rs` owns startup restore. It keeps the loaded `PaneruState`
 alive in `SessionRestore` for the configured grace period so applications have
@@ -98,7 +103,8 @@ are ignored by default, and the restored layout is compacted around the matched
 windows.
 
 Restore rebuilds `LayoutStrip`s, virtual workspace rows, selected virtual
-workspace markers, and display associations. When the current macOS workspace
+workspace markers, display associations, saved oversized `WidthRatio`s, and
+the horizontal pan position of each restored strip. When the current macOS workspace
 to display mapping conflicts with saved display data, the current mapping is
 preferred; otherwise restore falls back to the saved display, then the active
 display, then any available display. Matched startup windows skip static
@@ -120,7 +126,7 @@ graph TD
     H[CommandReader] -->|Unix Socket| C
     S[PaneruState file] -->|Startup load| R(session restore)
     R -->|Rebuild saved strips| E
-    E -->|Periodic / exit save| S
+    E -->|Dirty debounce / exit flush| S
 ```
 
 ## 8. Testing Strategy

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -67,6 +67,8 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | `direction` | String | `"Natural"` | Direction of movement: `"Natural"` or `"Reversed"`. |
 | `vertical` | Boolean | `true` | Interpret the vertical gestures with `fingers_count` or ignore them. Enabling this allows using vertical swipe gestures to change virtual desktops. |
 
+When `fingers_count` is omitted or set below 3, Paneru does not intercept native macOS gestures. If macOS uses three-finger horizontal swipes for Spaces, prefer `[swipe.scroll]` with a modifier or configure a different finger count.
+
 ### `[swipe.scroll]`
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -58,7 +58,8 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | :--- | :--- | :--- | :--- |
 | `sensitivity` | Float (0.1–2.0) | `0.35` | Multiplier for swipe distance. |
 | `deceleration` | Float (1.0–10.0) | `4.0` | Rate at which inertia slows down after a swipe. |
-| `continuous` | Boolean | `true` | If enabled, the swipe gesture moves windows smoothly with the fingers. If disabled, it snaps to windows as you swipe. |
+| `continuous` | Boolean | `true` | Controls strip edge limits while scrolling; disable to clamp strictly to the full content bounds. |
+| `sticky` | Boolean | `false` | After scrolling ends, smoothly snap the nearest column to the center of the viewport. |
 
 ### `[swipe.gesture]`
 | Option | Type | Default | Description |
@@ -134,6 +135,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 | `window_swap_first` / `_last` | Move current window to start/end of strip. |
 | `window_center` | Center the current window in the viewport. |
 | `window_resize` | Cycle through preset widths (Grow). |
+| `window_width_<percent>` | Set an exact display-width percentage, e.g. `window_width_150`. |
 | `window_grow` | Alias for `window_resize`. |
 | `window_shrink` | Cycle through preset widths (Shrink). |
 | `window_fullwidth` | Toggle full-width mode. |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -21,7 +21,7 @@ General behavior settings for the window manager.
 | `mouse_follows_focus` | Boolean | `true` | If enabled, the mouse cursor will warp to the center of the focused window when focus changes via keyboard. |
 | `horizontal_mouse_warp` | Integer ``(-1, 1)`` | Off | If enabled, the mouse will warp to another screen above or below, when touching the left or right edge. The direction depends on the direction - a negative value will cause the left edge to warp to a screen above and the right edge to a screen below. This allows having horizontal positioning of displays while having them aligned in a virtual layout in macOS settings. The cursor lands at the *opposite* edge of the target display (preserving cursor flow), with the source's relative Y position. Carries pre-warp horizontal velocity to avoid a "standing start", and skips the warp when the equivalent Y has no position on the target — matching macOS's native side-by-side behavior for displays of unequal height. (inspired by https://github.com/mogenson/WarpMouse.spoon) |
 | `horizontal_mouse_warp_offset` | Integer (px) | `0` | Vertical pixel offset applied to the `horizontal_mouse_warp` landing position, signed by warp direction. Positive values shift the cursor lower when warping to a display *below* (in macOS arrangement) and higher when warping to one *above*. Use to compensate for physical desk arrangement differing from the macOS arrangement (e.g. portrait monitor sitting physically higher or lower than the laptop). |
-| `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75]` | Ratios of the screen width used by the `window_resize` command to cycle sizes. |
+| `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75, 1.0, 1.5, 2.0]` | Ratios of the screen width used by the `window_resize` command and the menu bar width picker. Values above `1.0` create a horizontally scrollable oversized window. |
 | `animation_speed` | Float | *None* | Speed of window animations. Comfortable range is from 8 to 20. Unset or set to a very high value to effectively disable animations. |
 | `auto_center` | Boolean | `false` | Automatically center the focused window on the screen when switching focus. |
 | `sliver_height` | Float (0.1–1.0) | `1.0` | Vertical ratio of off-screen windows kept visible to prevent macOS from relocating them. |
@@ -229,7 +229,7 @@ Define specific behaviors for applications based on their Title or Bundle ID.
 | `manage` | Boolean | Force Paneru to manage this app/window even if macOS reports the app as unobservable or the window has a non-standard role/subrole. |
 | `index` | Integer | Preferred position in the strip when spawned. |
 | `dont_focus` | Boolean | Prevent the window from taking focus when spawned. |
-| `width` | Float (0.0–1.0) | Initial width ratio for the window. |
+| `width` | Positive Float | Initial width ratio for the window. Values above `1.0` create an oversized, horizontally scrollable window. |
 | `grid` | String | placement for floating windows: `"cols:rows:x:y:w:h"`. |
 | `horizontal_padding` | Integer | Gaps to the left/right of this window. |
 | `vertical_padding` | Integer | Gaps to the top/bottom of this window. |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -274,12 +274,20 @@ starts. Restore is a startup-only phase: Paneru loads the saved session, applies
 it after initial window discovery, keeps matching open for a short grace period,
 then stops consulting the saved state until the next Paneru process start.
 
+State writes are event-driven: each persisted layout/display/selection change
+resets a 250 ms trailing debounce, so continuous scrolling does not write every
+frame. Pending dirty state is flushed on shutdown; failed writes remain dirty
+and retry with bounded backoff. With `enabled = false`, Paneru does not read or
+write the state file.
+
 The saved session includes:
 
 - native workspace ids
 - virtual workspace rows and the selected row per native workspace
 - layout structure: singles, stacks, tabs, and fullscreen strips
 - display/screen association
+- saved width ratios, including values above `1.0`
+- horizontal strip pan positions
 - window identity for matching across restarts
 
 Matched startup windows use the saved session before static `[windows]` rules.
@@ -290,7 +298,7 @@ grace period ends, keep normal `[windows]` behavior.
 
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `enabled` | Boolean | `true` | Enables session restore on startup. |
+| `enabled` | Boolean | `true` | Enables state persistence and startup restore. When false, no state-file I/O or persistence deadline is installed. |
 | `startup_grace_ms` | Integer (ms) | `2000` | How long Paneru keeps restore matching active after startup. This gives apps a chance to create windows shortly after Paneru starts. |
 | `missing_windows` | String | `"ignore"` | Behavior when a saved window is not present during restore. Currently only `"ignore"` is supported, which drops the missing window and compacts the restored layout. |
 
@@ -333,6 +341,9 @@ the workspace is already present on a display. Otherwise it restores to the
 saved display id when that screen is still connected, then falls back to the
 current active display, then the first available display by id. Paneru does not
 create placeholder displays or off-screen state for disconnected monitors.
+
+For matched windows, restore reapplies the saved width ratio and horizontal
+strip pan. Older state files without those optional fields remain compatible.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "paneru"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "accessibility-sys",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "paneru"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "accessibility-sys",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paneru"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.89.0"
 description = "A sliding, tiling window manager for MacOS."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "paneru"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.89.0"
 description = "A sliding, tiling window manager for MacOS."
-homepage = "https://github.com/karinushka/paneru"
-repository = "https://github.com/karinushka/paneru"
+homepage = "https://github.com/MrFlashAccount/paneru"
+repository = "https://github.com/MrFlashAccount/paneru"
 readme = "README.md"
 license = "MIT"
 categories = ["os::macos-apis"]

--- a/README.md
+++ b/README.md
@@ -204,10 +204,11 @@ settings without restarting the application.
 
 Paneru saves managed window layout state to the user state directory
 (`$XDG_STATE_HOME/paneru/state.json`, usually
-`~/.local/state/paneru/state.json`) and loads it when Paneru starts. During the
+`~/.local/state/paneru/state.json`) after a short quiet period following a
+relevant layout change and flushes pending state on shutdown. During the
 startup restore window, Paneru matches reopened windows to the saved session and
-restores their layout placement, virtual workspace row, and display assignment
-where possible.
+restores their layout placement, virtual workspace row, display assignment,
+oversized width ratio, and horizontal strip pan where possible.
 
 Restore is startup-only. After the configured startup grace period expires, new
 or unmatched windows follow the normal configuration and window-rule behavior.
@@ -216,6 +217,7 @@ layout is compacted around the windows that were found. The behavior is
 configured with `[restore]`; see the
 **[Session Restore](./CONFIGURATION.md#session-restore)** section in the
 configuration guide.
+When restore is disabled, Paneru neither reads nor writes the state file.
 
 ### Running as a service
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ inspired by [Niri] and [PaperWM.spoon].
 
 ## Installation
 
+### Installing the macOS app
+
+Download `Paneru-<version>.dmg` from the
+[latest GitHub Release](https://github.com/MrFlashAccount/paneru/releases/latest),
+open it, and drag `Paneru.app` to Applications. Paneru lives in the menu bar;
+there is no Dock icon or main window. Grant it access in **System Settings →
+Privacy & Security → Accessibility** when macOS asks.
+
+The current releases are ad-hoc signed but not Apple-notarized. If macOS blocks
+the first launch, control-click Paneru in Applications and choose **Open**. If
+that is still blocked, remove the downloaded quarantine attribute once:
+
+```shell
+xattr -dr com.apple.quarantine /Applications/Paneru.app
+```
+
+Paneru checks the signed GitHub update feed automatically in the background.
+Use **Check for Updates…** in the menu bar to check immediately. Update
+archives and the appcast are protected with Sparkle's Ed25519 signatures.
+
 ### Recommended System Options
 
 - Like all non-native window managers for MacOS, Paneru requires accessibility
@@ -114,6 +134,16 @@ $ cargo install --path .
 
 It can run directly from the command line or as a service.
 Note that you will need to grant accessibility privileges to the binary.
+
+To build a local `.app` bundle instead, run:
+
+```shell
+./scripts/build-app.sh
+open .build/release/Paneru.app
+```
+
+Local builds target the current Mac architecture. Release builds set
+`PANERU_BUILD_ARCHS=universal` and contain both Apple Silicon and Intel slices.
 
 ### Installing with Homebrew
 
@@ -340,6 +370,24 @@ The system is decoupled into three primary layers:
 
 - **`main` branch**: Contains the stable, released code.
 - **`testing` branch**: Used for experimental features and architectural refactors. This branch is volatile and may be force-pushed.
+
+### Publishing a release
+
+1. Update the package version in `Cargo.toml` and commit the change.
+2. Add `SPARKLE_ED25519_PRIVATE_KEY` to the protected GitHub `release`
+   environment. It must match `SUPublicEDKey` in `assets/Info.plist`.
+3. Run the **Release** workflow and enter that same version, with or without a
+   leading `v`.
+
+The workflow cross-compiles `arm64` and `x86_64`, creates a universal
+`Paneru.app`, ZIP and DMG, generates and verifies a signed `appcast.xml`, tags
+the selected commit, and publishes all three files to GitHub Releases. The ZIP
+is Sparkle's update enclosure; the DMG is the human-facing installer.
+
+For a production distribution without Gatekeeper warnings—and to keep macOS
+Accessibility approval stable across releases—the next step is Developer ID
+signing and Apple notarization. Sparkle's Ed25519 signature secures updates,
+but it does not replace Apple's code-signing identity.
 
 ## Tile Scrollably Elsewhere
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Paneru checks for configuration in following locations:
 - `$XDG_CONFIG_HOME/paneru/paneru.toml`
 
 Additionally it allows overriding the location with `$PANERU_CONFIG` environment variable.
+If none of these files exists, Paneru creates
+`$XDG_CONFIG_HOME/paneru/paneru.toml` with the built-in defaults on first launch.
 
 You can use the following basic configuration as a starting point. For a
 complete guide to all available options, keybindings, and window rules, see the
@@ -194,9 +196,9 @@ quit = "ctrl + alt - q"
 
 ### Live reloading
 
-Configuration changes made to your `~/.paneru` file are automatically reloaded
-while Paneru is running. This is useful for tweaking keyboard bindings and
-other settings without restarting the application.
+Changes made to the active configuration file are automatically reloaded while
+Paneru is running. This is useful for tweaking keyboard bindings and other
+settings without restarting the application.
 
 ### Startup session restore
 

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.0</string>
+    <string>0.5.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -2,13 +2,49 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Paneru</string>
+    <key>CFBundleExecutable</key>
+    <string>paneru</string>
     <key>CFBundleIdentifier</key>
-    <string>com.github.karinushka.paneru</string>
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>com.github.mrflashaccount.paneru</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Paneru</string>
     <key>CFBundlePackageType</key>
-    <string>BNDL</string>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.5.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>LSMultipleInstancesProhibited</key>
+    <true/>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>Copyright (c) 2025 Karinushka@github. All rights reserved.</string>
+    <string>Copyright (c) 2026 MrFlashAccount. All rights reserved.</string>
+    <key>SUAllowsAutomaticUpdates</key>
+    <true/>
+    <key>SUAutomaticallyUpdate</key>
+    <true/>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+    <key>SUFeedURL</key>
+    <string>https://github.com/MrFlashAccount/paneru/releases/latest/download/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>8z1ChHWDW5rJJwCEZx6Q4cr7A7DLwpDWq5LYFCDhaVc=</string>
+    <key>SURequireSignedFeed</key>
+    <true/>
+    <key>SUScheduledCheckInterval</key>
+    <integer>86400</integer>
+    <key>SUVerifyUpdateBeforeExtraction</key>
+    <true/>
   </dict>
 </plist>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:-$(/usr/bin/awk -F '"' '/^version = / { print $2; exit }' "$ROOT/Cargo.toml")}"
+BUILD_NUMBER="${PANERU_BUILD_NUMBER:-${GITHUB_RUN_NUMBER:-1}}"
+BUILD_ARCHS="${PANERU_BUILD_ARCHS:-host}"
+BUILD_ROOT="$ROOT/.build/release"
+APP_DIR="$BUILD_ROOT/Paneru.app"
+CONTENTS_DIR="$APP_DIR/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
+EXECUTABLE="$MACOS_DIR/paneru"
+SIGN_IDENTITY="${PANERU_SIGN_IDENTITY:--}"
+CARGO_BIN="${CARGO:-}"
+
+if [[ -z "$CARGO_BIN" ]]; then
+  if command -v cargo >/dev/null 2>&1; then
+    CARGO_BIN="$(command -v cargo)"
+  elif command -v rustup >/dev/null 2>&1; then
+    CARGO_BIN="$(rustup which cargo)"
+  else
+    echo "cargo was not found. Install Rust with rustup before building Paneru." >&2
+    exit 1
+  fi
+fi
+if ! command -v rustc >/dev/null 2>&1 && command -v rustup >/dev/null 2>&1; then
+  RUSTC_BIN="$(rustup which rustc)"
+  export PATH="$(dirname "$RUSTC_BIN"):$PATH"
+fi
+
+if [[ -z "$VERSION" ]]; then
+  echo "Unable to resolve the Paneru version." >&2
+  exit 1
+fi
+
+case "$BUILD_ARCHS" in
+  universal)
+    "$CARGO_BIN" build --locked --release --target aarch64-apple-darwin
+    "$CARGO_BIN" build --locked --release --target x86_64-apple-darwin
+    /bin/mkdir -p "$BUILD_ROOT"
+    /usr/bin/lipo -create \
+      "$ROOT/target/aarch64-apple-darwin/release/paneru" \
+      "$ROOT/target/x86_64-apple-darwin/release/paneru" \
+      -output "$BUILD_ROOT/paneru"
+    BUILT_EXECUTABLE="$BUILD_ROOT/paneru"
+    ;;
+  host)
+    "$CARGO_BIN" build --locked --release
+    BUILT_EXECUTABLE="$ROOT/target/release/paneru"
+    ;;
+  arm64|aarch64)
+    "$CARGO_BIN" build --locked --release --target aarch64-apple-darwin
+    BUILT_EXECUTABLE="$ROOT/target/aarch64-apple-darwin/release/paneru"
+    ;;
+  x86_64)
+    "$CARGO_BIN" build --locked --release --target x86_64-apple-darwin
+    BUILT_EXECUTABLE="$ROOT/target/x86_64-apple-darwin/release/paneru"
+    ;;
+  *)
+    echo "PANERU_BUILD_ARCHS must be host, universal, arm64, or x86_64." >&2
+    exit 1
+    ;;
+esac
+
+SPARKLE_ROOT="${SPARKLE_DIR:-$("$ROOT/scripts/download-sparkle.sh")}"
+if [[ -d "$SPARKLE_ROOT/Sparkle.framework" ]]; then
+  SPARKLE_FRAMEWORK="$SPARKLE_ROOT/Sparkle.framework"
+else
+  SPARKLE_FRAMEWORK="$(/usr/bin/find "$SPARKLE_ROOT" -type d -name Sparkle.framework \
+    -path '*macos-arm64_x86_64*' -print -quit)"
+fi
+if [[ -z "$SPARKLE_FRAMEWORK" ]]; then
+  echo "Universal Sparkle.framework was not found under $SPARKLE_ROOT." >&2
+  exit 1
+fi
+
+/bin/rm -rf "$APP_DIR"
+/bin/mkdir -p "$MACOS_DIR" "$FRAMEWORKS_DIR"
+/bin/cp "$BUILT_EXECUTABLE" "$EXECUTABLE"
+/bin/chmod 755 "$EXECUTABLE"
+/bin/cp "$ROOT/assets/Info.plist" "$CONTENTS_DIR/Info.plist"
+/usr/bin/ditto "$SPARKLE_FRAMEWORK" "$FRAMEWORKS_DIR/Sparkle.framework"
+
+/usr/bin/plutil -replace CFBundleShortVersionString -string "$VERSION" "$CONTENTS_DIR/Info.plist"
+/usr/bin/plutil -replace CFBundleVersion -string "$BUILD_NUMBER" "$CONTENTS_DIR/Info.plist"
+
+if [[ "$BUILD_ARCHS" == universal ]]; then
+  EXECUTABLE_ARCHS="$(/usr/bin/lipo -archs "$EXECUTABLE")"
+  [[ "$EXECUTABLE_ARCHS" == *arm64* && "$EXECUTABLE_ARCHS" == *x86_64* ]] || {
+    echo "The packaged executable is not universal: $EXECUTABLE_ARCHS" >&2
+    exit 1
+  }
+fi
+
+sign_path() {
+  local path="$1"
+  if [[ "$SIGN_IDENTITY" == "-" ]]; then
+    /usr/bin/codesign --force --sign - "$path"
+  else
+    /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$path"
+  fi
+}
+
+SPARKLE_VERSION_DIR="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B"
+for nested in \
+  "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc" \
+  "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc" \
+  "$SPARKLE_VERSION_DIR/Updater.app" \
+  "$SPARKLE_VERSION_DIR/Autoupdate"; do
+  [[ ! -e "$nested" ]] || sign_path "$nested"
+done
+sign_path "$FRAMEWORKS_DIR/Sparkle.framework"
+sign_path "$APP_DIR"
+
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+printf '%s\n' "$APP_DIR"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:-$(/usr/bin/awk -F '"' '/^version = / { print $2; exit }' "$ROOT/Cargo.toml")}"
+APP_DIR="${PANERU_APP_PATH:-$ROOT/.build/release/Paneru.app}"
+STAGE_DIR="$ROOT/.build/dmg-root"
+DIST_DIR="$ROOT/dist"
+DMG_PATH="$DIST_DIR/Paneru-$VERSION.dmg"
+SIGN_IDENTITY="${PANERU_SIGN_IDENTITY:--}"
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "Paneru.app was not found at $APP_DIR. Run scripts/build-app.sh first." >&2
+  exit 1
+fi
+
+/bin/rm -rf "$STAGE_DIR" "$DMG_PATH"
+/bin/mkdir -p "$STAGE_DIR" "$DIST_DIR"
+/usr/bin/ditto "$APP_DIR" "$STAGE_DIR/Paneru.app"
+/bin/ln -s /Applications "$STAGE_DIR/Applications"
+
+/usr/bin/hdiutil create \
+  -volname Paneru \
+  -srcfolder "$STAGE_DIR" \
+  -ov \
+  -format UDZO \
+  -imagekey zlib-level=9 \
+  "$DMG_PATH"
+
+if [[ "$SIGN_IDENTITY" != "-" ]]; then
+  /usr/bin/codesign --force --timestamp --sign "$SIGN_IDENTITY" "$DMG_PATH"
+fi
+/usr/bin/hdiutil verify "$DMG_PATH"
+/bin/rm -rf "$STAGE_DIR"
+printf '%s\n' "$DMG_PATH"

--- a/scripts/download-sparkle.sh
+++ b/scripts/download-sparkle.sh
@@ -27,7 +27,8 @@ fi
   "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz" \
   --output "$ARCHIVE"
 
-printf '%s  %s\n' "$SPARKLE_SHA256" "$ARCHIVE" | /usr/bin/shasum --algorithm 256 --check
+printf '%s  %s\n' "$SPARKLE_SHA256" "$ARCHIVE" \
+  | /usr/bin/shasum --algorithm 256 --check >&2
 /bin/rm -rf "$DESTINATION"
 /bin/mkdir -p "$DESTINATION"
 /usr/bin/tar -xJf "$ARCHIVE" -C "$DESTINATION"

--- a/scripts/download-sparkle.sh
+++ b/scripts/download-sparkle.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPARKLE_VERSION="${SPARKLE_VERSION:-2.9.4}"
+SPARKLE_SHA256="${SPARKLE_SHA256:-ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9}"
+CACHE_ROOT="${PANERU_DEPENDENCIES_DIR:-$ROOT/.build/dependencies}"
+DESTINATION="$CACHE_ROOT/sparkle-$SPARKLE_VERSION"
+ARCHIVE="$CACHE_ROOT/Sparkle-$SPARKLE_VERSION.tar.xz"
+
+framework_path() {
+  if [[ -d "$DESTINATION/Sparkle.framework" ]]; then
+    printf '%s\n' "$DESTINATION/Sparkle.framework"
+  else
+    /usr/bin/find "$DESTINATION" -type d -name Sparkle.framework \
+      -path '*macos-arm64_x86_64*' -print -quit 2>/dev/null
+  fi
+}
+
+if [[ -n "$(framework_path)" ]] && [[ -x "$DESTINATION/bin/generate_appcast" ]]; then
+  printf '%s\n' "$DESTINATION"
+  exit 0
+fi
+
+/bin/mkdir -p "$CACHE_ROOT"
+/usr/bin/curl --fail --location --silent --show-error \
+  "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz" \
+  --output "$ARCHIVE"
+
+printf '%s  %s\n' "$SPARKLE_SHA256" "$ARCHIVE" | /usr/bin/shasum --algorithm 256 --check
+/bin/rm -rf "$DESTINATION"
+/bin/mkdir -p "$DESTINATION"
+/usr/bin/tar -xJf "$ARCHIVE" -C "$DESTINATION"
+
+if [[ -z "$(framework_path)" ]]; then
+  echo "Sparkle.framework was not found in the downloaded archive." >&2
+  exit 1
+fi
+if [[ ! -x "$DESTINATION/bin/generate_appcast" ]]; then
+  echo "Sparkle signing tools were not found in the downloaded archive." >&2
+  exit 1
+fi
+
+printf '%s\n' "$DESTINATION"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,7 @@ mod query;
 use crate::config::Config;
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::{Column, LayoutStrip, StackItem};
+use crate::ecs::layout::{Column, LayoutStrip, StackItem, clamp_origin_to_viewport};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker,
@@ -75,6 +75,8 @@ pub enum Operation {
     Center,
     /// Resizes the focused window in the given direction.
     Resize(ResizeDirection),
+    /// Resizes the focused window to an exact display-width ratio.
+    SetWidth(f64),
     /// Toggles the focused window to full width or a preset width.
     FullWidth,
     /// Moves the focused window to the next available display.
@@ -742,9 +744,10 @@ fn resize_window(
     config: Res<Config>,
     mut commands: Commands,
 ) {
-    let Some(Operation::Resize(direction)) =
-        filter_window_operations(&mut messages, |op| matches!(op, Operation::Resize(_))).next()
-    else {
+    let Some(operation) = filter_window_operations(&mut messages, |op| {
+        matches!(op, Operation::Resize(_) | Operation::SetWidth(_))
+    })
+    .next() else {
         return;
     };
 
@@ -765,8 +768,9 @@ fn resize_window(
     let widths = config.preset_column_widths();
     let fallback = *widths.first().unwrap_or(&0.5);
     let cycle = config.window_resize_cycle();
-    let next_ratio = match direction {
-        ResizeDirection::Grow => widths
+    let next_ratio = match operation {
+        Operation::SetWidth(ratio) if ratio.is_finite() && *ratio > 0.0 => *ratio,
+        Operation::Resize(ResizeDirection::Grow) => widths
             .iter()
             .copied()
             .find(|&r| r > current_ratio + 0.05)
@@ -777,7 +781,7 @@ fn resize_window(
                     *widths.last().unwrap_or(&fallback)
                 }
             }),
-        ResizeDirection::Shrink => widths
+        Operation::Resize(ResizeDirection::Shrink) => widths
             .iter()
             .rev()
             .copied()
@@ -789,13 +793,17 @@ fn resize_window(
                     fallback
                 }
             }),
+        _ => return,
     };
 
     let new_width = (next_ratio * f64::from(viewport.width())).round() as i32;
     let size = Size::new(new_width, frame.height());
 
-    let mut origin = IRect::from_center_size(frame.center(), size).min;
-    origin.x = origin.x.clamp(viewport.min.x, viewport.max.x - size.x);
+    let origin = clamp_origin_to_viewport(
+        IRect::from_center_size(frame.center(), size).min,
+        size,
+        viewport,
+    );
     commands.reposition_entity(entity, origin);
 
     // Resize all windows in the column so stacked siblings share the new width.
@@ -1223,9 +1231,7 @@ fn snap_window(
     // Clamp the frame into the display and reposition the *strip* (not the
     // window) so the layout stays consistent.
     let size = frame.size();
-    frame.min = frame
-        .min
-        .clamp(display_bounds.min, display_bounds.max - size);
+    frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
     frame.max = frame.min + size;
 
     let strip_position = frame.min - layout_position.0;

--- a/src/config.rs
+++ b/src/config.rs
@@ -207,6 +207,17 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
             argv.get(1)
                 .map_or(Ok(ResizeDirection::Grow), |arg| parse_resize_direction(arg))?,
         ),
+        "width" => {
+            let percentage = argv
+                .get(1)
+                .ok_or(err.clone())?
+                .parse::<f64>()
+                .map_err(|_| err.clone())?;
+            if !percentage.is_finite() || percentage <= 0.0 {
+                return Err(err);
+            }
+            Operation::SetWidth(percentage / 100.0)
+        }
         "grow" => Operation::Resize(ResizeDirection::Grow),
         "shrink" => Operation::Resize(ResizeDirection::Shrink),
         "fullwidth" => Operation::FullWidth,
@@ -404,6 +415,17 @@ impl Config {
                 (bind.code == keycode && bind.modifiers.matches(mask))
                     .then_some(bind.command.clone())
             })
+    }
+
+    /// Returns the first configured keybinding for a command name.
+    /// Menus use the same source as the global input handler so displayed
+    /// shortcuts cannot drift from the combinations that actually execute.
+    pub fn first_keybinding(&self, command_name: &str) -> Option<Keybinding> {
+        self.inner()
+            .bindings
+            .get(command_name)
+            .and_then(|bindings| bindings.all().into_iter().next())
+            .cloned()
     }
 
     /// Finds window properties for a given `title` and `bundle_id`.
@@ -653,6 +675,14 @@ impl Config {
             .or(config.options.continuous_swipe)
             // Default: true (enabled).
             .unwrap_or(true)
+    }
+
+    pub fn sticky_scroll(&self) -> bool {
+        self.inner()
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.sticky)
+            .unwrap_or(false)
     }
 
     pub fn swipe_deceleration(&self) -> f64 {
@@ -1110,7 +1140,7 @@ pub fn default_preset_column_widths() -> Vec<f64> {
 
 /// `Keybinding` represents a keyboard shortcut and the command it triggers.
 /// It includes the key, its raw keycode, modifier keys, and the associated command.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Keybinding {
     pub key: String,
     pub code: u8,
@@ -1755,6 +1785,24 @@ index = 1
     let defaults = Config::default();
     assert_eq!(defaults.swipe_sensitivity(), 0.35);
     assert_eq!(defaults.swipe_deceleration(), 4.0);
+    assert!(!defaults.sticky_scroll());
+}
+
+#[test]
+fn test_sticky_scroll_config() {
+    let config = Config::try_from(
+        r"
+[options]
+
+[swipe]
+sticky = true
+
+[bindings]
+",
+    )
+    .expect("sticky swipe config should parse");
+
+    assert!(config.sticky_scroll());
 }
 
 #[test]
@@ -1810,6 +1858,16 @@ fn test_parse_resize_commands() {
         parse_command(&["window", "shrink"]).unwrap(),
         Command::Window(Operation::Resize(ResizeDirection::Shrink))
     ));
+}
+
+#[test]
+fn test_parse_exact_width_command() {
+    assert!(matches!(
+        parse_command(&["window", "width", "150"]).unwrap(),
+        Command::Window(Operation::SetWidth(ratio)) if (ratio - 1.5).abs() < f64::EPSILON
+    ));
+    assert!(parse_command(&["window", "width", "0"]).is_err());
+    assert!(parse_command(&["window", "width", "invalid"]).is_err());
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1105,7 +1105,7 @@ pub struct MainOptions {
 
 /// Returns a default set of column widths.
 pub fn default_preset_column_widths() -> Vec<f64> {
-    vec![0.25, 0.33333, 0.50, 0.66667, 0.75]
+    vec![0.25, 0.33333, 0.50, 0.66667, 0.75, 1.0, 1.5, 2.0]
 }
 
 /// `Keybinding` represents a keyboard shortcut and the command it triggers.
@@ -1174,7 +1174,8 @@ pub struct WindowParams {
     pub vertical_padding: Option<i32>,
     pub horizontal_padding: Option<i32>,
     pub dont_focus: Option<bool>,
-    /// An optional initial width ratio (0.0–1.0) relative to the display width.
+    /// An optional positive initial width ratio relative to the display width.
+    /// Values above 1.0 create an oversized, horizontally scrollable window.
     /// Overrides the default column width when the window is first managed.
     pub width: Option<f64>,
     /// Grid placement for floating windows: "cols:rows:x:y:w:h".

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,8 @@ use std::{
     collections::HashMap,
     env,
     ffi::c_void,
-    fs::read_to_string,
+    fs::{OpenOptions, create_dir_all, read_to_string},
+    io::{ErrorKind, Write},
     path::{Path, PathBuf},
     ptr::NonNull,
     sync::{Arc, LazyLock},
@@ -35,15 +36,59 @@ pub mod swipe;
 
 /// A `LazyLock` that determines the path to the application's configuration file.
 /// It checks the `PANERU_CONFIG` environment variable first, then standard XDG locations and user home directory.
-/// If no configuration file is found, the application will panic.
+/// If no configuration file is found, a minimal one is created in the user's
+/// XDG configuration directory so a fresh app installation can start with the
+/// built-in defaults.
 pub static CONFIGURATION_FILE: LazyLock<PathBuf> = LazyLock::new(|| {
     discover_configuration_file().unwrap_or_else(|| {
-        panic!(
-            "{}: Configuration file not found. Tried: $PANERU_CONFIG, $HOME/.paneru, $HOME/.paneru.toml, $XDG_CONFIG_HOME/paneru/paneru.toml",
-            function_name!()
-        )
+        create_default_configuration_file().unwrap_or_else(|error| {
+            panic!(
+                "{}: Unable to create default configuration: {error}",
+                function_name!()
+            )
+        })
     })
 });
+
+const DEFAULT_CONFIGURATION: &str = "# Paneru configuration\n\n[options]\n\n[bindings]\n";
+
+fn default_configuration_file() -> std::io::Result<PathBuf> {
+    let config_home = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::NotFound,
+                "neither XDG_CONFIG_HOME nor HOME is set",
+            )
+        })?;
+
+    Ok(config_home.join("paneru").join("paneru.toml"))
+}
+
+fn create_default_configuration_file() -> std::io::Result<PathBuf> {
+    let path = default_configuration_file()?;
+    if create_configuration_file_at(&path)? {
+        info!("Created default configuration at {}", path.display());
+    }
+    Ok(path)
+}
+
+fn create_configuration_file_at(path: &Path) -> std::io::Result<bool> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(ErrorKind::InvalidInput, "configuration path has no parent")
+    })?;
+    create_dir_all(parent)?;
+
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut file) => {
+            file.write_all(DEFAULT_CONFIGURATION.as_bytes())?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(false),
+        Err(error) => Err(error),
+    }
+}
 
 /// Finds the first existing configuration file from supported locations.
 /// Unlike [`CONFIGURATION_FILE`], this does not panic when no file is found.
@@ -2007,6 +2052,30 @@ fn test_config_defaults() {
     assert_eq!(config.border_width(), 2.0);
     assert_eq!(config.border_radius(), BorderRadiusOption::Auto);
     assert_eq!(config.menubar_height(), None);
+}
+
+#[test]
+fn test_first_launch_creates_parseable_config_without_overwriting_it() {
+    let unique = format!(
+        "paneru-first-launch-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let directory = std::env::temp_dir().join(unique);
+    let path = directory.join("paneru.toml");
+
+    assert!(create_configuration_file_at(&path).unwrap());
+    Config::new(&path).expect("generated configuration should parse");
+
+    let custom = "[options]\nauto_center = false\n\n[bindings]\n";
+    std::fs::write(&path, custom).unwrap();
+    assert!(!create_configuration_file_at(&path).unwrap());
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), custom);
+
+    std::fs::remove_dir_all(directory).unwrap();
 }
 
 #[test]

--- a/src/config/swipe.rs
+++ b/src/config/swipe.rs
@@ -23,6 +23,10 @@ pub struct SwipeOptions {
     #[allow(dead_code)]
     pub continuous: Option<bool>,
 
+    /// Snap to the nearest column after native momentum settles.
+    /// Default: false.
+    pub sticky: Option<bool>,
+
     pub gesture: Option<GestureOptions>,
     pub scroll: Option<ScrollOptions>,
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -85,8 +85,6 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 || focus_lost.read().next().is_some()
                 || !focused_moved.is_empty()
         };
-    let workspace_menu_status =
-        |config: Option<Res<Config>>| config.is_some_and(|config| config.workspace_menu_status());
     let native_tabs_enabled =
         |config: Option<Res<Config>>| config.is_none_or(|config| config.native_tabs_enabled());
 
@@ -157,7 +155,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 systems::update_flash_messages,
             )
                 .chain(),
-            crate::menubar::update_virtual_workspace_status_item.run_if(workspace_menu_status),
+            crate::menubar::update_menu_bar,
         ),
     );
 }
@@ -566,12 +564,13 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         .add_plugins(display::DisplayEventsPlugin)
         .add_plugins((register_triggers, register_systems, register_commands));
 
+    let menu_events = sender.clone();
     let mut platform_callbacks = PlatformCallbacks::new(sender);
     platform_callbacks.setup_handlers()?;
     let mtm = platform_callbacks.main_thread_marker;
     let overlay_manager = OverlayManager::new(mtm);
     let flash_message_manager = FlashMessageManager::new(mtm);
-    let menu_bar_manager = MenuBarManager::new(mtm);
+    let menu_bar_manager = MenuBarManager::new(mtm, menu_events);
     app.insert_non_send_resource(platform_callbacks)
         .insert_non_send_resource(overlay_manager)
         .insert_non_send_resource(flash_message_manager)

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -1,9 +1,8 @@
-use std::sync::mpsc::Receiver;
 use std::time::{Duration, Instant};
 
 use bevy::MinimalPlugins;
 use bevy::app::App as BevyApp;
-use bevy::app::{PostUpdate, PreUpdate, Startup};
+use bevy::app::{First, PostUpdate, PreUpdate, Startup};
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::lifecycle::RemovedComponents;
 use bevy::ecs::message::Messages;
@@ -12,10 +11,8 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
 use bevy::ecs::system::{Commands, EntityCommands, Query, Res, SystemId};
 use bevy::prelude::Event as BevyEvent;
-use bevy::tasks::Task;
 use bevy::time::Timer;
-use bevy::time::common_conditions::on_timer;
-use bevy::time::{Time, Virtual};
+use bevy::time::{Time, TimeSystems, Virtual};
 use bevy::{
     app::Update,
     ecs::{component::Component, entity::Entity, schedule::IntoScheduleConfigs},
@@ -27,26 +24,31 @@ use crate::commands::register_commands;
 use crate::config::{CONFIGURATION_FILE, Config, WindowParams};
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::layout::LayoutStrip;
-use crate::ecs::state::PaneruState;
 use crate::errors::Result;
-use crate::events::{Event, EventSender};
+use crate::events::{Event, EventReceiver, EventSender};
 use crate::manager::{
     Application, Origin, ProcessApi, Size, Window, WindowManager, WindowManagerApi, WindowManagerOS,
 };
 use crate::menubar::MenuBarManager;
 use crate::overlay::{FlashMessageManager, OverlayManager};
-use crate::platform::{Modifiers, PlatformCallbacks, WinID, WorkspaceId};
+use crate::platform::{AxMainThread, Modifiers, PlatformCallbacks, WinID, WorkspaceId};
 
+mod config_reload;
 pub mod display;
+mod floating;
 pub mod focus;
 pub mod layout;
 pub mod mouse;
+pub(crate) mod observation;
 pub mod params;
+pub(crate) mod persistence;
 pub(crate) mod restore;
+pub(crate) mod runtime;
 pub mod scroll;
 pub mod state;
 mod systems;
 mod triggers;
+mod width_ratio;
 pub mod workspace;
 
 /// Registers the Bevy systems for the `WindowManager`.
@@ -58,8 +60,8 @@ pub mod workspace;
 /// * `app` - The Bevy application to register the systems with.
 #[allow(clippy::too_many_lines)]
 pub fn register_systems(app: &mut bevy::app::App) {
-    const LOW_POWER_MODE_CHECK_SEC: u64 = 60;
-
+    app.init_resource::<persistence::PersistenceState>()
+        .init_resource::<runtime::SyntheticEventPending>();
     let not_swiping = |scrolling: Query<&Scrolling, With<ActiveWorkspaceMarker>>| {
         scrolling
             .iter()
@@ -90,12 +92,23 @@ pub fn register_systems(app: &mut bevy::app::App) {
 
     app.add_systems(
         Startup,
-        (systems::gather_displays, systems::gather_initial_processes).chain(),
+        (
+            systems::gather_displays,
+            systems::gather_initial_processes,
+            persistence::load_restore_state,
+        )
+            .chain(),
     );
+    // Native events must be published before every MessageReader<Event>.
+    // All readers live in PreUpdate or later; the pump runs in First after
+    // Bevy updates Time so its blocking wait can resync the real clock.
     app.add_systems(
-        PreUpdate,
-        (systems::window_creation_event, systems::pump_events),
+        First,
+        runtime::pump_events
+            .after(TimeSystems)
+            .after(bevy::ecs::message::message_update_system),
     );
+    app.add_systems(PreUpdate, systems::window_creation_event);
     app.add_systems(
         Update,
         (
@@ -117,9 +130,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
             systems::fresh_marker_cleanup,
             systems::timeout_ticker,
             systems::retry_front_switch,
-            systems::update_low_power_state
-                .run_if(resource_exists::<LowPowerMode>)
-                .run_if(on_timer(Duration::from_secs(LOW_POWER_MODE_CHECK_SEC))),
+            crate::menubar::tick_silent_updater,
             (
                 systems::window_resized_update_frame,
                 systems::window_moved_update_frame,
@@ -128,8 +139,6 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 .run_if(not_swiping),
             systems::cleanup_on_exit,
             restore::tick_restore_grace,
-            state::periodic_state_save.run_if(on_timer(Duration::from_secs(300))),
-            state::cleanup_on_exit,
         ),
     );
     app.add_systems(
@@ -155,8 +164,18 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 systems::update_flash_messages,
             )
                 .chain(),
-            crate::menubar::update_menu_bar,
+            crate::menubar::update_menu_bar.run_if(crate::menubar::menu_bar_dirty),
         ),
+    );
+    app.add_systems(
+        PostUpdate,
+        (
+            persistence::track_dirty_state,
+            persistence::flush_due_state,
+            persistence::flush_on_exit,
+        )
+            .chain()
+            .after(crate::menubar::update_menu_bar),
     );
 }
 
@@ -168,10 +187,11 @@ pub fn register_triggers(app: &mut bevy::app::App) {
             triggers::front_switched_trigger,
             triggers::window_focused_trigger,
             triggers::mission_control_trigger,
-            triggers::application_event_trigger,
+            observation::application_event_trigger,
+            observation::retry_observer_detaches,
             triggers::dispatch_application_messages,
             triggers::window_destroyed_trigger,
-            triggers::refresh_configuration_trigger,
+            config_reload::refresh_configuration_trigger,
             triggers::theme_change_trigger,
             triggers::window_resize_verifier,
         ),
@@ -210,6 +230,12 @@ pub struct FreshMarker;
 /// Marker component used to gather existing processes and windows during initialization.
 #[derive(Component)]
 pub struct ExistingMarker;
+
+/// Marks applications whose broad AX notifications are currently attached.
+/// Only the frontmost application and applications owning managed windows
+/// retain this observer.
+#[derive(Component)]
+pub struct ApplicationObserved;
 
 /// Component representing a request to reposition a window.
 #[derive(Component, Debug, Deref, DerefMut)]
@@ -315,6 +341,7 @@ pub struct BProcess(pub Box<dyn ProcessApi>);
 pub struct Timeout {
     /// The Bevy timer instance.
     pub timer: Timer,
+    deadline: Instant,
     /// An optional system to execute on timeout.
     pub system_id: Option<SystemId>,
 }
@@ -332,17 +359,32 @@ impl Timeout {
     ///
     /// A new `Timeout` instance.
     pub fn new(duration: Duration, message: Option<String>, commands: &mut Commands) -> Self {
+        Self::new_at(Instant::now(), duration, message, commands)
+    }
+
+    fn new_at(
+        now: Instant,
+        duration: Duration,
+        message: Option<String>,
+        commands: &mut Commands,
+    ) -> Self {
         let timer = Timer::from_seconds(duration.as_secs_f32(), bevy::time::TimerMode::Once);
+        let deadline = now + duration;
         if let Some(message) = message {
             let callback = move || {
                 tracing::debug!("{message}");
             };
             let system_id = Some(commands.register_system(callback));
 
-            Self { timer, system_id }
+            Self {
+                timer,
+                deadline,
+                system_id,
+            }
         } else {
             Self {
                 timer,
+                deadline,
                 system_id: None,
             }
         }
@@ -353,8 +395,17 @@ impl Timeout {
         let timer = Timer::from_seconds(duration.as_secs_f32(), bevy::time::TimerMode::Once);
         commands.spawn(Self {
             timer,
+            deadline: Instant::now() + duration,
             system_id: Some(system_id),
         });
+    }
+
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.deadline
+    }
+
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.deadline
     }
 }
 
@@ -365,10 +416,31 @@ pub struct StrayFocusEvent(pub WinID);
 /// Component used as a retry mechanism when `focused_window_id()` fails during
 /// an `ApplicationFrontSwitched` event (e.g. transient `kAXErrorCannotComplete`).
 #[derive(Component)]
-pub struct RetryFrontSwitch(pub Entity);
+pub struct RetryFrontSwitch {
+    pub application: Entity,
+    next_attempt: Instant,
+}
 
-#[derive(Component)]
-pub struct BruteforceWindows(Task<Vec<Window>>);
+impl RetryFrontSwitch {
+    pub fn new(application: Entity) -> Self {
+        Self {
+            application,
+            next_attempt: Instant::now(),
+        }
+    }
+
+    pub fn due(&self, now: Instant) -> bool {
+        now >= self.next_attempt
+    }
+
+    pub fn schedule_retry(&mut self, now: Instant) {
+        self.next_attempt = now + Duration::from_millis(50);
+    }
+
+    pub fn next_deadline(&self) -> Instant {
+        self.next_attempt
+    }
+}
 
 #[derive(Component, Debug)]
 pub enum DockPosition {
@@ -383,37 +455,52 @@ pub struct RefreshWindowSizes(pub Instant);
 
 impl Default for RefreshWindowSizes {
     fn default() -> Self {
-        Self(Instant::now())
+        Self(Instant::now() + Self::DELAY)
     }
 }
 
 impl RefreshWindowSizes {
-    pub fn ready(&self) -> bool {
-        const REFRESH_WINDOW_SIZE_DELAY_SEC: u64 = 5;
-        self.0.elapsed() > Duration::from_secs(REFRESH_WINDOW_SIZE_DELAY_SEC)
+    const DELAY: Duration = Duration::from_secs(5);
+
+    pub fn ready(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.0
     }
 }
 
 #[derive(Component)]
 pub struct VerifyWindowPosition {
     remaining: u8,
+    next_attempt: Instant,
 }
 
 impl Default for VerifyWindowPosition {
     fn default() -> Self {
-        Self { remaining: 3 }
+        Self {
+            remaining: 3,
+            next_attempt: Instant::now(),
+        }
     }
 }
 
 impl VerifyWindowPosition {
+    pub fn due(&self, now: Instant) -> bool {
+        now >= self.next_attempt
+    }
+
     pub fn tick(&mut self) -> bool {
         self.remaining = self.remaining.saturating_sub(1);
+        self.next_attempt = Instant::now() + Duration::from_millis(50);
         self.remaining == 0
     }
-}
 
-#[derive(Deref, DerefMut, Resource)]
-pub struct LowPowerMode(pub bool);
+    pub fn next_deadline(&self) -> Instant {
+        self.next_attempt
+    }
+}
 
 #[derive(Resource)]
 pub struct SystemTheme {
@@ -545,7 +632,7 @@ impl SpawnCommandsExt for Commands<'_, '_> {
     }
 }
 
-pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<BevyApp> {
+pub fn setup_bevy_app(sender: EventSender, receiver: EventReceiver) -> Result<BevyApp> {
     let window_manager: Box<dyn WindowManagerApi> = Box::new(WindowManagerOS::new(sender.clone()));
     let watcher = window_manager.setup_config_watcher(CONFIGURATION_FILE.as_path())?;
 
@@ -562,6 +649,7 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         .insert_resource(MissionControlActive(false))
         .insert_resource(FocusFollowsMouse(None))
         .insert_resource(Initializing)
+        .insert_resource(persistence::PersistenceStore::default())
         .insert_non_send_resource(watcher)
         .add_plugins(mouse::MouseEventsPlugin)
         .add_plugins(scroll::ScrollEventsPlugin)
@@ -575,23 +663,16 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
     let mut platform_callbacks = PlatformCallbacks::new(sender);
     platform_callbacks.setup_handlers()?;
     let mtm = platform_callbacks.main_thread_marker;
+    let ax_main_thread = AxMainThread::new(mtm);
     let overlay_manager = OverlayManager::new(mtm);
     let flash_message_manager = FlashMessageManager::new(mtm);
     let menu_bar_manager = MenuBarManager::new(mtm, menu_events);
     app.insert_non_send_resource(platform_callbacks)
+        .insert_non_send_resource(ax_main_thread)
         .insert_non_send_resource(overlay_manager)
         .insert_non_send_resource(flash_message_manager)
         .insert_non_send_resource(menu_bar_manager)
         .insert_non_send_resource(receiver);
-
-    if let Some(previous_state) =
-        PaneruState::load_from_file(&PaneruState::default_state_file_path())
-    {
-        app.insert_resource(previous_state);
-    }
-
-    // Do not insert this in mocks.
-    app.insert_resource(LowPowerMode(false));
 
     Ok(app)
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -236,6 +236,11 @@ pub struct EnsureVisibleMarker;
 pub struct Scrolling {
     pub velocity: f64,
     pub position: f64,
+    /// Target supplied by native modifier-scroll events. The current position
+    /// follows it over a few frames so discrete event delivery is not visible.
+    pub target_position: Option<f64>,
+    /// A physical gesture ended and still needs to choose its sticky anchor.
+    pub snap_pending: bool,
     /// When true, the user's fingers are on the trackpad.
     pub is_user_swiping: bool,
     /// Last time a physical swipe event was received.
@@ -247,6 +252,8 @@ impl Default for Scrolling {
         Self {
             velocity: 0.0,
             position: 0.0,
+            target_position: None,
+            snap_pending: false,
             is_user_swiping: false,
             last_event: Instant::now(),
         }

--- a/src/ecs/config_reload.rs
+++ b/src/ecs/config_reload.rs
@@ -1,0 +1,133 @@
+use std::pin::Pin;
+
+use bevy::ecs::message::MessageReader;
+use bevy::ecs::system::{NonSend, NonSendMut, Query, Res, ResMut};
+use notify::event::{DataChange, MetadataKind, ModifyKind};
+use notify::{EventKind, Watcher};
+use tracing::{debug, error, info};
+
+use super::params::Windows;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::events::Event;
+use crate::manager::{Application, Display, WindowManager};
+use crate::platform::{AxMainThread, PlatformCallbacks};
+use crate::util::symlink_target;
+
+fn replace_config_transactionally(
+    current: &mut Config,
+    candidate: Config,
+    reconfigure: impl FnOnce(&Config) -> Result<()>,
+) -> Result<()> {
+    reconfigure(&candidate)?;
+    *current = candidate;
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub(super) fn refresh_configuration_trigger(
+    _main_thread: NonSend<AxMainThread>,
+    mut messages: MessageReader<Event>,
+    window_manager: Res<WindowManager>,
+    mut config: ResMut<Config>,
+    mut watcher: Option<NonSendMut<Box<dyn Watcher>>>,
+    windows: Windows,
+    mut displays: Query<&mut Display>,
+    applications: Query<&Application>,
+    mut platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
+) {
+    for event in messages.read() {
+        let Event::ConfigRefresh(event) = event else {
+            continue;
+        };
+        let Some(ref mut watcher) = watcher else {
+            continue;
+        };
+        match &event.kind {
+            EventKind::Modify(
+                ModifyKind::Metadata(MetadataKind::WriteTime)
+                | ModifyKind::Data(DataChange::Content),
+            ) => (),
+            EventKind::Remove(_) => {
+                for path in &event.paths {
+                    _ = watcher.unwatch(path).inspect_err(|err| {
+                        error!("unwatching the config '{}': {err}", path.display());
+                    });
+                }
+                continue;
+            }
+            _ => continue,
+        }
+
+        let mut candidate = config.clone();
+        let mut reloaded = false;
+        for path in &event.paths {
+            if let Some(symlink) = symlink_target(path) {
+                debug!(
+                    "symlink '{}' changed, replacing the watcher.",
+                    symlink.display()
+                );
+                if let Ok(new_watcher) =
+                    window_manager
+                        .setup_config_watcher(path)
+                        .inspect_err(|err| {
+                            error!("watching the config '{}': {err}", path.display());
+                        })
+                {
+                    **watcher = new_watcher;
+                }
+            }
+            info!("Reloading configuration file; {}", path.display());
+            reloaded |= candidate
+                .reload_config(path.as_path())
+                .inspect_err(|err| {
+                    error!("loading config '{}': {err}", path.display());
+                })
+                .is_ok();
+        }
+
+        if reloaded
+            && let Err(err) = replace_config_transactionally(&mut config, candidate, |candidate| {
+                platform.as_mut().map_or(Ok(()), |platform| {
+                    platform.reconfigure_input_handler(candidate).map(|_| ())
+                })
+            })
+        {
+            error!("reconfiguring input handler; keeping previous config: {err}");
+            continue;
+        }
+
+        let height = config.menubar_height();
+        for mut display in &mut displays {
+            display.set_menubar_height_override(height);
+        }
+        if let Some((window, _, parent)) = windows
+            .focused()
+            .and_then(|(w, e)| windows.find_parent(w.id()).map(|(w, _, p)| (w, e, p)))
+            && let Ok(app) = applications.get(parent)
+        {
+            super::triggers::update_passthrough(window, app, &config);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::Error;
+
+    #[test]
+    fn failed_input_tap_replacement_keeps_running_config() {
+        let mut current = Config::default();
+        let running_focus_follows_mouse = current.focus_follows_mouse();
+        let candidate = Config::try_from("[options]\nfocus_follows_mouse = true\n\n[bindings]\n")
+            .expect("candidate config should parse");
+
+        let result = replace_config_transactionally(&mut current, candidate, |_| {
+            Err(Error::InvalidInput("injected tap creation failure".into()))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(current.focus_follows_mouse(), running_focus_follows_mouse);
+    }
+}

--- a/src/ecs/display.rs
+++ b/src/ecs/display.rs
@@ -6,7 +6,7 @@ use bevy::ecs::lifecycle::Add;
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
 use bevy::ecs::query::{Has, With};
-use bevy::ecs::system::{Commands, Local, NonSend, Query, Res};
+use bevy::ecs::system::{Commands, Local, NonSend, Query, Res, ResMut};
 use bevy::math::IRect;
 use bevy::platform::collections::HashSet;
 use objc2_app_kit::NSScreen;
@@ -18,13 +18,14 @@ use tracing::{Level, debug, error, instrument, warn};
 
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
+use crate::ecs::runtime::{OrphanReconcileDeadline, SyntheticEventPending};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, ReadDisplayProperties, RefreshWindowSizes,
-    SendMessageTrigger, SpawnCommandsExt, Timeout,
+    Scrolling, SendMessageTrigger, SpawnCommandsExt, Timeout,
 };
 use crate::events::Event;
 use crate::manager::{Display, WindowManager, irect_from};
-use crate::platform::{PlatformCallbacks, WorkspaceId};
+use crate::platform::{AxMainThread, PlatformCallbacks, WorkspaceId};
 use crate::util::read_screen_property;
 
 const ORPHANED_SPACES_TIMEOUT_SEC: u64 = 30;
@@ -108,6 +109,7 @@ pub(crate) fn reconcile_displays(
     mut displays: Query<(&mut Display, Entity)>,
     active_strips: Query<Entity, (With<LayoutStrip>, With<ActiveWorkspaceMarker>)>,
     window_manager: Res<WindowManager>,
+    _main_thread: NonSend<AxMainThread>,
     mut retries: Local<u8>,
     mut commands: Commands,
 ) {
@@ -141,11 +143,14 @@ pub(crate) fn reconcile_displays(
         warn!("No present displays found... retrying again in {DISPLAY_RETRY_TIMEOUT} seconds.");
         *retries = retries.saturating_sub(1);
         if *retries > 0 {
-            let retry_displays = move |mut messages: MessageWriter<Event>| {
-                messages.write(Event::SystemWoke {
-                    msg: "Retrying display scan".to_string(),
-                });
-            };
+            let retry_displays =
+                move |mut messages: MessageWriter<Event>,
+                      mut synthetic_events: ResMut<SyntheticEventPending>| {
+                    messages.write(Event::SystemWoke {
+                        msg: "Retrying display scan".to_string(),
+                    });
+                    synthetic_events.mark();
+                };
             let system_id = commands.register_system(retry_displays);
             Timeout::callback(
                 Duration::from_secs(DISPLAY_RETRY_TIMEOUT),
@@ -264,7 +269,9 @@ fn remove_display(
             commands,
         );
         if let Ok(mut commands) = commands.get_entity(entity) {
-            commands.try_insert(timeout);
+            commands
+                .try_remove::<Scrolling>()
+                .try_insert((timeout, OrphanReconcileDeadline::default()));
         }
         if let Ok(mut commands) = commands.get_entity(display_entity) {
             commands.detach_child(entity);

--- a/src/ecs/floating.rs
+++ b/src/ecs/floating.rs
@@ -1,0 +1,38 @@
+use bevy::math::IRect;
+
+use crate::manager::{Origin, Size};
+
+pub(super) fn clamp_origin_to_bounds(origin: IRect, size: Size, bounds: IRect) -> IRect {
+    let max = (bounds.max - size).max(bounds.min);
+    let min = origin.min.clamp(bounds.min, max);
+    IRect::from_corners(min, min + size)
+}
+
+pub(super) fn offset_frame_within_bounds(frame: IRect, bounds: IRect, offset: i32) -> IRect {
+    let candidates = [
+        (offset, offset),
+        (offset, -offset),
+        (-offset, offset),
+        (-offset, -offset),
+        (offset, 0),
+        (-offset, 0),
+        (0, offset),
+        (0, -offset),
+    ];
+
+    for (dx, dy) in candidates {
+        let moved = IRect::from_corners(
+            Origin::new(frame.min.x + dx, frame.min.y + dy),
+            Origin::new(frame.max.x + dx, frame.max.y + dy),
+        );
+        if moved.min.x >= bounds.min.x
+            && moved.max.x <= bounds.max.x
+            && moved.min.y >= bounds.min.y
+            && moved.max.y <= bounds.max.y
+        {
+            return moved;
+        }
+    }
+
+    frame
+}

--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
 
 use bevy::app::{App, Plugin, PostUpdate};
 use bevy::ecs::entity::Entity;
@@ -9,23 +8,21 @@ use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With};
 use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
-use bevy::ecs::system::{Commands, Populated, Query, Res, Single};
+use bevy::ecs::system::{Commands, NonSend, Populated, Query, Res, ResMut, Single};
 use bevy::prelude::Event as BevyEvent;
-use bevy::time::common_conditions::on_timer;
 use tracing::{Level, debug, error, instrument, trace, warn};
 
 use super::{FocusedMarker, MouseHeldMarker, SystemTheme, Unmanaged};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
+use crate::ecs::runtime::FocusRecoveryDeadline;
 use crate::ecs::{
     ActiveWorkspaceMarker, Scrolling, SendMessageTrigger, SpawnCommandsExt, StrayFocusEvent,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Window, WindowManager};
-use crate::platform::WorkspaceId;
-
-const REFRESH_WINDOW_CHECK_FREQ_MS: u64 = 1000;
+use crate::platform::{AxMainThread, WorkspaceId};
 
 #[derive(Default)]
 pub struct TierMemory {
@@ -90,14 +87,13 @@ pub struct FocusEventsPlugin;
 impl Plugin for FocusEventsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<FocusHistory>();
+        app.init_resource::<FocusRecoveryDeadline>();
         app.add_systems(
             PostUpdate,
             (
                 autocenter_window_on_focus.after(super::systems::animate_resize_entities),
                 mouse_follows_focus.after(super::systems::animate_resize_entities),
-                recover_lost_focus.run_if(on_timer(Duration::from_millis(
-                    REFRESH_WINDOW_CHECK_FREQ_MS,
-                ))),
+                recover_lost_focus,
             ),
         );
         app.add_observer(dim_remove_window_trigger)
@@ -293,7 +289,12 @@ fn virtual_strip_activated(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn focus_window_trigger(trigger: On<FocusWindow>, windows: Windows, apps: Query<&Application>) {
+fn focus_window_trigger(
+    trigger: On<FocusWindow>,
+    _main_thread: NonSend<AxMainThread>,
+    windows: Windows,
+    apps: Query<&Application>,
+) {
     let FocusWindow { entity, raise } = *trigger.event();
     let Some(window) = windows.get(entity) else {
         return;
@@ -316,11 +317,17 @@ fn focus_window_trigger(trigger: On<FocusWindow>, windows: Windows, apps: Query<
 fn recover_lost_focus(
     windows: Windows,
     active_workspace: Query<&LayoutStrip, With<ActiveWorkspaceMarker>>,
+    mut deadline: ResMut<FocusRecoveryDeadline>,
     mut commands: Commands,
 ) {
     if windows.focused().is_some() {
         return;
     }
+    let now = std::time::Instant::now();
+    if !deadline.due(now) {
+        return;
+    }
+    deadline.schedule_next(now);
     error!("Lost focus marker, recovering!");
     if let Ok(strip) = active_workspace
         .single()

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -1875,10 +1875,10 @@ mod tests {
         // Remove e2 (follower)
         strip.remove(e2);
         assert_eq!(strip.len(), 1);
-        match strip.get(0).unwrap() {
-            Column::Tabs(tabs) => assert_eq!(tabs, vec![e3, e1]),
-            _ => panic!(),
-        }
+        let Column::Tabs(tabs) = strip.get(0).unwrap() else {
+            panic!();
+        };
+        assert_eq!(tabs, vec![e3, e1]);
 
         // Remove e1 (leader)
         strip.remove(e1);
@@ -1983,10 +1983,10 @@ mod tests {
         }
 
         assert_eq!(strip.len(), 1);
-        match strip.get(0).unwrap() {
-            Column::Tabs(tabs) => assert_eq!(tabs, vec![e2, e1]),
-            _ => panic!(),
-        }
+        let Column::Tabs(tabs) = strip.get(0).unwrap() else {
+            panic!();
+        };
+        assert_eq!(tabs, vec![e2, e1]);
     }
 
     // Mirrors the real `detect_tabbed_windows` flow: spawn_window_trigger

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -19,10 +19,20 @@ use crate::ecs::{
     Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, SpawnCommandsExt,
 };
 use crate::errors::{Error, Result};
-use crate::manager::{Display, Origin, Window};
+use crate::manager::{Display, Origin, Size, Window};
 use crate::platform::WorkspaceId;
 
 pub struct LayoutEventsPlugin;
+
+/// Clamp a window origin to the range where it still touches both viewport
+/// edges. For an oversized window this range is reversed: from right-aligned
+/// to left-aligned, which lets the strip pan across the hidden content.
+pub(crate) fn clamp_origin_to_viewport(origin: Origin, size: Size, viewport: IRect) -> Origin {
+    let far_edge = viewport.max - size;
+    let minimum = viewport.min.min(far_edge);
+    let maximum = viewport.min.max(far_edge);
+    origin.clamp(minimum, maximum)
+}
 
 impl Plugin for LayoutEventsPlugin {
     fn build(&self, app: &mut App) {
@@ -1024,9 +1034,7 @@ fn reshuffle_layout_strip(
         let visible_width = display_bounds.intersect(frame).width();
 
         // Expose the window by clamping it into the viewport.
-        frame.min = frame
-            .min
-            .clamp(display_bounds.min, display_bounds.max - size);
+        frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
         frame.max = frame.min + size;
 
         let strip_position = (frame.min - layout_position.0).with_y(display_bounds.min.y);
@@ -1101,9 +1109,7 @@ fn ensure_visible_in_strip(
         let candidate_min = layout_position.0 + strip_position.0;
         // Clamp into the viewport. If already on-screen, this is a no-op and
         // the strip target equals its current position — no movement.
-        //let clamped_min = candidate_min.clamp(viewport.min, viewport.max - size);
-        let clamped_min =
-            candidate_min.clamp(viewport.min, (viewport.max - size).max(viewport.min));
+        let clamped_min = clamp_origin_to_viewport(candidate_min, size, viewport);
         if clamped_min == candidate_min {
             return;
         }
@@ -1356,6 +1362,36 @@ fn position_layout_windows(
 mod tests {
     use super::*;
     use bevy::prelude::*;
+
+    #[test]
+    fn clamp_origin_supports_oversized_windows() {
+        let viewport = IRect::new(0, 20, 1024, 768);
+        let size = Size::new(2048, 748);
+
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(300, 20), size, viewport),
+            Origin::new(0, 20)
+        );
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-1600, 20), size, viewport),
+            Origin::new(-1024, 20)
+        );
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-600, 20), size, viewport),
+            Origin::new(-600, 20)
+        );
+    }
+
+    #[test]
+    fn clamp_origin_keeps_regular_windows_inside_viewport() {
+        let viewport = IRect::new(0, 20, 1024, 768);
+        let size = Size::new(400, 300);
+
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-100, 900), size, viewport),
+            Origin::new(0, 468)
+        );
+    }
 
     fn setup_world_and_strip() -> (World, LayoutStrip, Vec<Entity>) {
         let mut world = World::new();

--- a/src/ecs/observation.rs
+++ b/src/ecs/observation.rs
@@ -1,0 +1,544 @@
+use bevy::ecs::component::Component;
+use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::Children;
+use bevy::ecs::message::MessageReader;
+use bevy::ecs::query::{Has, With, Without};
+use bevy::ecs::system::{Commands, NonSend, Query, SystemParam};
+use std::time::{Duration, Instant};
+use tracing::{error, warn};
+
+use super::{ApplicationObserved, BProcess, FreshMarker, Timeout, Unmanaged};
+use crate::config::Config;
+use crate::ecs::runtime::FreshPollDeadline;
+use crate::errors::Result as AppResult;
+use crate::events::Event;
+use crate::manager::{Application, Process, Window};
+use crate::platform::{AxMainThread, WinID};
+
+const DETACH_RETRY_INTERVAL: Duration = Duration::from_millis(250);
+const DETACH_RETRY_LIMIT: u8 = 3;
+
+#[derive(Component, Debug)]
+pub(crate) struct ObserverDetachRetry {
+    deadline: Instant,
+    attempts: u8,
+    remove_application_marker: bool,
+}
+
+impl ObserverDetachRetry {
+    fn new(remove_application_marker: bool) -> Self {
+        Self {
+            deadline: Instant::now() + DETACH_RETRY_INTERVAL,
+            attempts: 0,
+            remove_application_marker,
+        }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.deadline
+    }
+
+    fn due(&self, now: Instant) -> bool {
+        now >= self.deadline
+    }
+
+    fn failed_attempt(&mut self, now: Instant) -> bool {
+        self.attempts += 1;
+        self.deadline = now + DETACH_RETRY_INTERVAL;
+        self.attempts >= DETACH_RETRY_LIMIT
+    }
+}
+
+fn schedule_detach_retry(
+    app_entity: Entity,
+    remove_application_marker: bool,
+    commands: &mut Commands,
+) {
+    if let Ok(mut entity_commands) = commands.get_entity(app_entity) {
+        entity_commands.try_insert(ObserverDetachRetry::new(remove_application_marker));
+    }
+}
+
+/// Owns broad application AX observer reconciliation. Broad notifications are
+/// retained only for the frontmost app and applications with managed windows.
+#[derive(SystemParam)]
+pub(crate) struct ApplicationObservationScope<'w, 's> {
+    applications: Query<
+        'w,
+        's,
+        (
+            Entity,
+            &'static mut Application,
+            Option<&'static Children>,
+            Has<ApplicationObserved>,
+        ),
+    >,
+    managed_windows: Query<'w, 's, (), (With<Window>, Without<Unmanaged>)>,
+}
+
+impl ApplicationObservationScope<'_, '_> {
+    pub(crate) fn activate(
+        &mut self,
+        target: Option<Entity>,
+        config: &Config,
+        _main_thread: &AxMainThread,
+        commands: &mut Commands,
+    ) -> Option<AppResult<WinID>> {
+        for (entity, mut app, children, observed) in &mut self.applications {
+            let owns_managed = children.is_some_and(|children| {
+                children
+                    .iter()
+                    .any(|child| self.managed_windows.get(*child).is_ok())
+            });
+            let required = Some(entity) == target || owns_managed;
+            if required && !observed && app.observe().is_ok_and(|good| good) {
+                if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                    entity_commands.try_insert(ApplicationObserved);
+                }
+            } else if !required && observed {
+                if app.unobserve() {
+                    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                        entity_commands.try_remove::<ApplicationObserved>();
+                    }
+                } else {
+                    schedule_detach_retry(entity, true, commands);
+                }
+            }
+        }
+
+        let target = target?;
+        let Ok((_, app, _, _)) = self.applications.get_mut(target) else {
+            return None;
+        };
+        let windows = app.window_list(config);
+        if !windows.is_empty() {
+            commands.trigger(super::SpawnWindowTrigger(windows));
+        }
+        Some(app.focused_window_id())
+    }
+}
+
+pub(crate) fn attach_managed_window(
+    app_entity: Entity,
+    app: &mut Application,
+    window: &Window,
+    observed: bool,
+    main_thread: &AxMainThread,
+    commands: &mut Commands,
+) {
+    ensure_application_observer(app_entity, app, observed, main_thread, commands);
+    if app.observe_window(window).is_err() {
+        warn!("Error observing managed window {}.", window.id());
+    }
+}
+
+pub(crate) fn ensure_application_observer(
+    app_entity: Entity,
+    app: &mut Application,
+    observed: bool,
+    _main_thread: &AxMainThread,
+    commands: &mut Commands,
+) {
+    if !observed
+        && app.observe().is_ok_and(|good| good)
+        && let Ok(mut entity_commands) = commands.get_entity(app_entity)
+    {
+        entity_commands.try_insert(ApplicationObserved);
+    }
+}
+
+pub(crate) fn detach_unmanaged_window(
+    app_entity: Entity,
+    app: &mut Application,
+    window: &Window,
+    observed: bool,
+    owns_other_managed_windows: bool,
+    _main_thread: &AxMainThread,
+    commands: &mut Commands,
+) {
+    let mut retry = !app.unobserve_window(window);
+    let mut remove_application_marker = false;
+    if observed && !app.is_frontmost() && !owns_other_managed_windows {
+        if app.unobserve() {
+            if let Ok(mut entity_commands) = commands.get_entity(app_entity) {
+                entity_commands.try_remove::<ApplicationObserved>();
+            }
+        } else {
+            retry = true;
+            remove_application_marker = true;
+        }
+    }
+    if retry {
+        schedule_detach_retry(app_entity, remove_application_marker, commands);
+    }
+}
+
+pub(crate) fn shutdown_application_observers<'a>(
+    app: &mut Application,
+    windows: impl IntoIterator<Item = &'a Window>,
+    _main_thread: &AxMainThread,
+) {
+    for window in windows {
+        _ = app.unobserve_window(window);
+    }
+    _ = app.unobserve();
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn retry_observer_detaches(
+    _main_thread: NonSend<AxMainThread>,
+    mut applications: Query<(
+        Entity,
+        &mut Application,
+        &mut ObserverDetachRetry,
+        Has<ApplicationObserved>,
+    )>,
+    mut commands: Commands,
+) {
+    let now = Instant::now();
+    for (entity, mut app, mut retry, observed) in &mut applications {
+        if !retry.due(now) {
+            continue;
+        }
+        if app.retry_observer_removals() {
+            if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                entity_commands.try_remove::<ObserverDetachRetry>();
+                if retry.remove_application_marker && observed {
+                    entity_commands.try_remove::<ApplicationObserved>();
+                }
+            }
+        } else if retry.failed_attempt(now) {
+            error!(
+                "AX observer detach still ambiguous after {DETACH_RETRY_LIMIT} retries; retaining ECS observation marker/context for safety"
+            );
+            if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                entity_commands.try_remove::<ObserverDetachRetry>();
+            }
+        } else {
+            warn!(
+                attempt = retry.attempts,
+                "AX observer detach remains ambiguous; scheduled bounded retry"
+            );
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn application_event_trigger(
+    main_thread: NonSend<AxMainThread>,
+    mut messages: MessageReader<Event>,
+    processes: Query<(&BProcess, Entity, Option<&Children>)>,
+    mut applications: Query<(&mut Application, Option<&Children>)>,
+    windows: Query<&Window>,
+    mut commands: Commands,
+) {
+    const PROCESS_READY_TIMEOUT_SEC: u64 = 5;
+    let find_process = |psn| {
+        processes
+            .iter()
+            .find(|(BProcess(process), _, _)| process.psn() == psn)
+    };
+
+    for event in messages.read() {
+        match event {
+            Event::ApplicationLaunched { psn, observer } if find_process(*psn).is_none() => {
+                let process: BProcess = Process::new(psn, observer.clone()).into();
+                let timeout = Timeout::new(
+                    Duration::from_secs(PROCESS_READY_TIMEOUT_SEC),
+                    Some(format!(
+                        "Process '{}' did not become ready in {PROCESS_READY_TIMEOUT_SEC}s.",
+                        process.name()
+                    )),
+                    &mut commands,
+                );
+                commands.spawn((FreshMarker, FreshPollDeadline::default(), timeout, process));
+            }
+            Event::ApplicationTerminated { psn } => {
+                if let Some((_, entity, app_entities)) = find_process(*psn) {
+                    if let Some(app_entities) = app_entities {
+                        for app_entity in app_entities {
+                            if let Ok((mut app, window_entities)) =
+                                applications.get_mut(*app_entity)
+                            {
+                                let owned_windows = window_entities
+                                    .into_iter()
+                                    .flat_map(|children| children.iter())
+                                    .filter_map(|window_entity| windows.get(*window_entity).ok());
+                                shutdown_application_observers(
+                                    &mut app,
+                                    owned_windows,
+                                    &main_thread,
+                                );
+                            }
+                        }
+                    }
+                    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                        entity_commands.try_despawn();
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ApplicationObservationScope, DETACH_RETRY_INTERVAL, DETACH_RETRY_LIMIT,
+        ObserverDetachRetry, attach_managed_window, detach_unmanaged_window,
+        retry_observer_detaches, shutdown_application_observers,
+    };
+    use crate::config::Config;
+    use crate::ecs::ApplicationObserved;
+    use crate::manager::app::MockApplicationApi;
+    use crate::manager::{Application, MockWindowApi, Window};
+    use crate::platform::AxMainThread;
+    use bevy::app::{App, Update};
+    use bevy::ecs::entity::Entity;
+    use bevy::ecs::query::Has;
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::system::{Commands, Local, NonSend, Query, Res, Single};
+    use std::time::Instant;
+
+    fn required(frontmost: bool, owns_managed: bool) -> bool {
+        frontmost || owns_managed
+    }
+
+    #[test]
+    fn observation_scope_excludes_irrelevant_background_apps() {
+        assert!(required(true, false));
+        assert!(required(false, true));
+        assert!(!required(false, false));
+    }
+
+    fn app_with_token() -> App {
+        let mut app = App::new();
+        app.insert_non_send_resource(AxMainThread::for_tests())
+            .insert_resource(Config::default());
+        app
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn attach_system(
+        main_thread: NonSend<AxMainThread>,
+        mut apps: Query<(Entity, &mut Application, Has<ApplicationObserved>)>,
+        window: Single<&Window>,
+        mut commands: Commands,
+    ) {
+        for (entity, mut app, observed) in &mut apps {
+            attach_managed_window(
+                entity,
+                &mut app,
+                *window,
+                observed,
+                &main_thread,
+                &mut commands,
+            );
+        }
+    }
+
+    #[test]
+    fn startup_managed_owner_attaches_broad_observer_once() {
+        let mut mock = MockApplicationApi::new();
+        mock.expect_observe().times(1).returning(|| Ok(true));
+        mock.expect_observe_window()
+            .times(2)
+            .returning(|_| Ok(true));
+        let mut app = app_with_token();
+        let app_entity = app.world_mut().spawn(Application::new(Box::new(mock))).id();
+        app.world_mut()
+            .spawn(Window::new(Box::new(MockWindowApi::new())));
+        app.add_systems(Update, attach_system);
+        app.update();
+        app.update();
+        assert!(
+            app.world()
+                .entity(app_entity)
+                .contains::<ApplicationObserved>()
+        );
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn detach_once_system(
+        main_thread: NonSend<AxMainThread>,
+        mut done: Local<bool>,
+        mut app: Single<(Entity, &mut Application, Has<ApplicationObserved>)>,
+        window: Single<&Window>,
+        mut commands: Commands,
+    ) {
+        if *done {
+            return;
+        }
+        *done = true;
+        let app_entity = app.0;
+        let observed = app.2;
+        detach_unmanaged_window(
+            app_entity,
+            &mut app.1,
+            *window,
+            observed,
+            false,
+            &main_thread,
+            &mut commands,
+        );
+    }
+
+    #[test]
+    fn last_background_managed_window_detaches_window_and_app() {
+        let mut mock = MockApplicationApi::new();
+        mock.expect_unobserve_window().times(1).return_const(true);
+        mock.expect_is_frontmost().times(1).return_const(false);
+        mock.expect_unobserve().times(1).return_const(true);
+        let mut app = app_with_token();
+        let app_entity = app
+            .world_mut()
+            .spawn((Application::new(Box::new(mock)), ApplicationObserved))
+            .id();
+        app.world_mut()
+            .spawn(Window::new(Box::new(MockWindowApi::new())));
+        app.add_systems(Update, detach_once_system);
+        app.update();
+        assert!(
+            !app.world()
+                .entity(app_entity)
+                .contains::<ApplicationObserved>()
+        );
+    }
+
+    #[derive(Resource)]
+    struct ActivationTarget(Option<Entity>);
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn activate_system(
+        target: Res<ActivationTarget>,
+        config: Res<Config>,
+        main_thread: NonSend<AxMainThread>,
+        mut scope: ApplicationObservationScope,
+        mut commands: Commands,
+    ) {
+        scope.activate(target.0, &config, &main_thread, &mut commands);
+    }
+
+    fn activation_mock(observe: usize, unobserve: usize, activations: usize) -> Application {
+        let mut mock = MockApplicationApi::new();
+        mock.expect_observe().times(observe).returning(|| Ok(true));
+        mock.expect_unobserve().times(unobserve).return_const(true);
+        mock.expect_window_list()
+            .times(activations)
+            .returning(|_| Vec::new());
+        mock.expect_focused_window_id()
+            .times(activations)
+            .returning(|| Ok(1));
+        Application::new(Box::new(mock))
+    }
+
+    #[test]
+    fn repeated_front_switches_are_idempotent_and_detach_previous_app() {
+        let mut app = app_with_token();
+        let first = app.world_mut().spawn(activation_mock(1, 1, 2)).id();
+        let second = app.world_mut().spawn(activation_mock(1, 0, 1)).id();
+        app.insert_resource(ActivationTarget(Some(first)))
+            .add_systems(Update, activate_system);
+        app.update();
+        app.update();
+        app.world_mut().resource_mut::<ActivationTarget>().0 = Some(second);
+        app.update();
+        assert!(!app.world().entity(first).contains::<ApplicationObserved>());
+        assert!(app.world().entity(second).contains::<ApplicationObserved>());
+    }
+
+    #[test]
+    fn switching_to_untracked_process_detaches_unowned_previous_observer() {
+        let mut app = app_with_token();
+        let tracked = app.world_mut().spawn(activation_mock(1, 1, 1)).id();
+        app.insert_resource(ActivationTarget(Some(tracked)))
+            .add_systems(Update, activate_system);
+        app.update();
+        assert!(
+            app.world()
+                .entity(tracked)
+                .contains::<ApplicationObserved>()
+        );
+
+        app.world_mut().resource_mut::<ActivationTarget>().0 = None;
+        app.update();
+        assert!(
+            !app.world()
+                .entity(tracked)
+                .contains::<ApplicationObserved>()
+        );
+    }
+
+    #[test]
+    fn termination_shutdown_detaches_all_window_and_application_observers() {
+        let mut mock = MockApplicationApi::new();
+        mock.expect_unobserve_window().times(1).return_const(true);
+        mock.expect_unobserve().times(1).return_const(true);
+        let mut app = Application::new(Box::new(mock));
+        let window = Window::new(Box::new(MockWindowApi::new()));
+        let main_thread = AxMainThread::for_tests();
+        shutdown_application_observers(&mut app, [&window], &main_thread);
+    }
+
+    #[test]
+    fn ambiguous_detach_retry_is_bounded_and_non_spinning() {
+        let mut retry = ObserverDetachRetry::new(true);
+        let first = retry.next_deadline();
+        assert!(first > Instant::now());
+        assert!(!retry.failed_attempt(first));
+        assert_eq!(retry.next_deadline(), first + DETACH_RETRY_INTERVAL);
+        let second = retry.next_deadline();
+        assert!(!retry.failed_attempt(second));
+        let third = retry.next_deadline();
+        assert!(retry.failed_attempt(third));
+    }
+
+    #[test]
+    fn successful_retry_reconciles_context_and_ecs_marker() {
+        let mut mock = MockApplicationApi::new();
+        mock.expect_retry_observer_removals()
+            .times(1)
+            .return_const(true);
+        let mut retry = ObserverDetachRetry::new(true);
+        retry.deadline = Instant::now();
+        let mut app = app_with_token();
+        let entity = app
+            .world_mut()
+            .spawn((Application::new(Box::new(mock)), ApplicationObserved, retry))
+            .id();
+        app.add_systems(Update, retry_observer_detaches);
+
+        app.update();
+
+        assert!(!app.world().entity(entity).contains::<ObserverDetachRetry>());
+        assert!(!app.world().entity(entity).contains::<ApplicationObserved>());
+    }
+
+    #[test]
+    fn exhausted_retry_stops_waking_but_keeps_observed_marker() {
+        let mut mock = MockApplicationApi::new();
+        mock.expect_retry_observer_removals()
+            .times(usize::from(DETACH_RETRY_LIMIT))
+            .return_const(false);
+        let mut retry = ObserverDetachRetry::new(true);
+        retry.deadline = Instant::now();
+        let mut app = app_with_token();
+        let entity = app
+            .world_mut()
+            .spawn((Application::new(Box::new(mock)), ApplicationObserved, retry))
+            .id();
+        app.add_systems(Update, retry_observer_detaches);
+
+        for _ in 0..DETACH_RETRY_LIMIT {
+            app.world_mut()
+                .get_mut::<ObserverDetachRetry>(entity)
+                .unwrap()
+                .deadline = Instant::now();
+            app.update();
+        }
+
+        assert!(!app.world().entity(entity).contains::<ObserverDetachRetry>());
+        assert!(app.world().entity(entity).contains::<ApplicationObserved>());
+    }
+}

--- a/src/ecs/persistence.rs
+++ b/src/ecs/persistence.rs
@@ -1,0 +1,473 @@
+use std::io;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bevy::app::AppExit;
+use bevy::ecs::change_detection::DetectChanges;
+use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::lifecycle::RemovedComponents;
+use bevy::ecs::message::MessageReader;
+use bevy::ecs::query::{Changed, Has, Or};
+use bevy::ecs::resource::Resource;
+use bevy::ecs::system::{Commands, NonSend, Query, Res, ResMut};
+use tracing::{debug, warn};
+
+use super::layout::LayoutStrip;
+use super::params::Windows;
+use super::state::PaneruState;
+use super::{ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, Position, WidthRatio};
+use crate::config::Config;
+use crate::events::Event;
+use crate::manager::{Application, Display};
+use crate::platform::AxMainThread;
+
+const SAVE_DEBOUNCE: Duration = Duration::from_millis(250);
+const RETRY_INITIAL: Duration = Duration::from_secs(1);
+const RETRY_MAX: Duration = Duration::from_secs(60);
+
+pub(crate) trait StateStoreApi: Send + Sync {
+    fn load(&self) -> Option<PaneruState>;
+    fn save(&self, state: &PaneruState) -> io::Result<()>;
+}
+
+#[derive(Default)]
+struct FileStateStore;
+
+impl StateStoreApi for FileStateStore {
+    fn load(&self) -> Option<PaneruState> {
+        PaneruState::load_from_file(&PaneruState::default_state_file_path())
+    }
+
+    fn save(&self, state: &PaneruState) -> io::Result<()> {
+        state.save_to_file(&PaneruState::default_state_file_path())
+    }
+}
+
+#[derive(Resource)]
+pub(crate) struct PersistenceStore(Arc<dyn StateStoreApi>);
+
+impl Default for PersistenceStore {
+    fn default() -> Self {
+        Self(Arc::new(FileStateStore))
+    }
+}
+
+#[derive(Debug, Resource)]
+pub(crate) struct PersistenceState {
+    dirty: bool,
+    save_at: Option<Instant>,
+    retry_delay: Duration,
+}
+
+impl Default for PersistenceState {
+    fn default() -> Self {
+        Self {
+            dirty: false,
+            save_at: None,
+            retry_delay: RETRY_INITIAL,
+        }
+    }
+}
+
+impl PersistenceState {
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.save_at
+    }
+
+    fn mark_changed(&mut self, enabled: bool, now: Instant) {
+        if enabled {
+            self.dirty = true;
+            self.save_at = Some(now + SAVE_DEBOUNCE);
+            self.retry_delay = RETRY_INITIAL;
+        } else {
+            self.clear();
+        }
+    }
+
+    fn due(&self, now: Instant) -> bool {
+        self.dirty && self.save_at.is_some_and(|deadline| now >= deadline)
+    }
+
+    fn saved(&mut self) {
+        self.clear();
+    }
+
+    fn save_failed(&mut self, now: Instant) {
+        self.dirty = true;
+        self.save_at = Some(now + self.retry_delay);
+        self.retry_delay = self.retry_delay.saturating_mul(2).min(RETRY_MAX);
+    }
+
+    fn clear(&mut self) {
+        self.dirty = false;
+        self.save_at = None;
+        self.retry_delay = RETRY_INITIAL;
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn load_restore_state(
+    config: Res<Config>,
+    store: Option<Res<PersistenceStore>>,
+    mut commands: Commands,
+) {
+    if !config.restore_enabled() {
+        return;
+    }
+    if let Some(state) = store.and_then(|store| store.0.load()) {
+        commands.insert_resource(state);
+    }
+}
+
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments,
+    clippy::type_complexity
+)]
+pub(crate) fn track_dirty_state(
+    config: Res<Config>,
+    changed: Query<
+        (),
+        Or<(
+            Changed<LayoutStrip>,
+            Changed<Position>,
+            Changed<Bounds>,
+            Changed<WidthRatio>,
+            Changed<ChildOf>,
+            Changed<Display>,
+            Changed<ActiveWorkspaceMarker>,
+            Changed<ActiveDisplayMarker>,
+        )>,
+    >,
+    mut removed_strips: RemovedComponents<LayoutStrip>,
+    mut removed_positions: RemovedComponents<Position>,
+    mut removed_bounds: RemovedComponents<Bounds>,
+    mut removed_widths: RemovedComponents<WidthRatio>,
+    mut removed_parents: RemovedComponents<ChildOf>,
+    mut removed_displays: RemovedComponents<Display>,
+    mut removed_active_workspaces: RemovedComponents<ActiveWorkspaceMarker>,
+    mut removed_active_displays: RemovedComponents<ActiveDisplayMarker>,
+    mut identity_events: MessageReader<Event>,
+    mut state: ResMut<PersistenceState>,
+) {
+    let enabled = config.restore_enabled();
+    let removed = removed_strips.read().next().is_some()
+        || removed_positions.read().next().is_some()
+        || removed_bounds.read().next().is_some()
+        || removed_widths.read().next().is_some()
+        || removed_parents.read().next().is_some()
+        || removed_displays.read().next().is_some()
+        || removed_active_workspaces.read().next().is_some()
+        || removed_active_displays.read().next().is_some();
+    let identity_changed = identity_events
+        .read()
+        .any(|event| matches!(event, Event::WindowTitleChanged { .. }));
+    if !enabled {
+        state.mark_changed(false, Instant::now());
+    } else if config.is_changed() || !changed.is_empty() || removed || identity_changed {
+        state.mark_changed(true, Instant::now());
+    }
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub(crate) fn flush_due_state(
+    _main_thread: NonSend<AxMainThread>,
+    config: Res<Config>,
+    store: Option<Res<PersistenceStore>>,
+    mut state: ResMut<PersistenceState>,
+    snapshot: PersistenceSnapshot,
+) {
+    let now = Instant::now();
+    if !config.restore_enabled() || !state.due(now) {
+        return;
+    }
+    save_snapshot(store.as_deref(), &snapshot, &mut state, now);
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub(crate) fn flush_on_exit(
+    _main_thread: NonSend<AxMainThread>,
+    mut exits: MessageReader<AppExit>,
+    config: Res<Config>,
+    store: Option<Res<PersistenceStore>>,
+    mut state: ResMut<PersistenceState>,
+    snapshot: PersistenceSnapshot,
+) {
+    if exits.read().next().is_none() || !config.restore_enabled() || !state.is_dirty() {
+        return;
+    }
+    save_snapshot(store.as_deref(), &snapshot, &mut state, Instant::now());
+}
+
+#[derive(bevy::ecs::system::SystemParam)]
+#[allow(clippy::type_complexity)]
+pub(crate) struct PersistenceSnapshot<'w, 's> {
+    workspaces: Query<
+        'w,
+        's,
+        (
+            Option<&'static ChildOf>,
+            &'static LayoutStrip,
+            Option<&'static Position>,
+            Has<ActiveWorkspaceMarker>,
+        ),
+    >,
+    displays: Query<'w, 's, (&'static Display, Entity, Has<ActiveDisplayMarker>)>,
+    windows: Windows<'w, 's>,
+    apps: Query<'w, 's, &'static Application>,
+}
+
+fn save_snapshot(
+    store: Option<&PersistenceStore>,
+    snapshot: &PersistenceSnapshot,
+    state: &mut PersistenceState,
+    now: Instant,
+) {
+    let Some(store) = store else {
+        state.save_failed(now);
+        warn!("persistence store missing; retry scheduled");
+        return;
+    };
+    let snapshot = PaneruState::extract(
+        &snapshot.workspaces,
+        &snapshot.displays,
+        &snapshot.windows,
+        &snapshot.apps,
+    );
+    match store.0.save(&snapshot) {
+        Ok(()) => {
+            state.saved();
+            debug!("saved dirty state");
+        }
+        Err(err) => {
+            state.save_failed(now);
+            warn!(%err, "failed to save dirty state; retry scheduled");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PersistenceState, PersistenceStore, RETRY_INITIAL, SAVE_DEBOUNCE, StateStoreApi,
+        flush_due_state, flush_on_exit, load_restore_state, track_dirty_state,
+    };
+    use crate::config::Config;
+    use crate::ecs::Position;
+    use crate::ecs::state::PaneruState;
+    use crate::events::Event;
+    use crate::platform::AxMainThread;
+    use bevy::MinimalPlugins;
+    use bevy::app::{App, AppExit, Startup, Update};
+    use bevy::ecs::message::Messages;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::math::IVec2;
+    use std::io;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    #[derive(Default)]
+    struct TestStore {
+        loads: AtomicUsize,
+        saves: AtomicUsize,
+        fail_saves: AtomicBool,
+    }
+
+    impl StateStoreApi for TestStore {
+        fn load(&self) -> Option<PaneruState> {
+            self.loads.fetch_add(1, Ordering::Relaxed);
+            None
+        }
+
+        fn save(&self, _: &PaneruState) -> io::Result<()> {
+            self.saves.fetch_add(1, Ordering::Relaxed);
+            if self.fail_saves.load(Ordering::Relaxed) {
+                Err(io::Error::other("injected save failure"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn persistence_app(config: Config, store: Arc<TestStore>) -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Messages<AppExit>>()
+            .init_resource::<Messages<Event>>()
+            .init_resource::<PersistenceState>()
+            .insert_resource(config)
+            .insert_resource(PersistenceStore(store))
+            .insert_non_send_resource(AxMainThread::for_tests())
+            .add_systems(
+                Update,
+                (track_dirty_state, flush_due_state, flush_on_exit).chain(),
+            );
+        app
+    }
+
+    fn make_due(app: &mut App) {
+        app.world_mut().resource_mut::<PersistenceState>().save_at = Some(
+            Instant::now()
+                .checked_sub(Duration::from_millis(1))
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn trailing_debounce_moves_after_every_change() {
+        let now = Instant::now();
+        let mut state = PersistenceState::default();
+        state.mark_changed(true, now);
+        state.mark_changed(true, now + Duration::from_millis(200));
+        assert!(!state.due(now + SAVE_DEBOUNCE));
+        assert!(state.due(now + Duration::from_millis(200) + SAVE_DEBOUNCE));
+    }
+
+    #[test]
+    fn disabled_restore_never_keeps_dirty_work() {
+        let now = Instant::now();
+        let mut state = PersistenceState::default();
+        state.mark_changed(true, now);
+        state.mark_changed(false, now);
+        assert!(!state.is_dirty());
+        assert_eq!(state.next_deadline(), None);
+    }
+
+    #[test]
+    fn failed_save_stays_dirty_with_bounded_backoff() {
+        let now = Instant::now();
+        let mut state = PersistenceState::default();
+        state.mark_changed(true, now);
+        state.save_failed(now + SAVE_DEBOUNCE);
+        assert!(state.is_dirty());
+        assert_eq!(
+            state.next_deadline(),
+            Some(now + SAVE_DEBOUNCE + RETRY_INITIAL)
+        );
+    }
+
+    #[test]
+    fn schedule_continuous_mutation_does_not_save_until_quiet() {
+        let store = Arc::new(TestStore::default());
+        let mut app = persistence_app(Config::default(), Arc::clone(&store));
+        let entity = app.world_mut().spawn(Position(IVec2::ZERO)).id();
+        app.update();
+        make_due(&mut app);
+
+        app.world_mut()
+            .entity_mut(entity)
+            .get_mut::<Position>()
+            .unwrap()
+            .0
+            .x += 1;
+        app.update();
+        assert_eq!(store.saves.load(Ordering::Relaxed), 0);
+
+        make_due(&mut app);
+        app.update();
+        assert_eq!(store.saves.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn schedule_same_frame_change_and_exit_flushes_latest_state() {
+        let store = Arc::new(TestStore::default());
+        let mut app = persistence_app(Config::default(), Arc::clone(&store));
+        app.update();
+        app.world_mut().spawn(Position(IVec2::new(42, 0)));
+        app.world_mut()
+            .resource_mut::<Messages<AppExit>>()
+            .write(AppExit::Success);
+        app.update();
+        assert_eq!(store.saves.load(Ordering::Relaxed), 1);
+        assert!(!app.world().resource::<PersistenceState>().is_dirty());
+    }
+
+    #[test]
+    fn disabled_restore_never_reads_or_writes_store() {
+        let config = Config::try_from(
+            r"
+[options]
+
+[restore]
+enabled = false
+
+[bindings]
+",
+        )
+        .unwrap();
+        let store = Arc::new(TestStore::default());
+        let mut app = persistence_app(config, Arc::clone(&store));
+        app.add_systems(Startup, load_restore_state);
+        app.world_mut().spawn(Position(IVec2::new(7, 0)));
+        app.world_mut()
+            .resource_mut::<Messages<AppExit>>()
+            .write(AppExit::Success);
+        app.update();
+        assert_eq!(store.loads.load(Ordering::Relaxed), 0);
+        assert_eq!(store.saves.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn failed_due_save_is_retried_immediately_on_shutdown() {
+        let store = Arc::new(TestStore::default());
+        store.fail_saves.store(true, Ordering::Relaxed);
+        let mut app = persistence_app(Config::default(), Arc::clone(&store));
+        app.update();
+        make_due(&mut app);
+        app.update();
+        assert_eq!(store.saves.load(Ordering::Relaxed), 1);
+        assert!(app.world().resource::<PersistenceState>().is_dirty());
+
+        store.fail_saves.store(false, Ordering::Relaxed);
+        app.world_mut()
+            .resource_mut::<Messages<AppExit>>()
+            .write(AppExit::Success);
+        app.update();
+        assert_eq!(store.saves.load(Ordering::Relaxed), 2);
+        assert!(!app.world().resource::<PersistenceState>().is_dirty());
+    }
+
+    #[test]
+    fn expired_dirty_state_without_store_uses_backoff_instead_of_zero_wait() {
+        let store = Arc::new(TestStore::default());
+        let mut app = persistence_app(Config::default(), store);
+        app.update();
+        make_due(&mut app);
+        app.world_mut().remove_resource::<PersistenceStore>();
+        let before = Instant::now();
+
+        app.update();
+
+        let state = app.world().resource::<PersistenceState>();
+        assert!(state.is_dirty());
+        assert!(
+            state
+                .next_deadline()
+                .is_some_and(|deadline| deadline > before)
+        );
+    }
+
+    #[test]
+    fn production_title_notification_marks_restore_identity_dirty() {
+        let store = Arc::new(TestStore::default());
+        let mut app = persistence_app(Config::default(), store);
+        app.update();
+        let window_id: crate::platform::WinID = 7;
+        let event =
+            crate::platform::notify::window_title_event_from_bytes(&window_id.to_ne_bytes())
+                .expect("CGS title payload should produce a persistence event");
+        app.world_mut()
+            .resource_mut::<Messages<Event>>()
+            .write(event);
+
+        app.update();
+
+        assert!(app.world().resource::<PersistenceState>().is_dirty());
+    }
+}

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
@@ -7,7 +7,6 @@ use bevy::ecs::observer::On;
 use bevy::ecs::query::Has;
 use bevy::ecs::resource::Resource;
 use bevy::ecs::system::{Commands, Query, Res, ResMut};
-use bevy::time::{Time, Timer, TimerMode, Virtual};
 use objc2_core_graphics::CGDirectDisplayID;
 use tracing::{Level, info, instrument, warn};
 
@@ -28,24 +27,40 @@ use crate::platform::{Pid, WinID, WorkspaceId};
 #[derive(Debug, Resource)]
 pub(crate) struct SessionRestore {
     state: PaneruState,
-    timer: Timer,
+    deadline: Instant,
     saved_hard_keys: HashSet<WindowHardMatchKey>,
 }
 
 impl SessionRestore {
     fn new(state: PaneruState, grace: Duration) -> Self {
+        Self::new_at(state, grace, Instant::now())
+    }
+
+    fn new_at(state: PaneruState, grace: Duration, now: Instant) -> Self {
         let saved_hard_keys = saved_hard_match_keys(&state);
         Self {
             state,
-            timer: Timer::new(grace, TimerMode::Once),
+            deadline: now + grace,
             saved_hard_keys,
         }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.deadline
+    }
+
+    fn expired(&self, now: Instant) -> bool {
+        now >= self.deadline
+    }
+
+    #[cfg(test)]
+    pub(crate) fn expire_now(&mut self) {
+        self.deadline = Instant::now();
     }
 }
 
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn tick_restore_grace(
-    time: Res<Time<Virtual>>,
     mut session: Option<ResMut<SessionRestore>>,
     mut commands: Commands,
 ) {
@@ -53,8 +68,7 @@ pub(super) fn tick_restore_grace(
         return;
     };
 
-    session.timer.tick(time.delta());
-    if session.timer.is_finished() {
+    if session.expired(Instant::now()) {
         info!("Session restore grace period ended");
         commands.remove_resource::<SessionRestore>();
         commands.remove_resource::<PaneruState>();
@@ -130,15 +144,22 @@ pub(crate) struct PlannedStrip {
     pub display_id: Option<CGDirectDisplayID>,
     pub virtual_index: u32,
     pub columns: Vec<PlannedColumn>,
+    pub position_x: Option<i32>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct SavedGeometry {
+    pub width_ratio: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct RestorePlan {
     pub strips: Vec<PlannedStrip>,
     pub active_virtual_by_workspace: HashMap<WorkspaceId, u32>,
     pub consumed_entities: HashSet<Entity>,
     pub ignored_missing_windows: usize,
     pub skipped_ambiguous_matches: usize,
+    pub geometry: HashMap<Entity, SavedGeometry>,
 }
 
 pub(crate) struct RestorePlanner<'a> {
@@ -197,6 +218,11 @@ impl<'a> RestorePlanner<'a> {
             display_id: workspace.display_id,
             virtual_index: strip.virtual_index,
             columns,
+            position_x: strip
+                .columns
+                .iter()
+                .flat_map(saved_windows_in_column)
+                .find_map(|window| window.strip_position_x),
         })
     }
 
@@ -256,6 +282,12 @@ impl<'a> RestorePlanner<'a> {
                 && saved.hard_match(window.window_id, window.pid, &window.bundle_id)
         }) {
             plan.consumed_entities.insert(window.entity);
+            plan.geometry.insert(
+                window.entity,
+                SavedGeometry {
+                    width_ratio: saved.width_ratio,
+                },
+            );
             return Some(window.entity);
         }
 
@@ -271,6 +303,12 @@ impl<'a> RestorePlanner<'a> {
         match fallback_matches.as_slice() {
             [window] => {
                 plan.consumed_entities.insert(window.entity);
+                plan.geometry.insert(
+                    window.entity,
+                    SavedGeometry {
+                        width_ratio: saved.width_ratio,
+                    },
+                );
                 Some(window.entity)
             }
             [] => {
@@ -527,7 +565,11 @@ pub(super) fn restore_window_state(
         }
 
         let origin = if is_global_active {
-            display.bounds().min
+            let mut origin = display.bounds().min;
+            if let Some(saved_x) = planned.position_x {
+                origin.x = saved_x;
+            }
+            origin
         } else {
             display.bounds().max - 10
         };
@@ -543,6 +585,25 @@ pub(super) fn restore_window_state(
             spawned.insert(previous);
         }
         restored_strips += 1;
+
+        for entity in planned.columns.iter().flat_map(planned_column_entities) {
+            if let Some(width_ratio) = plan
+                .geometry
+                .get(&entity)
+                .and_then(|geometry| geometry.width_ratio)
+                && width_ratio.is_finite()
+                && width_ratio > 0.0
+                && let Some(size) = windows.size(entity)
+            {
+                commands.resize_entity(
+                    entity,
+                    crate::manager::Size::new(
+                        (f64::from(display.bounds().width()) * width_ratio).round() as i32,
+                        size.y,
+                    ),
+                );
+            }
+        }
     }
 
     info!(
@@ -552,6 +613,19 @@ pub(super) fn restore_window_state(
         plan.ignored_missing_windows,
         plan.skipped_ambiguous_matches
     );
+}
+
+fn planned_column_entities(column: &PlannedColumn) -> Box<dyn Iterator<Item = Entity> + '_> {
+    match column {
+        PlannedColumn::Single(entity) | PlannedColumn::Fullscreen(entity) => {
+            Box::new(std::iter::once(*entity))
+        }
+        PlannedColumn::Tabs(tabs) => Box::new(tabs.iter().copied()),
+        PlannedColumn::Stack(items) => Box::new(items.iter().flat_map(|item| match item {
+            PlannedStackItem::Single(entity) => vec![*entity],
+            PlannedStackItem::Tabs(tabs) => tabs.clone(),
+        })),
+    }
 }
 
 fn layout_strip_from_plan(planned: &PlannedStrip) -> LayoutStrip {
@@ -734,5 +808,33 @@ fn compact_stack_items(items: Vec<PlannedStackItem>) -> Option<PlannedColumn> {
         [PlannedStackItem::Single(entity)] => Some(PlannedColumn::Single(*entity)),
         [PlannedStackItem::Tabs(entities)] => Some(PlannedColumn::Tabs(entities.clone())),
         _ => Some(PlannedColumn::Stack(items)),
+    }
+}
+
+#[cfg(test)]
+mod deadline_tests {
+    use std::time::{Duration, Instant};
+
+    use super::SessionRestore;
+    use crate::ecs::state::PaneruState;
+
+    #[test]
+    fn restore_grace_fires_at_one_absolute_monotonic_deadline() {
+        let now = Instant::now();
+        let grace = Duration::from_millis(50);
+        let restore = SessionRestore::new_at(
+            PaneruState {
+                version: 2,
+                timestamp: 0,
+                active_display_id: None,
+                displays: Vec::new(),
+                workspaces: Vec::new(),
+            },
+            grace,
+            now,
+        );
+        assert_eq!(restore.next_deadline(), now + grace);
+        assert!(!restore.expired(now + grace.checked_sub(Duration::from_nanos(1)).unwrap()));
+        assert!(restore.expired(now + grace));
     }
 }

--- a/src/ecs/runtime.rs
+++ b/src/ecs/runtime.rs
@@ -1,0 +1,596 @@
+use std::pin::Pin;
+use std::sync::mpsc::TryRecvError;
+use std::time::{Duration, Instant};
+
+use bevy::app::AppExit;
+use bevy::ecs::component::Component;
+use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::message::MessageWriter;
+use bevy::ecs::query::{With, Without};
+use bevy::ecs::resource::Resource;
+use bevy::ecs::system::{NonSend, NonSendMut, Query, Res, ResMut, SystemParam};
+use bevy::time::{Real, Time};
+
+use super::{
+    ActiveWorkspaceMarker, FlashMessage, FocusedMarker, FreshMarker, Initializing,
+    RefreshWindowSizes, RepositionMarker, ResizeMarker, RetryFrontSwitch, Scrolling, Timeout,
+    VerifyWindowPosition,
+};
+use crate::ecs::observation::ObserverDetachRetry;
+use crate::events::{Event, EventReceiver};
+use crate::manager::Window;
+use crate::menubar::MenuBarManager;
+use crate::platform::PlatformCallbacks;
+
+pub(crate) const ACTIVE_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+const FRESH_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const ORPHAN_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+const FOCUS_RECOVERY_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Component, Debug)]
+pub(crate) struct FreshPollDeadline(Instant);
+
+impl Default for FreshPollDeadline {
+    fn default() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl FreshPollDeadline {
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn schedule_next(&mut self, now: Instant) {
+        self.0 = now + FRESH_POLL_INTERVAL;
+    }
+
+    fn next_deadline(&self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Component, Debug)]
+pub(crate) struct OrphanReconcileDeadline(Instant);
+
+impl Default for OrphanReconcileDeadline {
+    fn default() -> Self {
+        Self(Instant::now() + ORPHAN_RECONCILE_INTERVAL)
+    }
+}
+
+impl OrphanReconcileDeadline {
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn schedule_next(&mut self, now: Instant) {
+        self.0 = now + ORPHAN_RECONCILE_INTERVAL;
+    }
+
+    fn next_deadline(&self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Resource, Debug)]
+pub(crate) struct FocusRecoveryDeadline(Instant);
+
+impl Default for FocusRecoveryDeadline {
+    fn default() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl FocusRecoveryDeadline {
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn schedule_next(&mut self, now: Instant) {
+        self.0 = now + FOCUS_RECOVERY_INTERVAL;
+    }
+
+    fn next_deadline(&self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RuntimeActivity {
+    pub frame_work: bool,
+    pub nearest_deadline: Option<Instant>,
+}
+
+/// Latches synthetic Bevy messages produced after the `First`-stage native
+/// event pump. The next pump consumes the latch and skips its blocking wait so
+/// those already-published messages reach their readers without requiring an
+/// unrelated native wake.
+#[derive(Resource, Debug, Default)]
+pub(super) struct SyntheticEventPending(bool);
+
+impl SyntheticEventPending {
+    pub(super) fn mark(&mut self) {
+        self.0 = true;
+    }
+
+    fn take(&mut self) -> bool {
+        std::mem::take(&mut self.0)
+    }
+}
+
+impl RuntimeActivity {
+    pub(crate) fn wait(self, now: Instant) -> Option<Duration> {
+        if self.frame_work {
+            Some(ACTIVE_FRAME_INTERVAL)
+        } else {
+            self.nearest_deadline
+                .map(|deadline| deadline.saturating_duration_since(now))
+        }
+    }
+
+    pub(crate) fn nearest(deadlines: impl IntoIterator<Item = Option<Instant>>) -> Option<Instant> {
+        deadlines.into_iter().flatten().min()
+    }
+}
+
+#[derive(SystemParam)]
+pub(super) struct RuntimeWork<'w, 's> {
+    repositioning: Query<'w, 's, (), With<RepositionMarker>>,
+    resizing: Query<'w, 's, (), With<ResizeMarker>>,
+    scrolling: Query<'w, 's, (), With<Scrolling>>,
+    flash_messages: Query<'w, 's, (), With<FlashMessage>>,
+    timeouts: Query<'w, 's, &'static Timeout>,
+    fresh_polls: Query<'w, 's, &'static FreshPollDeadline, With<FreshMarker>>,
+    refreshes: Query<'w, 's, &'static RefreshWindowSizes, With<ActiveWorkspaceMarker>>,
+    observer_detaches: Query<'w, 's, &'static ObserverDetachRetry>,
+    orphan_checks: Query<'w, 's, &'static OrphanReconcileDeadline, Without<ChildOf>>,
+    windows: Query<'w, 's, (), With<Window>>,
+    focused_windows: Query<'w, 's, (), (With<Window>, With<FocusedMarker>)>,
+    focus_recovery: Option<Res<'w, FocusRecoveryDeadline>>,
+    retries: Query<'w, 's, &'static RetryFrontSwitch>,
+    verifications: Query<'w, 's, &'static VerifyWindowPosition>,
+    initializing: Option<Res<'w, Initializing>>,
+    restore: Option<Res<'w, crate::ecs::restore::SessionRestore>>,
+    persistence: Option<Res<'w, crate::ecs::persistence::PersistenceState>>,
+    menu_bar: Option<NonSend<'w, MenuBarManager>>,
+}
+
+fn runtime_activity(work: &RuntimeWork<'_, '_>, now: Instant) -> RuntimeActivity {
+    let timeout_deadline = work.timeouts.iter().map(Timeout::next_deadline).min();
+    let fresh_poll_deadline = work
+        .fresh_polls
+        .iter()
+        .map(FreshPollDeadline::next_deadline)
+        .min();
+    let refresh_deadline = work
+        .refreshes
+        .iter()
+        .map(RefreshWindowSizes::next_deadline)
+        .min();
+    let observer_detach_deadline = work
+        .observer_detaches
+        .iter()
+        .map(ObserverDetachRetry::next_deadline)
+        .min();
+    let orphan_deadline = work
+        .orphan_checks
+        .iter()
+        .map(OrphanReconcileDeadline::next_deadline)
+        .min();
+    let focus_recovery_deadline = (!work.windows.is_empty() && work.focused_windows.is_empty())
+        .then(|| {
+            work.focus_recovery
+                .as_deref()
+                .map(FocusRecoveryDeadline::next_deadline)
+        })
+        .flatten();
+    let retry_deadline = work
+        .retries
+        .iter()
+        .map(RetryFrontSwitch::next_deadline)
+        .min();
+    let verification_deadline = work
+        .verifications
+        .iter()
+        .map(VerifyWindowPosition::next_deadline)
+        .min();
+    let restore_deadline = work
+        .restore
+        .as_deref()
+        .map(super::restore::SessionRestore::next_deadline);
+    let persistence_deadline = work
+        .persistence
+        .as_deref()
+        .and_then(crate::ecs::persistence::PersistenceState::next_deadline);
+    let updater_deadline = work
+        .menu_bar
+        .as_deref()
+        .and_then(MenuBarManager::updater_deadline);
+    let immediate_deferred = work
+        .initializing
+        .is_some()
+        .then_some(now + ACTIVE_FRAME_INTERVAL);
+    RuntimeActivity {
+        frame_work: !work.repositioning.is_empty()
+            || !work.resizing.is_empty()
+            || !work.scrolling.is_empty()
+            || !work.flash_messages.is_empty(),
+        nearest_deadline: RuntimeActivity::nearest([
+            timeout_deadline,
+            fresh_poll_deadline,
+            refresh_deadline,
+            observer_detach_deadline,
+            orphan_deadline,
+            focus_recovery_deadline,
+            retry_deadline,
+            verification_deadline,
+            restore_deadline,
+            persistence_deadline,
+            updater_deadline,
+            immediate_deferred,
+        ]),
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn pump_events(
+    mut exit: MessageWriter<AppExit>,
+    mut messages: MessageWriter<Event>,
+    incoming_events: Option<NonSend<EventReceiver>>,
+    platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
+    mut real_time: Option<ResMut<Time<Real>>>,
+    mut synthetic_events: ResMut<SyntheticEventPending>,
+    work: RuntimeWork,
+) {
+    let Some((ref mut platform, incoming_events)) = platform.zip(incoming_events) else {
+        // No platform interface or incoming event pipe - probably executing in a unit test.
+        return;
+    };
+
+    let now = Instant::now();
+    let activity = runtime_activity(&work, now);
+    let synthetic_pending = synthetic_events.take();
+    let (received_events, should_exit, did_wait) =
+        pump_receiver(&incoming_events, activity, now, synthetic_pending, |wait| {
+            platform.pump_cocoa_event_loop(wait);
+        });
+    if did_wait && let Some(real_time) = real_time.as_mut() {
+        real_time.update_with_instant(Instant::now());
+    }
+    if should_exit {
+        exit.write(AppExit::Success);
+    }
+    messages.write_batch(received_events);
+}
+
+fn pump_receiver(
+    receiver: &EventReceiver,
+    activity: RuntimeActivity,
+    now: Instant,
+    synthetic_pending: bool,
+    mut pump: impl FnMut(Option<Duration>),
+) -> (Vec<Event>, bool, bool) {
+    let generation_before_drain = receiver.generation();
+    let (mut received_events, mut should_exit) = drain_event_channel(receiver);
+    let should_wait = !synthetic_pending
+        && received_events.is_empty()
+        && !should_exit
+        && receiver.generation() == generation_before_drain;
+    if should_wait {
+        pump(activity.wait(now));
+        let (after_wait, exit_after_wait) = drain_event_channel(receiver);
+        received_events = after_wait;
+        should_exit = exit_after_wait;
+    }
+    (received_events, should_exit, should_wait)
+}
+
+fn drain_event_channel(receiver: &EventReceiver) -> (Vec<Event>, bool) {
+    let mut received_events = Vec::new();
+    let mut pending_mouse = None;
+    let mut should_exit = false;
+    loop {
+        match receiver.try_recv() {
+            Ok(Event::Exit) | Err(TryRecvError::Disconnected) => {
+                should_exit = true;
+                break;
+            }
+            Ok(event) if matches!(event, Event::MouseMoved { .. }) => {
+                pending_mouse = Some(event);
+            }
+            Ok(event) => {
+                received_events.extend(pending_mouse.take());
+                received_events.push(event);
+            }
+            Err(TryRecvError::Empty) => break,
+        }
+    }
+    received_events.extend(pending_mouse);
+    (received_events, should_exit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ACTIVE_FRAME_INTERVAL, FreshPollDeadline, RuntimeActivity, RuntimeWork,
+        SyntheticEventPending, pump_receiver, runtime_activity,
+    };
+    use crate::ecs::{ActiveWorkspaceMarker, RefreshWindowSizes, Scrolling, SendMessageTrigger};
+    use crate::events::{Event, EventReceiver, EventSender};
+    use bevy::app::{App, First, PostUpdate, PreUpdate, Update};
+    use bevy::ecs::message::{MessageReader, MessageWriter, Messages};
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::ecs::system::{Commands, Local, NonSend, Res, ResMut};
+    use bevy::time::{Real, Time, TimeSystems, Virtual};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn idle_runtime_has_no_periodic_deadline() {
+        let now = Instant::now();
+        assert_eq!(
+            RuntimeActivity {
+                frame_work: false,
+                nearest_deadline: None,
+            }
+            .wait(now),
+            None
+        );
+    }
+
+    #[test]
+    fn frame_work_and_real_deadlines_have_distinct_waits() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(3);
+        assert_eq!(
+            RuntimeActivity {
+                frame_work: true,
+                nearest_deadline: Some(deadline),
+            }
+            .wait(now),
+            Some(ACTIVE_FRAME_INTERVAL)
+        );
+        assert_eq!(
+            RuntimeActivity {
+                frame_work: false,
+                nearest_deadline: Some(deadline),
+            }
+            .wait(now),
+            Some(Duration::from_secs(3))
+        );
+    }
+
+    #[test]
+    fn absolute_deadline_is_charged_once_after_sleep() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_millis(50);
+        let activity = RuntimeActivity {
+            frame_work: false,
+            nearest_deadline: Some(deadline),
+        };
+        assert_eq!(activity.wait(now), Some(Duration::from_millis(50)));
+        assert_eq!(activity.wait(deadline), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn deferred_deadline_wakes_real_pump_core_and_delivers_event() {
+        let (sender, receiver) = EventSender::new();
+        let now = Instant::now();
+        let activity = RuntimeActivity {
+            frame_work: false,
+            nearest_deadline: Some(now + Duration::from_millis(25)),
+        };
+        let mut observed_wait = None;
+
+        let (events, should_exit, did_wait) =
+            pump_receiver(&receiver, activity, now, false, |wait| {
+                observed_wait = wait;
+                sender
+                    .send(Event::UpdaterStatusChanged)
+                    .expect("deadline wake event should send");
+            });
+
+        assert_eq!(observed_wait, Some(Duration::from_millis(25)));
+        assert!(!should_exit);
+        assert!(did_wait);
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, Event::UpdaterStatusChanged))
+        );
+    }
+
+    #[test]
+    fn fresh_poll_exposes_monotonic_retry_deadline() {
+        let mut poll = FreshPollDeadline(Instant::now());
+        let now = poll.next_deadline();
+        assert!(poll.due(now));
+        poll.schedule_next(now);
+        assert_eq!(poll.next_deadline(), now + Duration::from_millis(50));
+        assert!(!poll.due(now));
+    }
+
+    #[derive(Resource, Default)]
+    struct CapturedActivity(Option<RuntimeActivity>);
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn capture_activity(work: RuntimeWork, mut captured: ResMut<CapturedActivity>) {
+        captured.0 = Some(runtime_activity(&work, Instant::now()));
+    }
+
+    #[test]
+    fn inactive_past_due_refresh_does_not_force_zero_wait() {
+        let now = Instant::now();
+        let active_deadline = now + Duration::from_secs(2);
+        let mut app = App::new();
+        app.init_resource::<CapturedActivity>()
+            .add_systems(Update, capture_activity);
+        app.world_mut().spawn(RefreshWindowSizes(now));
+        app.world_mut()
+            .spawn((RefreshWindowSizes(active_deadline), ActiveWorkspaceMarker));
+
+        app.update();
+
+        let activity = app.world().resource::<CapturedActivity>().0.unwrap();
+        assert_eq!(activity.nearest_deadline, Some(active_deadline));
+        assert!(activity.wait(now).is_some_and(|wait| wait > Duration::ZERO));
+    }
+
+    #[derive(Resource, Default)]
+    struct ScrollProbe(f64);
+
+    fn simulate_idle_wait_once(mut once: Local<bool>, mut real_time: ResMut<Time<Real>>) {
+        if *once {
+            return;
+        }
+        *once = true;
+        std::thread::sleep(Duration::from_millis(40));
+        real_time.update_with_instant(Instant::now());
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn advance_scroll_probe(time: Res<Time<Virtual>>, mut probe: ResMut<ScrollProbe>) {
+        probe.0 += time.delta_secs_f64() * 1_000.0;
+    }
+
+    #[test]
+    fn long_idle_wait_is_not_charged_to_next_scroll_frame() {
+        let mut app = App::new();
+        app.add_plugins(bevy::MinimalPlugins)
+            .init_resource::<ScrollProbe>()
+            .add_systems(PreUpdate, simulate_idle_wait_once)
+            .add_systems(Update, advance_scroll_probe);
+        app.world_mut().spawn(Scrolling::default());
+
+        app.update();
+        app.update();
+
+        assert!(
+            app.world().resource::<ScrollProbe>().0 < 20.0,
+            "40ms idle wait leaked into the next animation delta"
+        );
+    }
+
+    #[derive(Resource, Default)]
+    struct EventPipelineProbe {
+        waits: usize,
+        first_reader: usize,
+        second_reader: usize,
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn publish_native_events(
+        receiver: NonSend<EventReceiver>,
+        mut messages: MessageWriter<Event>,
+        mut synthetic_events: ResMut<SyntheticEventPending>,
+        mut probe: ResMut<EventPipelineProbe>,
+    ) {
+        let activity = RuntimeActivity {
+            frame_work: false,
+            nearest_deadline: None,
+        };
+        let synthetic_pending = synthetic_events.take();
+        let (events, _, _) = pump_receiver(
+            &receiver,
+            activity,
+            Instant::now(),
+            synthetic_pending,
+            |_| {
+                probe.waits += 1;
+            },
+        );
+        messages.write_batch(events);
+    }
+
+    fn write_synthetic_after_pump(mut written: Local<bool>, mut commands: Commands) {
+        if *written {
+            return;
+        }
+        *written = true;
+        commands.trigger(SendMessageTrigger(Event::UpdaterStatusChanged));
+    }
+
+    fn first_native_reader(
+        mut messages: MessageReader<Event>,
+        mut probe: ResMut<EventPipelineProbe>,
+    ) {
+        probe.first_reader += messages
+            .read()
+            .filter(|event| matches!(event, Event::UpdaterStatusChanged))
+            .count();
+    }
+
+    fn second_native_reader(
+        mut messages: MessageReader<Event>,
+        mut probe: ResMut<EventPipelineProbe>,
+    ) {
+        probe.second_reader += messages
+            .read()
+            .filter(|event| matches!(event, Event::UpdaterStatusChanged))
+            .count();
+    }
+
+    #[test]
+    fn first_stage_pump_publishes_before_every_preupdate_reader() {
+        let (sender, receiver) = EventSender::new();
+        sender.send(Event::UpdaterStatusChanged).unwrap();
+        let mut app = App::new();
+        app.add_plugins(bevy::MinimalPlugins)
+            .init_resource::<Messages<Event>>()
+            .init_resource::<EventPipelineProbe>()
+            .init_resource::<SyntheticEventPending>()
+            .insert_non_send_resource(receiver)
+            .add_systems(
+                First,
+                publish_native_events
+                    .after(TimeSystems)
+                    .after(bevy::ecs::message::message_update_system),
+            )
+            .add_systems(PreUpdate, (first_native_reader, second_native_reader));
+
+        app.update();
+
+        let probe = app.world().resource::<EventPipelineProbe>();
+        assert_eq!(probe.waits, 0, "queued native work must prevent sleeping");
+        assert_eq!(probe.first_reader, 1);
+        assert_eq!(probe.second_reader, 1);
+    }
+
+    #[test]
+    fn synthetic_event_after_pump_prevents_next_frame_wait() {
+        let (_sender, receiver) = EventSender::new();
+        let mut app = App::new();
+        app.add_plugins(bevy::MinimalPlugins)
+            .init_resource::<Messages<Event>>()
+            .init_resource::<EventPipelineProbe>()
+            .init_resource::<SyntheticEventPending>()
+            .insert_non_send_resource(receiver)
+            .add_observer(crate::ecs::triggers::send_message_trigger)
+            .add_systems(
+                First,
+                publish_native_events
+                    .after(TimeSystems)
+                    .after(bevy::ecs::message::message_update_system),
+            )
+            .add_systems(PreUpdate, first_native_reader)
+            .add_systems(PostUpdate, write_synthetic_after_pump);
+
+        app.update();
+        let waits_after_first_pump = app.world().resource::<EventPipelineProbe>().waits;
+        assert_eq!(
+            app.world().resource::<EventPipelineProbe>().first_reader,
+            0,
+            "synthetic event is intentionally produced after the first pump"
+        );
+
+        app.update();
+
+        let probe = app.world().resource::<EventPipelineProbe>();
+        assert_eq!(
+            probe.waits, waits_after_first_pump,
+            "latched synthetic work must prevent the next pump from waiting"
+        );
+        assert_eq!(probe.first_reader, 1);
+    }
+}

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -63,8 +63,10 @@ fn swipe_gesture(
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
     let mut total_delta = 0.0;
+    let mut gesture_delta = 0.0;
     let mut touchpad_down = false;
     let mut has_scroll_event = false;
+    let mut has_gesture_event = false;
 
     // Normalization: Touchpad deltas are typically small fractions.
     // Scroll wheel deltas can be larger. We scale it down slightly
@@ -91,7 +93,9 @@ fn swipe_gesture(
                     .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 total_delta += delta;
+                gesture_delta += delta;
                 has_scroll_event = true;
+                has_gesture_event = true;
             }
             _ => (),
         }
@@ -117,15 +121,21 @@ fn swipe_gesture(
         };
 
         let dt = time.delta_secs_f64();
-        let new_velocity = if dt > 0.0 {
-            total_delta * swipe_sensitivity / dt
+        let new_velocity = if has_gesture_event && dt > 0.0 {
+            gesture_delta * swipe_sensitivity / dt
         } else {
             0.0
         };
 
         if let Some(scrolling) = scrolling.as_mut() {
-            // Smoothen velocity changes using EMA.
-            scrolling.velocity = 0.3 * new_velocity + 0.7 * scrolling.velocity;
+            // Native modifier-scroll events already include macOS momentum.
+            // Add synthetic inertia only for raw multi-finger gestures.
+            scrolling.velocity = if has_gesture_event {
+                // Smoothen gesture velocity changes using EMA.
+                0.3 * new_velocity + 0.7 * scrolling.velocity
+            } else {
+                0.0
+            };
             scrolling.is_user_swiping = true;
             scrolling.last_event = Instant::now();
             scrolling.position +=
@@ -135,7 +145,7 @@ fn swipe_gesture(
                 velocity: new_velocity,
                 position: f64::from(position.0.x)
                     + total_delta * viewport_width * direction_modifier * swipe_sensitivity,
-                is_user_swiping: touchpad_down,
+                is_user_swiping: true,
                 last_event: Instant::now(),
             });
         }

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -24,6 +24,9 @@ use crate::platform::Modifiers;
 
 pub struct ScrollEventsPlugin;
 
+const NATIVE_SCROLL_RESPONSE_SECONDS: f64 = 0.04;
+const NATIVE_SCROLL_SETTLE_PX: f64 = 0.25;
+
 impl Plugin for ScrollEventsPlugin {
     fn build(&self, app: &mut App) {
         let mission_control_inactive = |mission_control: Option<Res<MissionControlActive>>| {
@@ -62,7 +65,8 @@ fn swipe_gesture(
     mut commands: Commands,
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
-    let mut total_delta = 0.0;
+    let snap_enabled = config.sticky_scroll() || config.auto_center();
+    let mut scroll_delta = 0.0;
     let mut gesture_delta = 0.0;
     let mut touchpad_down = false;
     let mut has_scroll_event = false;
@@ -81,10 +85,9 @@ fn swipe_gesture(
         match event {
             Event::TouchpadDown => {
                 touchpad_down = true;
-                total_delta = 0.0;
             }
             Event::Scroll { delta } => {
-                total_delta += *delta * scroll_scale;
+                scroll_delta += *delta * scroll_scale;
                 has_scroll_event = true;
             }
             Event::Swipe { delta, fingers }
@@ -92,8 +95,7 @@ fn swipe_gesture(
                     .swipe_gesture_fingers()
                     .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
-                total_delta += delta;
-                gesture_delta += delta;
+                gesture_delta += *delta;
                 has_scroll_event = true;
                 has_gesture_event = true;
             }
@@ -109,6 +111,8 @@ fn swipe_gesture(
 
     if touchpad_down && let Some(scrolling) = scrolling.as_mut() {
         scrolling.velocity = 0.0;
+        scrolling.target_position = None;
+        scrolling.snap_pending = snap_enabled;
         scrolling.is_user_swiping = true;
         scrolling.last_event = Instant::now();
     }
@@ -126,8 +130,13 @@ fn swipe_gesture(
         } else {
             0.0
         };
+        let gesture_distance =
+            gesture_delta * viewport_width * direction_modifier * swipe_sensitivity;
+        let scroll_distance =
+            scroll_delta * viewport_width * direction_modifier * swipe_sensitivity;
 
         if let Some(scrolling) = scrolling.as_mut() {
+            let was_user_swiping = scrolling.is_user_swiping;
             // Native modifier-scroll events already include macOS momentum.
             // Add synthetic inertia only for raw multi-finger gestures.
             scrolling.velocity = if has_gesture_event {
@@ -137,15 +146,32 @@ fn swipe_gesture(
                 0.0
             };
             scrolling.is_user_swiping = true;
+            scrolling.snap_pending = snap_enabled;
             scrolling.last_event = Instant::now();
-            scrolling.position +=
-                total_delta * viewport_width * direction_modifier * swipe_sensitivity;
+
+            if has_gesture_event {
+                scrolling.target_position = None;
+                scrolling.position += gesture_distance;
+            }
+
+            if scroll_delta != 0.0 {
+                // A new physical gesture interrupts an in-flight sticky snap.
+                // Native momentum events keep extending the same target.
+                if !was_user_swiping {
+                    scrolling.target_position = None;
+                }
+                let target = scrolling.target_position.unwrap_or(scrolling.position);
+                scrolling.target_position = Some(target + scroll_distance);
+            }
         } else if let Ok(mut entity_commands) = commands.get_entity(*entity) {
+            let initial_position = f64::from(position.0.x) + gesture_distance;
             entity_commands.try_insert(Scrolling {
                 velocity: new_velocity,
-                position: f64::from(position.0.x)
-                    + total_delta * viewport_width * direction_modifier * swipe_sensitivity,
-                is_user_swiping: true,
+                position: initial_position,
+                target_position: (scroll_delta != 0.0)
+                    .then_some(initial_position + scroll_distance),
+                snap_pending: snap_enabled,
+                is_user_swiping: touchpad_down || has_scroll_event,
                 last_event: Instant::now(),
             });
         }
@@ -171,6 +197,8 @@ pub(super) fn swiping_timeout(
             scroll.is_user_swiping = false;
 
             if scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
+                && scroll.target_position.is_none()
+                && !scroll.snap_pending
                 && let Ok(mut entity_commands) = commands.get_entity(entity)
             {
                 entity_commands.try_remove::<Scrolling>();
@@ -214,12 +242,13 @@ fn apply_snap_force(
     active_display: ActiveDisplay,
     windows: Windows,
     config: Res<Config>,
-    time: Res<Time>,
 ) {
-    const CENTER_MAGNETIC_FORCE: f64 = 10.0;
     const SNAP_DISPLAY_RATIO: f64 = 0.45;
 
-    if !config.auto_center() {
+    let (layout_strip, position, ref mut scroll) = *strip;
+    let sticky = config.sticky_scroll();
+    if !sticky && !config.auto_center() {
+        scroll.snap_pending = false;
         return;
     }
 
@@ -227,12 +256,11 @@ fn apply_snap_force(
     let viewport_center = viewport.center().x;
     let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
 
-    let (strip, position, ref mut scroll) = *strip;
-    if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 {
+    if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 || scroll.target_position.is_some() {
         return;
     }
 
-    let target_offset = strip
+    let target_offset = layout_strip
         .all_columns()
         .into_iter()
         .filter_map(|entity| {
@@ -249,9 +277,12 @@ fn apply_snap_force(
         .unwrap_or(position.x);
 
     let dist_to_snap = f64::from(position.x - target_offset);
-    if dist_to_snap.abs() < snap_threshold {
-        let dt = time.delta_secs_f64();
-        scroll.position -= dist_to_snap * dt * CENTER_MAGNETIC_FORCE;
+    scroll.snap_pending = false;
+    if sticky || dist_to_snap.abs() < snap_threshold {
+        // Keep Scrolling alive until the shared target integrator reaches the
+        // anchor. This works for native modifier-scroll and raw gestures.
+        scroll.velocity = 0.0;
+        scroll.target_position = Some(f64::from(target_offset));
     }
 }
 
@@ -274,8 +305,28 @@ fn scrolling_integrator(
     };
 
     let scroll = &mut *strip;
+    if let Some(target) = scroll.target_position {
+        let (position, settled) = smooth_native_scroll(scroll.position, target, dt);
+        scroll.position = position;
+        if settled {
+            scroll.target_position = None;
+        }
+        return;
+    }
+
     if scroll.velocity.abs() > 0.0001 {
         scroll.position += scroll.velocity * dt * viewport_width * direction_modifier;
+    }
+}
+
+fn smooth_native_scroll(position: f64, target: f64, dt: f64) -> (f64, bool) {
+    let blend = 1.0 - (-dt / NATIVE_SCROLL_RESPONSE_SECONDS).exp();
+    let position = position + (target - position) * blend;
+
+    if (target - position).abs() <= NATIVE_SCROLL_SETTLE_PX {
+        (target, true)
+    } else {
+        (position, false)
     }
 }
 
@@ -304,8 +355,21 @@ fn apply_scrolling_constraints(
     ) {
         position.x = clamped_offset;
         scroll.position = f64::from(clamped_offset);
+        if let Some(target) = scroll.target_position
+            && let Some(clamped_target) = clamp_viewport_offset(
+                target as i32,
+                strip,
+                &windows,
+                &get_window_frame,
+                &viewport,
+                &config,
+            )
+        {
+            scroll.target_position = Some(f64::from(clamped_target));
+        }
     } else {
         scroll.velocity = 0.0;
+        scroll.target_position = None;
     }
 }
 
@@ -333,6 +397,11 @@ where
         .map(|(position, frame)| position.x + frame.width())?;
 
     let continuous_swipe = config.continuous_swipe();
+    let has_oversized_column = layout_strip.columns().any(|column| {
+        column
+            .width(get_window_frame)
+            .is_some_and(|width| width > viewport.width())
+    });
     let strip_position = |column: Result<Column>| {
         column
             .ok()
@@ -345,7 +414,10 @@ where
     let right_snap = strip_position(layout_strip.get(1));
 
     Some(
-        if continuous_swipe && let Some((left_snap, right_snap)) = left_snap.zip(right_snap) {
+        if continuous_swipe
+            && !has_oversized_column
+            && let Some((left_snap, right_snap)) = left_snap.zip(right_snap)
+        {
             // Allow to scroll away until the last or first window snaps.
             current_offset.clamp(viewport.min.x - left_snap, viewport.max.x - right_snap)
         } else if viewport.width() < total_strip_width {
@@ -431,4 +503,29 @@ fn switch_virtual_workspace(delta: f64, config: &Config, commands: &mut Commands
     commands.trigger(SendMessageTrigger(Event::Command {
         command: Command::Window(Operation::Virtual(direction)),
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::smooth_native_scroll;
+
+    #[test]
+    fn native_scroll_smoothing_converges_without_overshoot() {
+        let mut position = 0.0;
+        let mut settled = false;
+
+        for _ in 0..120 {
+            let previous = position;
+            (position, settled) = smooth_native_scroll(position, 100.0, 1.0 / 60.0);
+            assert!(position >= previous);
+            assert!(position <= 100.0);
+
+            if settled {
+                break;
+            }
+        }
+
+        assert!((position - 100.0).abs() < f64::EPSILON);
+        assert!(settled);
+    }
 }

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -88,7 +88,7 @@ fn swipe_gesture(
             Event::Swipe { delta, fingers }
                 if config
                     .swipe_gesture_fingers()
-                    .is_none_or(|fingers_configured| fingers_configured == *fingers) =>
+                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 total_delta += delta;
                 has_scroll_event = true;
@@ -386,7 +386,7 @@ fn vertical_swipe_gesture(
             Event::VerticalSwipe { delta, fingers }
                 if config
                     .swipe_gesture_fingers()
-                    .is_none_or(|fingers_configured| fingers_configured == *fingers) =>
+                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 state.last_event = Some(Instant::now());
 

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -1,9 +1,10 @@
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::{With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
-use bevy::ecs::system::{Commands, Local, Populated, Res, Single};
+use bevy::ecs::system::{Commands, Local, Populated, Query, Res, Single};
 use bevy::math::IRect;
 use bevy::time::Time;
 use std::time::{Duration, Instant};
@@ -15,11 +16,12 @@ use crate::config::swipe::SwipeGestureDirection;
 use crate::ecs::layout::{Column, LayoutStrip};
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, MissionControlActive, Position, Scrolling, SendMessageTrigger,
+    ActiveWorkspaceMarker, DockPosition, MissionControlActive, Position, Scrolling,
+    SendMessageTrigger,
 };
 use crate::errors::Result;
 use crate::events::Event;
-use crate::manager::{Window, WindowManager};
+use crate::manager::{Display, Window, WindowManager};
 use crate::platform::Modifiers;
 
 pub struct ScrollEventsPlugin;
@@ -36,6 +38,7 @@ impl Plugin for ScrollEventsPlugin {
         app.add_systems(
             Update,
             (
+                cleanup_detached_scrolling,
                 vertical_swipe_gesture.run_if(mission_control_inactive),
                 (
                     swipe_gesture.run_if(mission_control_inactive),
@@ -45,9 +48,22 @@ impl Plugin for ScrollEventsPlugin {
                     apply_scrolling_constraints,
                     swiping_timeout,
                 )
-                    .chain(),
+                    .chain()
+                    .after(crate::ecs::workspace::show_active_workspace),
             ),
         );
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn cleanup_detached_scrolling(
+    detached: Query<Entity, (With<Scrolling>, Without<ChildOf>)>,
+    mut commands: Commands,
+) {
+    for entity in detached {
+        if let Ok(mut entity_commands) = commands.get_entity(entity) {
+            entity_commands.try_remove::<Scrolling>();
+        }
     }
 }
 
@@ -181,35 +197,62 @@ fn swipe_gesture(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn swiping_timeout(
-    strips: Populated<(Entity, &mut Scrolling), With<LayoutStrip>>,
-    active_display: ActiveDisplay,
+    strips: Populated<(Entity, &mut Scrolling, &ChildOf), With<LayoutStrip>>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     time: Res<Time>,
+    config: Res<Config>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     const FINGER_LIFT_THRESHOLD: Duration = Duration::from_millis(50);
-    const MIN_VELOCITY_PX: f64 = 5.0;
     let dt = time.delta_secs_f64();
-    let viewport_width = f64::from(active_display.bounds().width());
 
-    for (entity, mut scroll) in strips {
-        if scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD {
-            scroll.is_user_swiping = false;
-
-            if scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
-                && scroll.target_position.is_none()
-                && !scroll.snap_pending
-                && let Ok(mut entity_commands) = commands.get_entity(entity)
-            {
-                entity_commands.try_remove::<Scrolling>();
-            }
-            if let Some(point) = window_manager.cursor_position() {
-                commands.trigger(SendMessageTrigger(Event::MouseMoved {
-                    point,
-                    modifiers: Modifiers::empty(),
-                }));
-            }
+    for (entity, mut scroll, parent) in strips {
+        let Ok((display, dock)) = displays.get(parent.parent()) else {
+            continue;
+        };
+        let viewport_width = f64::from(display.actual_display_bounds(dock, &config).width());
+        let timed_out = scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD;
+        let outcome = update_swipe_timeout(&mut scroll, timed_out, dt, viewport_width);
+        if outcome.remove
+            && let Ok(mut entity_commands) = commands.get_entity(entity)
+        {
+            entity_commands.try_remove::<Scrolling>();
         }
+        if outcome.emit_mouse_moved
+            && let Some(point) = window_manager.cursor_position()
+        {
+            commands.trigger(SendMessageTrigger(Event::MouseMoved {
+                point,
+                modifiers: Modifiers::empty(),
+            }));
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SwipeTimeoutOutcome {
+    emit_mouse_moved: bool,
+    remove: bool,
+}
+
+fn update_swipe_timeout(
+    scroll: &mut Scrolling,
+    timed_out: bool,
+    dt: f64,
+    viewport_width: f64,
+) -> SwipeTimeoutOutcome {
+    const MIN_VELOCITY_PX: f64 = 5.0;
+    let emit_mouse_moved = timed_out && scroll.is_user_swiping;
+    if emit_mouse_moved {
+        scroll.is_user_swiping = false;
+    }
+    SwipeTimeoutOutcome {
+        emit_mouse_moved,
+        remove: timed_out
+            && scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
+            && scroll.target_position.is_none()
+            && !scroll.snap_pending,
     }
 }
 
@@ -238,65 +281,66 @@ fn apply_inertia(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn apply_snap_force(
-    mut strip: Single<(&LayoutStrip, &Position, &mut Scrolling)>,
-    active_display: ActiveDisplay,
+    mut strips: Populated<(&LayoutStrip, &Position, &mut Scrolling, &ChildOf)>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     windows: Windows,
     config: Res<Config>,
 ) {
     const SNAP_DISPLAY_RATIO: f64 = 0.45;
 
-    let (layout_strip, position, ref mut scroll) = *strip;
     let sticky = config.sticky_scroll();
-    if !sticky && !config.auto_center() {
+    for (layout_strip, position, mut scroll, parent) in &mut strips {
+        if !sticky && !config.auto_center() {
+            scroll.snap_pending = false;
+            continue;
+        }
+        let Ok((display, dock)) = displays.get(parent.parent()) else {
+            scroll.snap_pending = false;
+            continue;
+        };
+        let viewport = display.actual_display_bounds(dock, &config);
+        let viewport_center = viewport.center().x;
+        let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
+
+        if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 || scroll.target_position.is_some()
+        {
+            continue;
+        }
+
+        let target_offset = layout_strip
+            .all_columns()
+            .into_iter()
+            .filter_map(|entity| {
+                windows
+                    .layout_position(entity)
+                    .map(|p| p.0.x)
+                    .zip(Some(entity))
+            })
+            .map(|(position, entity)| {
+                let col_width = windows.moving_frame(entity).map_or(0, |f| f.width());
+                viewport_center - (position + col_width / 2)
+            })
+            .min_by_key(|target| (position.x - target).abs())
+            .unwrap_or(position.x);
+
+        let dist_to_snap = f64::from(position.x - target_offset);
         scroll.snap_pending = false;
-        return;
-    }
-
-    let viewport = active_display.actual_bounds(&config);
-    let viewport_center = viewport.center().x;
-    let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
-
-    if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 || scroll.target_position.is_some() {
-        return;
-    }
-
-    let target_offset = layout_strip
-        .all_columns()
-        .into_iter()
-        .filter_map(|entity| {
-            windows
-                .layout_position(entity)
-                .map(|p| p.0.x)
-                .zip(Some(entity))
-        })
-        .map(|(position, entity)| {
-            let col_width = windows.moving_frame(entity).map_or(0, |f| f.width());
-            viewport_center - (position + col_width / 2)
-        })
-        .min_by_key(|target| (position.x - target).abs())
-        .unwrap_or(position.x);
-
-    let dist_to_snap = f64::from(position.x - target_offset);
-    scroll.snap_pending = false;
-    if sticky || dist_to_snap.abs() < snap_threshold {
-        // Keep Scrolling alive until the shared target integrator reaches the
-        // anchor. This works for native modifier-scroll and raw gestures.
-        scroll.velocity = 0.0;
-        scroll.target_position = Some(f64::from(target_offset));
+        if sticky || dist_to_snap.abs() < snap_threshold {
+            scroll.velocity = 0.0;
+            scroll.target_position = Some(f64::from(target_offset));
+        }
     }
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn scrolling_integrator(
-    mut strip: Single<&mut Scrolling, With<LayoutStrip>>,
+    mut strips: Populated<(&mut Scrolling, &ChildOf), With<LayoutStrip>>,
     time: Res<Time>,
-    active_display: ActiveDisplay,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     config: Res<Config>,
 ) {
     let dt = time.delta_secs_f64();
-    let viewport = active_display.actual_bounds(&config);
-    let viewport_width = f64::from(viewport.width());
 
     // Direction modifier: Natural moves strip left (negative offset) for positive delta (finger left)
     let direction_modifier = match config.swipe_gesture_direction() {
@@ -304,17 +348,29 @@ fn scrolling_integrator(
         SwipeGestureDirection::Reversed => 1.0,
     };
 
-    let scroll = &mut *strip;
+    for (mut scroll, parent) in &mut strips {
+        let viewport_width = displays
+            .get(parent.parent())
+            .map_or(0.0, |(display, dock)| {
+                f64::from(display.actual_display_bounds(dock, &config).width())
+            });
+        integrate_scrolling(&mut scroll, dt, viewport_width, direction_modifier);
+    }
+}
+
+fn integrate_scrolling(
+    scroll: &mut Scrolling,
+    dt: f64,
+    viewport_width: f64,
+    direction_modifier: f64,
+) {
     if let Some(target) = scroll.target_position {
         let (position, settled) = smooth_native_scroll(scroll.position, target, dt);
         scroll.position = position;
         if settled {
             scroll.target_position = None;
         }
-        return;
-    }
-
-    if scroll.velocity.abs() > 0.0001 {
+    } else if scroll.velocity.abs() > 0.0001 {
         scroll.position += scroll.velocity * dt * viewport_width * direction_modifier;
     }
 }
@@ -330,46 +386,67 @@ fn smooth_native_scroll(position: f64, target: f64, dt: f64) -> (f64, bool) {
     }
 }
 
+/// Preserve the integrator's subpixel remainder unless viewport constraints
+/// actually changed the integer position that macOS can apply.
+fn reconcile_integrated_position(
+    integrated_position: f64,
+    effective_position: i32,
+    clamped_position: i32,
+) -> f64 {
+    if effective_position == clamped_position {
+        integrated_position
+    } else {
+        f64::from(clamped_position)
+    }
+}
+
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn apply_scrolling_constraints(
-    mut strip: Single<
-        (&LayoutStrip, &mut Position, &mut Scrolling),
-        (With<ActiveWorkspaceMarker>, Without<Window>),
-    >,
-    active_display: ActiveDisplay,
+    mut strips: Populated<(&LayoutStrip, &mut Position, &mut Scrolling, &ChildOf), Without<Window>>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     windows: Windows,
     config: Res<Config>,
 ) {
-    let viewport = active_display.actual_bounds(&config);
-    let (strip, ref mut position, ref mut scroll) = *strip;
-
-    let get_window_frame = |entity| windows.moving_frame(entity);
-    if let Some(clamped_offset) = clamp_viewport_offset(
-        scroll.position as i32,
-        strip,
-        &windows,
-        &get_window_frame,
-        &viewport,
-        &config,
-    ) {
-        position.x = clamped_offset;
-        scroll.position = f64::from(clamped_offset);
-        if let Some(target) = scroll.target_position
-            && let Some(clamped_target) = clamp_viewport_offset(
-                target as i32,
-                strip,
-                &windows,
-                &get_window_frame,
-                &viewport,
-                &config,
-            )
-        {
-            scroll.target_position = Some(f64::from(clamped_target));
+    for (strip, mut position, mut scroll, parent) in &mut strips {
+        let Ok((display, dock)) = displays.get(parent.parent()) else {
+            continue;
+        };
+        let viewport = display.actual_display_bounds(dock, &config);
+        let get_window_frame = |entity| windows.moving_frame(entity);
+        let effective_offset = scroll.position as i32;
+        if let Some(clamped_offset) = clamp_viewport_offset(
+            effective_offset,
+            strip,
+            &windows,
+            &get_window_frame,
+            &viewport,
+            &config,
+        ) {
+            position.x = clamped_offset;
+            scroll.position =
+                reconcile_integrated_position(scroll.position, effective_offset, clamped_offset);
+            if let Some(target) = scroll.target_position
+                && let effective_target = target as i32
+                && let Some(clamped_target) = clamp_viewport_offset(
+                    effective_target,
+                    strip,
+                    &windows,
+                    &get_window_frame,
+                    &viewport,
+                    &config,
+                )
+            {
+                scroll.target_position = Some(reconcile_integrated_position(
+                    target,
+                    effective_target,
+                    clamped_target,
+                ));
+            }
+        } else {
+            scroll.velocity = 0.0;
+            scroll.target_position = None;
         }
-    } else {
-        scroll.velocity = 0.0;
-        scroll.target_position = None;
     }
 }
 
@@ -507,7 +584,20 @@ fn switch_virtual_workspace(delta: f64, config: &Config, commands: &mut Commands
 
 #[cfg(test)]
 mod tests {
-    use super::smooth_native_scroll;
+    use std::time::{Duration, Instant};
+
+    use bevy::ecs::query::With;
+    use bevy::prelude::{App, Entity, Update};
+    use bevy::time::TimeUpdateStrategy;
+
+    use super::{
+        ChildOf, Scrolling, cleanup_detached_scrolling, integrate_scrolling,
+        reconcile_integrated_position, smooth_native_scroll, update_swipe_timeout,
+    };
+    use crate::commands::Command;
+    use crate::ecs::{ActiveWorkspaceMarker, Position};
+    use crate::events::Event;
+    use crate::tests::TestHarness;
 
     #[test]
     fn native_scroll_smoothing_converges_without_overshoot() {
@@ -527,5 +617,115 @@ mod tests {
 
         assert!((position - 100.0).abs() < f64::EPSILON);
         assert!(settled);
+    }
+
+    #[test]
+    fn detached_strip_cancels_scrolling_on_next_ecs_update() {
+        let mut app = App::new();
+        app.add_systems(Update, cleanup_detached_scrolling);
+        let parent = app.world_mut().spawn_empty().id();
+        let strip = app
+            .world_mut()
+            .spawn((Scrolling::default(), ChildOf(parent)))
+            .id();
+        app.world_mut().entity_mut(strip).remove::<ChildOf>();
+
+        app.update();
+
+        assert!(!app.world().entity(strip).contains::<Scrolling>());
+    }
+
+    #[test]
+    fn two_scrolling_strips_integrate_independently() {
+        let now = Instant::now();
+        let mut first = Scrolling {
+            velocity: 1.0,
+            position: 10.0,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        let mut second = Scrolling {
+            velocity: -2.0,
+            position: -30.0,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        integrate_scrolling(&mut first, 0.1, 1000.0, 1.0);
+        integrate_scrolling(&mut second, 0.1, 500.0, 1.0);
+        assert!((first.position - 110.0).abs() < f64::EPSILON);
+        assert!((second.position + 130.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn timeout_uses_each_parent_display_width_and_emits_lift_once() {
+        let now = Instant::now();
+        let mut narrow = Scrolling {
+            velocity: 1.0,
+            is_user_swiping: true,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        let mut wide = Scrolling {
+            velocity: 1.0,
+            is_user_swiping: true,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        let narrow_result = update_swipe_timeout(&mut narrow, true, 0.016, 100.0);
+        let wide_result = update_swipe_timeout(&mut wide, true, 0.016, 1000.0);
+        assert!(narrow_result.remove);
+        assert!(!wide_result.remove);
+        assert!(narrow_result.emit_mouse_moved);
+        assert!(wide_result.emit_mouse_moved);
+        assert!(
+            !update_swipe_timeout(&mut narrow, true, 0.016, 100.0).emit_mouse_moved,
+            "synthetic mouse move is emitted only on the swiping transition"
+        );
+    }
+
+    #[test]
+    fn clamp_reconciliation_preserves_remainder_only_inside_boundary() {
+        assert!((reconcile_integrated_position(-0.75, 0, 0) + 0.75).abs() < f64::EPSILON);
+        assert!((reconcile_integrated_position(2.25, 2, 1) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn scrolling_component_is_removed_after_integer_effective_dead_zone() {
+        let commands = vec![
+            Event::MenuOpened { window_id: 0 },
+            Event::Command {
+                command: Command::PrintState,
+            },
+        ];
+
+        TestHarness::new()
+            .with_windows(3)
+            .on_iteration(0, |world, _state| {
+                world.insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
+                    16,
+                )));
+                let entity = {
+                    let mut query = world.query_filtered::<Entity, With<ActiveWorkspaceMarker>>();
+                    query.single(world).expect("one active workspace")
+                };
+                world.entity_mut(entity).insert(Scrolling {
+                    velocity: 0.0,
+                    position: 0.0,
+                    target_position: Some(-1.0),
+                    snap_pending: false,
+                    is_user_swiping: false,
+                    last_event: Instant::now()
+                        .checked_sub(Duration::from_millis(100))
+                        .expect("100ms must fit before now"),
+                });
+            })
+            .on_iteration(1, |world, _state| {
+                let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+                assert!(query.single(world).is_err());
+                let mut positions =
+                    world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+                assert_eq!(positions.single(world).expect("one active workspace").x, -1);
+            })
+            .run(commands);
     }
 }

--- a/src/ecs/state.rs
+++ b/src/ecs/state.rs
@@ -1,23 +1,23 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bevy::app::AppExit;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
-use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::Has;
 use bevy::ecs::resource::Resource;
 use bevy::ecs::system::Query;
 use bevy::math::IRect;
 use objc2_core_graphics::CGDirectDisplayID;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, info, warn};
+use tracing::error;
 
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::Windows;
-use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, Position};
 use crate::manager::Application;
 use crate::manager::Display;
 use crate::platform::{Pid, ProcessSerialNumber, WinID, WorkspaceId};
@@ -92,6 +92,15 @@ pub struct SavedWindow {
     pub identifier: String,
     pub role: String,
     pub subrole: String,
+
+    /// Width relative to the display at save time. Optional for compatibility
+    /// with v2 state files written before oversized-window persistence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width_ratio: Option<f64>,
+    /// Owning strip's horizontal viewport position. Duplicated per window so
+    /// old enum-shaped column data remains backward compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strip_position_x: Option<i32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -154,6 +163,7 @@ impl SavedWindow {
         entity: Entity,
         windows: &Windows,
         apps: &Query<&Application>,
+        strip_position_x: Option<i32>,
     ) -> Option<Self> {
         let window = windows.get(entity)?;
         let (_, _, app_entity) = windows.find_parent(window.id())?;
@@ -168,6 +178,8 @@ impl SavedWindow {
             identifier: window.identifier().unwrap_or_default(),
             role: window.role().unwrap_or_default(),
             subrole: window.subrole().unwrap_or_default(),
+            width_ratio: windows.width_ratio(entity),
+            strip_position_x,
         })
     }
 
@@ -180,7 +192,12 @@ impl SavedWindow {
 impl PaneruState {
     #[allow(clippy::type_complexity, clippy::too_many_lines)]
     pub fn extract(
-        workspaces: &Query<(Option<&ChildOf>, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+        workspaces: &Query<(
+            Option<&ChildOf>,
+            &LayoutStrip,
+            Option<&Position>,
+            Has<ActiveWorkspaceMarker>,
+        )>,
         displays: &Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
         windows: &Windows,
         apps: &Query<&Application>,
@@ -198,7 +215,8 @@ impl PaneruState {
             display_workspace_ids.insert(entity, Vec::new());
         }
 
-        for (child, strip, active_workspace) in workspaces {
+        for (child, strip, strip_position, active_workspace) in workspaces {
+            let strip_position_x = strip_position.map(|position| position.x);
             let display_entity = child.map(ChildOf::parent);
             let display_id =
                 display_entity.and_then(|entity| display_entity_ids.get(&entity).copied());
@@ -213,20 +231,31 @@ impl PaneruState {
             for col in strip.columns() {
                 let saved_col = match col {
                     Column::Single(entity) => {
-                        SavedWindow::from_entity(*entity, windows, apps).map(SavedColumn::Single)
+                        SavedWindow::from_entity(*entity, windows, apps, strip_position_x)
+                            .map(SavedColumn::Single)
                     }
                     Column::Stack(items) => {
                         let saved_items = items
                             .iter()
                             .filter_map(|item| match item {
-                                StackItem::Single(entity) => {
-                                    SavedWindow::from_entity(*entity, windows, apps)
-                                        .map(SavedStackItem::Single)
-                                }
+                                StackItem::Single(entity) => SavedWindow::from_entity(
+                                    *entity,
+                                    windows,
+                                    apps,
+                                    strip_position_x,
+                                )
+                                .map(SavedStackItem::Single),
                                 StackItem::Tabs(tabs) => {
                                     let saved_tabs: Vec<_> = tabs
                                         .iter()
-                                        .filter_map(|&e| SavedWindow::from_entity(e, windows, apps))
+                                        .filter_map(|&e| {
+                                            SavedWindow::from_entity(
+                                                e,
+                                                windows,
+                                                apps,
+                                                strip_position_x,
+                                            )
+                                        })
                                         .collect();
                                     if saved_tabs.is_empty() {
                                         None
@@ -245,7 +274,9 @@ impl PaneruState {
                     Column::Tabs(tabs) => {
                         let saved_tabs: Vec<_> = tabs
                             .iter()
-                            .filter_map(|&e| SavedWindow::from_entity(e, windows, apps))
+                            .filter_map(|&e| {
+                                SavedWindow::from_entity(e, windows, apps, strip_position_x)
+                            })
                             .collect();
                         if saved_tabs.is_empty() {
                             None
@@ -253,8 +284,10 @@ impl PaneruState {
                             Some(SavedColumn::Tabs(saved_tabs))
                         }
                     }
-                    Column::Fullscren(entity) => SavedWindow::from_entity(*entity, windows, apps)
-                        .map(SavedColumn::Fullscreen),
+                    Column::Fullscren(entity) => {
+                        SavedWindow::from_entity(*entity, windows, apps, strip_position_x)
+                            .map(SavedColumn::Fullscreen)
+                    }
                 };
 
                 if let Some(sc) = saved_col {
@@ -322,8 +355,17 @@ impl PaneruState {
             fs::create_dir_all(parent)?;
         }
         let tmp_path = path.with_extension("json.tmp");
-        fs::write(&tmp_path, json)?;
+        let mut tmp = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp_path)?;
+        tmp.write_all(json.as_bytes())?;
+        tmp.sync_all()?;
         fs::rename(tmp_path, path)?;
+        if let Some(parent) = path.parent() {
+            fs::File::open(parent)?.sync_all()?;
+        }
         Ok(())
     }
 
@@ -543,38 +585,4 @@ fn now_timestamp() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-#[allow(clippy::needless_pass_by_value)]
-pub fn periodic_state_save(
-    workspaces: Query<(Option<&ChildOf>, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
-    displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
-    windows: Windows,
-    apps: Query<&Application>,
-) {
-    let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
-    let path = PaneruState::default_state_file_path();
-    if let Err(e) = state.save_to_file(&path) {
-        warn!("Failed to save state: {e}");
-    } else {
-        debug!("State saved to {}", path.display());
-    }
-}
-
-#[allow(clippy::needless_pass_by_value)]
-pub fn cleanup_on_exit(
-    mut exit_events: MessageReader<AppExit>,
-    workspaces: Query<(Option<&ChildOf>, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
-    displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
-    windows: Windows,
-    apps: Query<&Application>,
-) {
-    if exit_events.read().next().is_some() {
-        info!("Exiting, saving state...");
-        let state = PaneruState::extract(&workspaces, &displays, &windows, &apps);
-        let path = PaneruState::default_state_file_path();
-        if let Err(e) = state.save_to_file(&path) {
-            error!("Failed to save state on exit: {e}");
-        }
-    }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -27,9 +27,9 @@ use crate::config::{Config, decorations::BorderRadiusOption};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, Initializing, LowPowerMode,
-    MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState, Scrolling,
-    SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
+    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, FocusedMarker, Initializing,
+    LowPowerMode, MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState,
+    Scrolling, SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -174,6 +174,7 @@ pub(crate) fn add_existing_application(
 pub(crate) fn finish_setup(
     process_query: Query<Entity, With<ExistingMarker>>,
     windows: Windows,
+    applications: Query<&Application>,
     mut bruteforce_tasks: Query<(Entity, &mut BruteforceWindows)>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>, &ChildOf)>,
     window_manager: Res<WindowManager>,
@@ -203,6 +204,7 @@ pub(crate) fn finish_setup(
         windows.iter().size_hint()
     );
 
+    let mut focused_managed_window = false;
     for (mut strip, active_strip, _) in &mut workspaces {
         debug!("space {}: before refresh {strip:?}", strip.id());
         let workspace_windows = window_manager
@@ -246,7 +248,22 @@ pub(crate) fn finish_setup(
 
         if active_strip && let Some(entity) = strip.first().ok().and_then(|column| column.top()) {
             commands.focus_entity(entity, true);
+            focused_managed_window = true;
         }
+    }
+
+    // An all-floating workspace has no strip member to receive the initial
+    // focus marker. Mirror the frontmost app's AX focus so menu actions such as
+    // Toggle Managed work immediately after launch.
+    if !focused_managed_window
+        && let Some(focused_window_id) = applications
+            .iter()
+            .find(|app| app.is_frontmost())
+            .and_then(|app| app.focused_window_id().ok())
+        && let Some((_, entity)) = windows.find(focused_window_id)
+        && let Ok(mut entity_commands) = commands.get_entity(entity)
+    {
+        entity_commands.try_insert(FocusedMarker);
     }
 
     commands.remove_resource::<Initializing>();

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -2,19 +2,13 @@ use bevy::app::AppExit;
 use bevy::ecs::change_detection::{DetectChanges, DetectChangesMut};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
-use bevy::ecs::message::{MessageReader, MessageWriter};
+use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
-use bevy::ecs::system::{
-    Commands, Local, NonSend, NonSendMut, Populated, Query, Res, ResMut, Single,
-};
+use bevy::ecs::system::{Commands, Local, NonSend, NonSendMut, Populated, Query, Res, Single};
 use bevy::math::IRect;
-use bevy::tasks::AsyncComputeTaskPool;
-use bevy::tasks::futures_lite::future;
 use bevy::time::Time;
 use objc2_foundation::NSPoint;
 use std::collections::HashSet;
-use std::pin::Pin;
-use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::time::Duration;
 use tracing::{Level, debug, error, info, instrument, trace, warn};
 
@@ -25,25 +19,20 @@ use super::{
 
 use crate::config::{Config, decorations::BorderRadiusOption};
 use crate::ecs::layout::LayoutStrip;
-use crate::ecs::params::{ActiveDisplay, Windows};
+use crate::ecs::params::Windows;
+use crate::ecs::runtime::FreshPollDeadline;
+use crate::ecs::width_ratio::width_ratio_for_owner;
 use crate::ecs::{
-    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, FocusedMarker, Initializing,
-    LowPowerMode, MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState,
-    Scrolling, SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
+    ActiveWorkspaceMarker, ApplicationObserved, Bounds, FlashMessage, FocusedMarker, Initializing,
+    MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState, Scrolling,
+    SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
 };
-use crate::events::Event;
-use crate::manager::{
-    Application, Display, Process, Window, WindowManager, WindowOS, bruteforce_windows,
-};
+use crate::events::{Event, EventReceiver};
+use crate::manager::{Application, Display, Process, Window, WindowManager, WindowOS};
 use crate::overlay::{FlashMessageManager, OverlayManager};
-use crate::platform::{PlatformCallbacks, WinID};
+use crate::platform::{AxMainThread, WinID};
 
 const ANIAMTE_SNAP_THRESHOLD: f32 = 5.0;
-const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
-const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
-const LOOP_MAX_TIMEOUT_MS: u32 = 50;
-const LOOP_TIMEOUT_STEP: u32 = 1;
-
 /// Gathers all present displays and spawns them as entities in the Bevy world.
 /// The currently active display (identified by `window_manager.active_display_id()`) is marked with `ActiveDisplayMarker`.
 ///
@@ -120,6 +109,7 @@ pub(crate) fn add_existing_process(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn add_existing_application(
+    _main_thread: NonSend<AxMainThread>,
     window_manager: Res<WindowManager>,
     workspaces: Query<&LayoutStrip>,
     fresh_apps: Populated<(&mut Application, Entity), With<ExistingMarker>>,
@@ -130,31 +120,28 @@ pub(crate) fn add_existing_application(
         .into_iter()
         .map(LayoutStrip::id)
         .collect::<Vec<_>>();
-    let thread_pool = AsyncComputeTaskPool::get();
-
     for (mut app, entity) in fresh_apps {
-        let mut offscreen_windows = vec![];
-
-        if app.observe().is_ok_and(|result| result)
-            && let Ok((found_windows, offscreen)) = window_manager
-                .find_existing_application_windows(&mut app, &spaces, &config)
-                .inspect_err(|err| warn!("{err}"))
+        if app.is_frontmost()
+            && app.observe().is_ok_and(|result| result)
+            && let Ok(mut entity_commands) = commands.get_entity(entity)
         {
-            offscreen_windows.extend(offscreen);
+            entity_commands.try_insert(ApplicationObserved);
+        }
+        if let Ok((found_windows, offscreen)) = window_manager
+            .find_existing_application_windows(&mut app, &spaces, &config)
+            .inspect_err(|err| warn!("{err}"))
+        {
             commands.trigger(SpawnWindowTrigger(found_windows));
+            if !offscreen.is_empty() {
+                debug!(
+                    "deferred discovery of {} inactive-space window(s) for pid {} until activation",
+                    offscreen.len(),
+                    app.pid()
+                );
+            }
         }
         if let Ok(mut entity_commands) = commands.get_entity(entity) {
             entity_commands.try_remove::<ExistingMarker>();
-        }
-
-        if !offscreen_windows.is_empty() {
-            let pid = app.pid();
-            let bundle_id = app.bundle_id();
-            let config = config.clone();
-            let bruteforce_task = thread_pool.spawn(async move {
-                bruteforce_windows(pid, bundle_id.as_deref(), offscreen_windows, &config)
-            });
-            commands.spawn(BruteforceWindows(bruteforce_task));
         }
     }
 }
@@ -172,30 +159,16 @@ pub(crate) fn add_existing_application(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn finish_setup(
+    _main_thread: NonSend<AxMainThread>,
     process_query: Query<Entity, With<ExistingMarker>>,
     windows: Windows,
     applications: Query<&Application>,
-    mut bruteforce_tasks: Query<(Entity, &mut BruteforceWindows)>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>, &ChildOf)>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     if !process_query.is_empty() {
         // The other two add_* functions are still running..
-        return;
-    }
-
-    // Reap the bruteforced windows.
-    if !bruteforce_tasks.is_empty() {
-        for (entity, mut job) in &mut bruteforce_tasks {
-            if let Some(found_windows) = future::block_on(future::poll_once(&mut job.0)) {
-                commands.trigger(SpawnWindowTrigger(found_windows));
-                if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                    entity_commands.try_despawn();
-                }
-            }
-        }
-        // Wait for the next tick to finish initialization.
         return;
     }
 
@@ -283,15 +256,24 @@ pub(crate) fn finish_setup(
 /// * `commands` - Bevy commands to spawn entities and manage components.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn add_launched_process(
+    _main_thread: NonSend<AxMainThread>,
     window_manager: Res<WindowManager>,
-    fresh_processes: Populated<(Entity, &mut BProcess, Has<Children>), With<FreshMarker>>,
+    fresh_processes: Populated<
+        (Entity, &mut BProcess, Has<Children>, &mut FreshPollDeadline),
+        With<FreshMarker>,
+    >,
     config: Res<Config>,
     mut commands: Commands,
 ) {
     const APP_OBSERVABLE_TIMEOUT_SEC: u64 = 5;
     let mut already_seen = HashSet::new();
 
-    for (entity, mut process, children) in fresh_processes {
+    let now = std::time::Instant::now();
+    for (entity, mut process, children, mut poll) in fresh_processes {
+        if !poll.due(now) {
+            continue;
+        }
+        poll.schedule_next(now);
         let process = &mut *process.0;
 
         if !already_seen.insert(process.psn()) {
@@ -313,7 +295,9 @@ pub(super) fn add_launched_process(
         if children {
             // Process already has an attached Application, so finish.
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_remove::<FreshMarker>();
+                entity_commands
+                    .try_remove::<FreshMarker>()
+                    .try_remove::<FreshPollDeadline>();
             }
             continue;
         }
@@ -323,7 +307,14 @@ pub(super) fn add_launched_process(
             return;
         };
 
-        if app.observe().is_ok_and(|good| good) {
+        if !app.is_frontmost() {
+            commands.spawn((
+                app,
+                FreshMarker,
+                FreshPollDeadline::default(),
+                ChildOf(entity),
+            ));
+        } else if app.observe().is_ok_and(|good| good) {
             let timeout = Timeout::new(
                 Duration::from_secs(APP_OBSERVABLE_TIMEOUT_SEC),
                 Some(format!(
@@ -331,7 +322,14 @@ pub(super) fn add_launched_process(
                 )),
                 &mut commands,
             );
-            commands.spawn((app, FreshMarker, timeout, ChildOf(entity)));
+            commands.spawn((
+                app,
+                FreshMarker,
+                FreshPollDeadline::default(),
+                ApplicationObserved,
+                timeout,
+                ChildOf(entity),
+            ));
         } else {
             debug!("failed to register some observers {}", process.name());
         }
@@ -350,7 +348,16 @@ pub(super) fn add_launched_process(
 /// * `commands` - Bevy commands to spawn entities and manage components.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn add_launched_application(
-    app_query: Populated<(&mut Application, Entity, Has<Children>), With<FreshMarker>>,
+    _main_thread: NonSend<AxMainThread>,
+    app_query: Populated<
+        (
+            &mut Application,
+            Entity,
+            Has<Children>,
+            &mut FreshPollDeadline,
+        ),
+        With<FreshMarker>,
+    >,
     windows: Windows,
     config: Res<Config>,
     mut commands: Commands,
@@ -358,14 +365,21 @@ pub(super) fn add_launched_application(
     // TODO: maybe refactor this with add_existing_application_windows()
     let find_window = |window_id| windows.find(window_id);
 
-    for (app, entity, has_children) in app_query {
+    let now = std::time::Instant::now();
+    for (app, entity, has_children, mut poll) in app_query {
+        if !poll.due(now) {
+            continue;
+        }
+        poll.schedule_next(now);
         let mut create_windows = app.window_list(&config);
         // Retain the non-existing windows, so they can be created.
         create_windows.retain(|window| find_window(window.id()).is_none());
 
         if !create_windows.is_empty() {
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_remove::<FreshMarker>();
+                entity_commands
+                    .try_remove::<FreshMarker>()
+                    .try_remove::<FreshPollDeadline>();
             }
             debug!(
                 "spawn! (polling path found {} new windows for {entity})",
@@ -377,7 +391,9 @@ pub(super) fn add_launched_application(
             // Remove FreshMarker so the Timeout gets cleaned up.
             debug!("removing FreshMarker from {entity}: windows already created via AXCreated");
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_remove::<FreshMarker>();
+                entity_commands
+                    .try_remove::<FreshMarker>()
+                    .try_remove::<FreshPollDeadline>();
             }
         }
     }
@@ -424,7 +440,8 @@ pub(super) fn timeout_ticker(
     mut commands: Commands,
 ) {
     for (entity, mut timeout) in timers {
-        if timeout.timer.is_finished() {
+        timeout.timer.tick(clock.delta());
+        if timeout.due(std::time::Instant::now()) {
             trace!("Despawning entity {entity} due to timeout.");
             if let Some(system_id) = timeout.system_id.take() {
                 commands.run_system(system_id);
@@ -434,8 +451,6 @@ pub(super) fn timeout_ticker(
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 entity_commands.try_despawn();
             }
-        } else {
-            timeout.timer.tick(clock.delta());
         }
     }
 }
@@ -444,12 +459,17 @@ pub(super) fn timeout_ticker(
 /// during `ApplicationFrontSwitched`. Runs each frame until success or timeout.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn retry_front_switch(
-    retries: Populated<(Entity, &RetryFrontSwitch)>,
+    _main_thread: NonSend<AxMainThread>,
+    mut retries: Populated<(Entity, &mut RetryFrontSwitch)>,
     applications: Query<&Application>,
     mut commands: Commands,
 ) {
-    for (entity, retry) in retries.iter() {
-        let Ok(app) = applications.get(retry.0) else {
+    let now = std::time::Instant::now();
+    for (entity, mut retry) in &mut retries {
+        if !retry.due(now) {
+            continue;
+        }
+        let Ok(app) = applications.get(retry.application) else {
             // Application entity no longer exists, clean up.
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 entity_commands.try_despawn();
@@ -472,6 +492,8 @@ pub(super) fn retry_front_switch(
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 entity_commands.try_despawn();
             }
+        } else {
+            retry.schedule_retry(now);
         }
         // Otherwise, let timeout_ticker handle expiry.
     }
@@ -578,68 +600,10 @@ pub(super) fn animate_resize_entities(
         });
 }
 
-#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
-pub(super) fn pump_events(
-    mut exit: MessageWriter<AppExit>,
-    mut messages: MessageWriter<Event>,
-    low_power_mode: Option<Res<LowPowerMode>>,
-    incoming_events: Option<NonSend<Receiver<Event>>>,
-    platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
-    repositioning: Query<(), With<RepositionMarker>>,
-    resizing: Query<(), With<ResizeMarker>>,
-    scrolling: Query<(), With<Scrolling>>,
-    flash_messages: Query<(), With<FlashMessage>>,
-    mut timeout: Local<u32>,
-) {
-    let Some((ref mut platform, incoming_events)) = platform.zip(incoming_events) else {
-        // No platform interface or incoming event pipe - probably executing in a unit test.
-        return;
-    };
-
-    platform.pump_cocoa_event_loop(f64::from(*timeout) / 1000.0);
-    let mut received_events = Vec::new();
-    let mut pending_mouse = None;
-    loop {
-        // Repeatedly drain the events until timeout.
-        match incoming_events.recv_timeout(Duration::from_millis(1)) {
-            Ok(Event::Exit) | Err(RecvTimeoutError::Disconnected) => {
-                exit.write(AppExit::Success);
-                break;
-            }
-            Ok(event) => {
-                if matches!(event, Event::MouseMoved { .. }) {
-                    pending_mouse = Some(event);
-                } else {
-                    received_events.extend(pending_mouse.take());
-                    received_events.push(event);
-                }
-                *timeout = LOOP_TIMEOUT_STEP;
-            }
-            Err(RecvTimeoutError::Timeout) => {
-                received_events.extend(pending_mouse.take());
-                messages.write_batch(received_events);
-                let frame_active = !repositioning.is_empty()
-                    || !resizing.is_empty()
-                    || !scrolling.is_empty()
-                    || !flash_messages.is_empty();
-                let low_power = low_power_mode.is_some_and(|low_power| low_power.0);
-                let timeout_limit = if frame_active {
-                    LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
-                } else if low_power {
-                    LOOP_MAX_TIMEOUT_LOWPOWER_MS
-                } else {
-                    LOOP_MAX_TIMEOUT_MS
-                };
-                *timeout = timeout.min(timeout_limit) + LOOP_TIMEOUT_STEP;
-                break;
-            }
-        }
-    }
-}
-
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn window_resized_update_frame(
+    _main_thread: NonSend<AxMainThread>,
     mut messages: MessageReader<Event>,
     mut windows: Query<
         (
@@ -719,6 +683,7 @@ pub(super) fn window_resized_update_frame(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn window_moved_update_frame(
+    _main_thread: NonSend<AxMainThread>,
     mut messages: MessageReader<Event>,
     mut windows: Query<
         (&mut Window, &mut Position, &Bounds, Option<&Unmanaged>),
@@ -752,7 +717,7 @@ pub(super) fn window_moved_update_frame(
 
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn gather_initial_processes(
-    receiver: Option<NonSendMut<Receiver<Event>>>,
+    receiver: Option<NonSendMut<EventReceiver>>,
     mut displays: Query<&mut Display>,
     mut commands: Commands,
 ) {
@@ -928,20 +893,26 @@ pub(super) fn update_overlays(
 
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn commit_window_position(
+    _main_thread: NonSend<AxMainThread>,
     mut moved_windows: Populated<(&mut Window, &Position), Changed<Position>>,
 ) {
-    moved_windows
-        .par_iter_mut()
-        .for_each(|(mut window, position)| window.reposition(position.0));
+    for (mut window, position) in &mut moved_windows {
+        window.reposition(position.0);
+    }
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn verify_window_position(
+    _main_thread: NonSend<AxMainThread>,
     mut windows: Populated<(Entity, &mut Window, &Position, &mut VerifyWindowPosition)>,
     mut commands: Commands,
 ) {
+    let now = std::time::Instant::now();
     for (entity, mut window, position, mut verification) in &mut windows {
+        if !verification.due(now) {
+            continue;
+        }
         if window
             .update_frame()
             .is_ok_and(|frame| frame.min == position.0)
@@ -964,16 +935,29 @@ pub(super) fn verify_window_position(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn commit_window_size(
-    active_display: ActiveDisplay,
-    mut resized_windows: Populated<(&mut Window, &Bounds, &mut WidthRatio), Changed<Bounds>>,
+    _main_thread: NonSend<AxMainThread>,
+    mut resized_windows: Populated<
+        (Entity, &mut Window, &Bounds, &mut WidthRatio),
+        Changed<Bounds>,
+    >,
+    strips: Query<(&LayoutStrip, &ChildOf)>,
+    displays: Query<&Display>,
 ) {
-    let display_bounds = active_display.bounds();
-    resized_windows
-        .par_iter_mut()
-        .for_each(|(mut window, size, mut width_ratio)| {
-            width_ratio.0 = f64::from(size.0.x) / f64::from(display_bounds.width());
-            window.resize(size.0);
-        });
+    for (entity, mut window, size, mut width_ratio) in &mut resized_windows {
+        if let Some(ratio) = width_ratio_for_owner(
+            entity,
+            size.0.x,
+            strips.iter().filter_map(|(strip, parent)| {
+                displays
+                    .get(parent.parent())
+                    .ok()
+                    .map(|display| (strip, display.bounds().width()))
+            }),
+        ) {
+            width_ratio.0 = ratio;
+        }
+        window.resize(size.0);
+    }
 }
 
 /// Restores user-visible window state before Paneru shuts down: clears any
@@ -981,6 +965,7 @@ pub(super) fn commit_window_size(
 /// managed window on the display its frame center falls in.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn cleanup_on_exit(
+    _main_thread: NonSend<AxMainThread>,
     mut exit_events: MessageReader<AppExit>,
     mut all_windows: Query<&mut Window>,
     displays: Query<&Display>,
@@ -1102,17 +1087,13 @@ pub(crate) fn update_flash_messages(
     }
 }
 
-pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>>) {
-    let Some(mut state) = low_power_mode else {
-        return;
-    };
-    let process_info = objc2_foundation::NSProcessInfo::processInfo();
-    state.0 = process_info.isLowPowerModeEnabled();
-}
-
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all)]
-pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut commands: Commands) {
+pub(crate) fn window_creation_event(
+    _main_thread: NonSend<AxMainThread>,
+    mut messages: MessageReader<Event>,
+    mut commands: Commands,
+) {
     for event in messages.read() {
         let Event::WindowCreated { element } = event else {
             continue;

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -4,23 +4,27 @@ use bevy::ecs::lifecycle::{Add, Remove, RemovedComponents};
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With};
-use bevy::ecs::system::{Commands, NonSendMut, Populated, Query, Res, ResMut, Single};
+use bevy::ecs::system::{Commands, NonSend, Populated, Query, Res, ResMut, Single};
 use bevy::math::IRect;
-use notify::event::{DataChange, MetadataKind, ModifyKind};
-use notify::{EventKind, Watcher};
 use std::cmp::Ordering;
 use std::time::Duration;
 use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 use super::{
-    ActiveDisplayMarker, BProcess, FocusedMarker, FreshMarker, MissionControlActive,
+    ActiveDisplayMarker, ApplicationObserved, BProcess, FocusedMarker, MissionControlActive,
     PreviousManagedStrip, RetryFrontSwitch, SpawnWindowTrigger, StrayFocusEvent, SystemTheme,
     Timeout, Unmanaged,
 };
 use crate::config::Config;
+use crate::ecs::floating::{clamp_origin_to_bounds, offset_frame_within_bounds};
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
+use crate::ecs::observation::{
+    ApplicationObservationScope, attach_managed_window, detach_unmanaged_window,
+    ensure_application_observer,
+};
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
+use crate::ecs::runtime::SyntheticEventPending;
 use crate::ecs::state::PaneruState;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, Position,
@@ -28,15 +32,12 @@ use crate::ecs::{
     VerifyWindowPosition, WidthRatio, WindowProperties,
 };
 use crate::events::Event;
-use crate::manager::{
-    Application, Display, Origin, Process, Size, Window, WindowManager, WindowPadding,
-};
-use crate::platform::WinID;
-use crate::util::symlink_target;
+use crate::manager::{Application, Display, Origin, Size, Window, WindowManager, WindowPadding};
+use crate::platform::{AxMainThread, WinID};
 
 /// Computes the passthrough keybinding set for the given window/app and
 /// publishes it to the input thread. Called on focus change and config reload.
-fn update_passthrough(window: &Window, app: &Application, config: &Config) {
+pub(super) fn update_passthrough(window: &Window, app: &Application, config: &Config) {
     let properties = WindowProperties::new(app, window, config);
     crate::platform::input::set_focused_passthrough(properties.passthrough_keys());
 }
@@ -51,12 +52,14 @@ fn update_passthrough(window: &Window, app: &Application, config: &Config) {
 /// * `focused_window` - A query for the focused window.
 /// * `focus_follows_mouse_id` - The resource to track focus follows mouse window ID.
 /// * `commands` - Bevy commands to trigger events and manage components.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub(super) fn front_switched_trigger(
+    main_thread: NonSend<AxMainThread>,
     mut messages: MessageReader<Event>,
     processes: Query<(&BProcess, &Children)>,
-    applications: Query<&Application>,
+    mut observation: ApplicationObservationScope,
     window_manager: Res<WindowManager>,
+    runtime_config: Res<Config>,
     mut config: GlobalState,
     mut commands: Commands,
 ) {
@@ -66,9 +69,12 @@ pub(super) fn front_switched_trigger(
             continue;
         };
 
-        let Some((BProcess(process), children)) =
-            processes.iter().find(|process| &process.0.psn() == psn)
-        else {
+        let tracked = processes.iter().find(|process| &process.0.psn() == psn);
+        let app_entity = tracked.and_then(|(_, children)| children.first().copied());
+        let focused_id =
+            observation.activate(app_entity, &runtime_config, &main_thread, &mut commands);
+
+        let Some((BProcess(process), children)) = tracked else {
             error!("Unable to find process with PSN {psn:?}");
             continue;
         };
@@ -76,18 +82,18 @@ pub(super) fn front_switched_trigger(
         if children.len() > 1 {
             warn!("Multiple apps registered to process '{}'.", process.name());
         }
-        let Some(&app_entity) = children.first() else {
+        let Some(app_entity) = app_entity else {
             error!("No application for process '{}'.", process.name());
             continue;
         };
-        let Some(app) = applications.get(app_entity).ok() else {
+        let Some(focused_id) = focused_id else {
             error!("No application for process '{}'.", process.name());
             continue;
         };
 
         debug!("front switching process: {}", process.name());
 
-        if let Ok(focused_id) = app.focused_window_id().inspect_err(|err| {
+        if let Ok(focused_id) = focused_id.inspect_err(|err| {
             warn!("can not get current focus: {err}");
         }) {
             if let Some(point) = window_manager.cursor_position()
@@ -114,7 +120,7 @@ pub(super) fn front_switched_trigger(
                 )),
                 &mut commands,
             );
-            commands.spawn((timeout, RetryFrontSwitch(app_entity)));
+            commands.spawn((timeout, RetryFrontSwitch::new(app_entity)));
         }
     }
 }
@@ -176,6 +182,7 @@ pub(super) fn theme_change_trigger(
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn window_focused_trigger(
+    _main_thread: NonSend<AxMainThread>,
     mut messages: MessageReader<Event>,
     applications: Query<&Application>,
     windows: Windows,
@@ -366,53 +373,6 @@ pub(super) fn mission_control_trigger(
     }
 }
 
-/// Dispatches process-related messages, such as application launch and termination.
-///
-/// # Arguments
-///
-/// * `trigger` - The Bevy event trigger containing the application event.
-/// * `processes` - A query for all processes.
-/// * `commands` - Bevy commands to spawn or despawn entities.
-#[allow(clippy::needless_pass_by_value)]
-pub(super) fn application_event_trigger(
-    mut messages: MessageReader<Event>,
-    processes: Query<(&BProcess, Entity)>,
-    mut commands: Commands,
-) {
-    const PROCESS_READY_TIMEOUT_SEC: u64 = 5;
-    let find_process = |psn| {
-        processes
-            .iter()
-            .find(|(BProcess(process), _)| process.psn() == psn)
-    };
-
-    for event in messages.read() {
-        match event {
-            Event::ApplicationLaunched { psn, observer } if find_process(*psn).is_none() => {
-                let process: BProcess = Process::new(psn, observer.clone()).into();
-                let timeout = Timeout::new(
-                    Duration::from_secs(PROCESS_READY_TIMEOUT_SEC),
-                    Some(format!(
-                        "Process '{}' did not become ready in {PROCESS_READY_TIMEOUT_SEC}s.",
-                        process.name()
-                    )),
-                    &mut commands,
-                );
-                commands.spawn((FreshMarker, timeout, process));
-            }
-
-            Event::ApplicationTerminated { psn } => {
-                if let Some((_, entity)) = find_process(*psn)
-                    && let Ok(mut entity_commands) = commands.get_entity(entity)
-                {
-                    entity_commands.try_despawn();
-                }
-            }
-            _ => (),
-        }
-    }
-}
-
 /// Dispatches application-related messages, such as window creation, destruction, and resizing.
 ///
 /// # Arguments
@@ -493,8 +453,9 @@ pub(super) fn dispatch_application_messages(
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 pub(super) fn window_unmanaged_trigger(
     trigger: On<Add, Unmanaged>,
+    main_thread: NonSend<AxMainThread>,
     windows: Windows,
-    apps: Query<(Entity, &Application)>,
+    mut apps: Query<(Entity, &mut Application, Has<ApplicationObserved>)>,
     workspaces: Query<&mut LayoutStrip>,
     active_display: Single<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
     config: Res<Config>,
@@ -504,41 +465,6 @@ pub(super) fn window_unmanaged_trigger(
     const UNMANAGED_MAX_SCREEN_RATIO_NUM: i32 = 4;
     const UNMANAGED_MAX_SCREEN_RATIO_DEN: i32 = 5;
     const UNMANAGED_POP_OFFSET: i32 = 32;
-
-    fn clamp_origin_to_bounds(origin: IRect, size: Size, bounds: IRect) -> IRect {
-        let max = (bounds.max - size).max(bounds.min);
-        let min = origin.min.clamp(bounds.min, max);
-        IRect::from_corners(min, min + size)
-    }
-
-    fn offset_frame_within_bounds(frame: IRect, bounds: IRect, offset: i32) -> IRect {
-        let candidates = [
-            (offset, offset),
-            (offset, -offset),
-            (-offset, offset),
-            (-offset, -offset),
-            (offset, 0),
-            (-offset, 0),
-            (0, offset),
-            (0, -offset),
-        ];
-
-        for (dx, dy) in candidates {
-            let moved = IRect::from_corners(
-                Origin::new(frame.min.x + dx, frame.min.y + dy),
-                Origin::new(frame.max.x + dx, frame.max.y + dy),
-            );
-            if moved.min.x >= bounds.min.x
-                && moved.max.x <= bounds.max.x
-                && moved.min.y >= bounds.min.y
-                && moved.max.y <= bounds.max.y
-            {
-                return moved;
-            }
-        }
-
-        frame
-    }
 
     let entity = trigger.event().entity;
     let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(entity) else {
@@ -554,14 +480,27 @@ pub(super) fn window_unmanaged_trigger(
     let Some((window, frame)) = windows.get(entity).zip(windows.frame(entity)) else {
         return;
     };
-    let Some((_, app)) = windows
-        .find_parent(window.id())
-        .and_then(|(_, _, parent)| apps.get(parent).ok())
-    else {
+    let Some((_, _, app_entity)) = windows.find_parent(window.id()) else {
+        return;
+    };
+    let Ok((_, mut app, observed)) = apps.get_mut(app_entity) else {
         return;
     };
 
-    let properties = WindowProperties::new(app, window, &config);
+    let still_owns_managed = windows.managed_iter().any(|(_, managed_entity, parent)| {
+        managed_entity != entity && parent.parent() == app_entity
+    });
+    detach_unmanaged_window(
+        app_entity,
+        &mut app,
+        window,
+        observed,
+        still_owns_managed,
+        &main_thread,
+        &mut commands,
+    );
+
+    let properties = WindowProperties::new(&app, window, &config);
 
     // Skip the active-display reposition/resize during init; the strip
     // removal below still has to run.
@@ -652,19 +591,16 @@ pub(super) fn window_minimized_trigger(
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 pub(super) fn window_managed_trigger(
     trigger: On<Remove, Unmanaged>,
+    main_thread: NonSend<AxMainThread>,
     active_display: Single<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
     windows: Windows,
-    apps: Query<(Entity, &Application)>,
+    mut apps: Query<(Entity, &mut Application, Has<ApplicationObserved>)>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     previous_strips: Query<&PreviousManagedStrip>,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
     mut commands: Commands,
 ) {
-    // finish_setup handles the initial strip assignment during init.
-    if initializing.is_some() {
-        return;
-    }
     let entity = trigger.event().entity;
 
     if windows
@@ -672,6 +608,27 @@ pub(super) fn window_managed_trigger(
         .is_some_and(|window| window.role().is_err())
     {
         // The marker was removed because the windows was destroyed.
+        return;
+    }
+
+    if let Some(window) = windows.get(entity)
+        && let Some((app_entity, mut app, observed)) = windows
+            .find_parent(window.id())
+            .and_then(|(_, _, parent)| apps.get_mut(parent).ok())
+    {
+        attach_managed_window(
+            app_entity,
+            &mut app,
+            window,
+            observed,
+            &main_thread,
+            &mut commands,
+        );
+    }
+
+    // finish_setup handles the initial strip assignment during init, but the
+    // observer attachment above is still required for managed background apps.
+    if initializing.is_some() {
         return;
     }
 
@@ -684,11 +641,11 @@ pub(super) fn window_managed_trigger(
         .map(|previous| previous.index);
 
     if let Some(window) = windows.get(entity)
-        && let Some((_, app)) = windows
+        && let Some((_, app, _)) = windows
             .find_parent(window.id())
-            .and_then(|(_, _, parent)| apps.get(parent).ok())
+            .and_then(|(_, _, parent)| apps.get_mut(parent).ok())
     {
-        let properties = WindowProperties::new(app, window, &config);
+        let properties = WindowProperties::new(&app, window, &config);
 
         if let Some(width_ratio) = properties.width_ratio() {
             let (_, pad_right, _, pad_left) = config.edge_padding();
@@ -760,13 +717,14 @@ pub(super) fn window_managed_trigger(
 /// * `apps` - A query for all applications.
 /// * `displays` - A query for all displays.
 /// * `commands` - Bevy commands to despawn entities and trigger events.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn window_destroyed_trigger(
+    main_thread: NonSend<AxMainThread>,
     mut messages: MessageReader<Event>,
     windows: Windows,
     active_display: ActiveDisplay,
-    mut apps: Query<&mut Application>,
+    mut apps: Query<(Entity, &mut Application, Has<ApplicationObserved>)>,
     mut config: GlobalState,
     mut focus_history: ResMut<FocusHistory>,
     mut commands: Commands,
@@ -785,11 +743,22 @@ pub(super) fn window_destroyed_trigger(
             continue;
         }
 
-        let Ok(mut app) = apps.get_mut(parent) else {
+        let Ok((app_entity, mut app, observed)) = apps.get_mut(parent) else {
             error!("Window {} has no parent!", window.id());
             continue;
         };
-        app.unobserve_window(window);
+        let owns_other_managed = windows
+            .managed_iter()
+            .any(|(_, other, parent)| other != entity && parent.parent() == app_entity);
+        detach_unmanaged_window(
+            app_entity,
+            &mut app,
+            window,
+            observed,
+            owns_other_managed,
+            &main_thread,
+            &mut commands,
+        );
 
         give_away_focus(
             entity,
@@ -869,10 +838,11 @@ fn give_away_focus(
 /// * `active_display` - A query for the active display.
 /// * `main_cid` - The main connection ID resource.
 /// * `commands` - Bevy commands to manage components and trigger events.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn spawn_window_trigger(
     mut trigger: On<SpawnWindowTrigger>,
+    _main_thread: NonSend<AxMainThread>,
     windows: Query<&Window>,
     mut apps: Query<(Entity, &mut Application)>,
     active_display: ActiveDisplay,
@@ -945,6 +915,7 @@ pub(super) fn spawn_window_trigger(
 
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn apply_window_defaults(
+    _main_thread: NonSend<AxMainThread>,
     added: Populated<(&mut Window, &mut Position, &mut Bounds, &ChildOf), Added<Window>>,
     apps: Query<(Entity, &Application)>,
     active_display: ActiveDisplay,
@@ -1006,10 +977,11 @@ pub(super) fn apply_window_defaults(
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(super) fn apply_window_positions(
+    main_thread: NonSend<AxMainThread>,
     added: Populated<Entity, Added<Window>>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
     windows: Windows,
-    apps: Query<&Application>,
+    mut apps: Query<(Entity, &mut Application, Has<ApplicationObserved>)>,
     config: Res<Config>,
     initializing: Option<Res<Initializing>>,
     restore: Option<Res<crate::ecs::restore::SessionRestore>>,
@@ -1028,17 +1000,24 @@ pub(super) fn apply_window_positions(
         else {
             continue;
         };
-        let Ok(app) = apps.get(parent) else {
+        let Ok((app_entity, mut app, observed)) = apps.get_mut(parent) else {
             continue;
         };
 
         if crate::ecs::restore::matches_startup_restore_state(
             window,
-            app,
+            &app,
             restore.as_deref(),
             restoration.as_deref(),
             &config,
         ) {
+            ensure_application_observer(
+                app_entity,
+                &mut app,
+                observed,
+                &main_thread,
+                &mut commands,
+            );
             continue;
         }
 
@@ -1046,7 +1025,7 @@ pub(super) fn apply_window_positions(
         let allready_inserted = workspaces
             .iter_mut()
             .find_map(|(strip, _)| strip.contains(entity).then_some(strip));
-        let properties = WindowProperties::new(app, window, &config);
+        let properties = WindowProperties::new(&app, window, &config);
 
         if properties.floating() {
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
@@ -1058,6 +1037,8 @@ pub(super) fn apply_window_positions(
             }
             continue;
         }
+
+        ensure_application_observer(app_entity, &mut app, observed, &main_thread, &mut commands);
 
         if allready_inserted.is_none()
             && let Some(mut strip) = workspaces
@@ -1111,81 +1092,6 @@ pub(super) fn apply_window_positions(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub(super) fn refresh_configuration_trigger(
-    mut messages: MessageReader<Event>,
-    window_manager: Res<WindowManager>,
-    mut config: ResMut<Config>,
-    mut watcher: Option<NonSendMut<Box<dyn Watcher>>>,
-    windows: Windows,
-    mut displays: Query<&mut Display>,
-    applications: Query<&Application>,
-) {
-    for event in messages.read() {
-        let Event::ConfigRefresh(event) = event else {
-            continue;
-        };
-
-        let Some(ref mut watcher) = watcher else {
-            continue;
-        };
-
-        match &event.kind {
-            EventKind::Modify(
-                // When using the RecommendedWatcher, the event triggers on file data.
-                // When using PollWatcher, it triggers on modification time.
-                ModifyKind::Metadata(MetadataKind::WriteTime)
-                | ModifyKind::Data(DataChange::Content),
-            ) => (),
-            EventKind::Remove(_) => {
-                for path in &event.paths {
-                    _ = watcher.unwatch(path).inspect_err(|err| {
-                        error!("unwatching the config '{}': {err}", path.display());
-                    });
-                }
-                continue;
-            }
-            _ => continue,
-        }
-
-        for path in &event.paths {
-            if let Some(symlink) = symlink_target(path) {
-                debug!(
-                    "symlink '{}' changed, replacing the watcher.",
-                    symlink.display()
-                );
-                if let Ok(new_watcher) =
-                    window_manager
-                        .setup_config_watcher(path)
-                        .inspect_err(|err| {
-                            error!("watching the config '{}': {err}", path.display());
-                        })
-                {
-                    **watcher = new_watcher;
-                }
-            }
-            info!("Reloading configuration file; {}", path.display());
-            _ = config.reload_config(path.as_path()).inspect_err(|err| {
-                error!("loading config '{}': {err}", path.display());
-            });
-        }
-
-        let height = config.menubar_height();
-        for mut display in &mut displays {
-            display.set_menubar_height_override(height);
-        }
-
-        // Recompute passthrough keys for the currently focused window.
-        if let Some((window, _, parent)) = windows
-            .focused()
-            .and_then(|(w, e)| windows.find_parent(w.id()).map(|(w, _, p)| (w, e, p)))
-            && let Ok(app) = applications.get(parent)
-        {
-            update_passthrough(window, app, &config);
-        }
-    }
-}
-
-#[allow(clippy::needless_pass_by_value)]
 pub(super) fn window_removal_trigger(
     trigger: On<Remove, Window>,
     mut workspaces: Query<&mut LayoutStrip>,
@@ -1205,9 +1111,11 @@ pub(super) fn window_removal_trigger(
 pub(super) fn send_message_trigger(
     trigger: On<SendMessageTrigger>,
     mut messages: MessageWriter<Event>,
+    mut synthetic_events: ResMut<SyntheticEventPending>,
 ) {
     let event = &trigger.event().0;
     messages.write(event.clone());
+    synthetic_events.mark();
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -1225,6 +1133,7 @@ pub(super) fn cleanup_timeout_trigger(
 }
 
 pub(super) fn window_resize_verifier(
+    _main_thread: NonSend<AxMainThread>,
     mut removed: RemovedComponents<ResizeMarker>,
     mut windows: Query<(&mut Window, &Position, &mut Bounds)>,
     layout_strips: Query<&LayoutStrip>,

--- a/src/ecs/width_ratio.rs
+++ b/src/ecs/width_ratio.rs
@@ -1,0 +1,76 @@
+use bevy::ecs::entity::Entity;
+
+use super::layout::LayoutStrip;
+
+pub(super) fn width_ratio_for_owner<'a>(
+    window: Entity,
+    width: i32,
+    strips: impl IntoIterator<Item = (&'a LayoutStrip, i32)>,
+) -> Option<f64> {
+    strips.into_iter().find_map(|(strip, display_width)| {
+        (strip.contains(window) && display_width > 0)
+            .then(|| f64::from(width) / f64::from(display_width))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::prelude::*;
+
+    use super::*;
+    use crate::ecs::{Bounds, Position, WidthRatio};
+    use crate::manager::{Display, MockWindowApi, Origin, Size, Window};
+    use crate::platform::AxMainThread;
+
+    #[test]
+    fn ecs_commit_uses_owning_display_and_runs_ax_on_main_thread() {
+        let expected_thread = std::thread::current().id();
+        let mut mock = MockWindowApi::new();
+        mock.expect_resize()
+            .with(mockall::predicate::eq(Size::new(1_200, 500)))
+            .times(1)
+            .return_const(());
+        mock.expect_reposition()
+            .with(mockall::predicate::eq(Origin::new(10, 20)))
+            .times(1)
+            .returning(move |_| assert_eq!(std::thread::current().id(), expected_thread));
+
+        let mut app = App::new();
+        app.insert_non_send_resource(AxMainThread::for_tests())
+            .add_systems(
+                Update,
+                (
+                    super::super::systems::commit_window_position,
+                    super::super::systems::commit_window_size,
+                ),
+            );
+        let primary_display = app
+            .world_mut()
+            .spawn(Display::new(1, IRect::new(0, 0, 2_000, 1_000), 0))
+            .id();
+        let external_display = app
+            .world_mut()
+            .spawn(Display::new(2, IRect::new(2_000, 0, 2_800, 1_000), 0))
+            .id();
+        let external_window = app
+            .world_mut()
+            .spawn((
+                Window::new(Box::new(mock)),
+                Position(Origin::new(10, 20)),
+                Bounds(Size::new(1_200, 500)),
+                WidthRatio(0.0),
+            ))
+            .id();
+        let primary = LayoutStrip::new(1, 0);
+        let mut external = LayoutStrip::new(2, 0);
+        external.append(external_window);
+        app.world_mut().spawn((primary, ChildOf(primary_display)));
+        app.world_mut().spawn((external, ChildOf(external_display)));
+
+        app.update();
+
+        let saved_ratio = app.world().get::<WidthRatio>(external_window).unwrap().0;
+        assert!((saved_ratio - 1.5).abs() < f64::EPSILON);
+        assert_eq!((800.0 * saved_ratio).round() as i32, 1_200);
+    }
+}

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -9,10 +9,10 @@ use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
-use bevy::ecs::system::{Commands, Local, ParamSet, Populated, Query, Res, ResMut, Single};
-use bevy::time::common_conditions::on_timer;
+use bevy::ecs::system::{
+    Commands, Local, NonSend, ParamSet, Populated, Query, Res, ResMut, Single,
+};
 use std::collections::HashSet;
-use std::time::Duration;
 use tracing::{Level, debug, error, instrument, warn};
 
 use super::{ActiveDisplayMarker, SpawnWindowTrigger};
@@ -21,6 +21,7 @@ use crate::config::Config;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
+use crate::ecs::runtime::OrphanReconcileDeadline;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, NativeFullscreenMarker, Position,
     RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker, SpawnCommandsExt,
@@ -29,15 +30,12 @@ use crate::ecs::{
 use crate::errors::Result;
 use crate::events::Event;
 use crate::manager::{Application, Display, Origin, Window, WindowManager};
-use crate::platform::{WinID, WorkspaceId};
+use crate::platform::{AxMainThread, WinID, WorkspaceId};
 
 pub struct WorkspaceEventsPlugin;
 
 impl Plugin for WorkspaceEventsPlugin {
     fn build(&self, app: &mut App) {
-        const REFRESH_WINDOW_CHECK_FREQ_MS: u64 = 1000;
-        const DISPLAY_CHANGE_CHECK_FREQ_MS: u64 = 1000;
-
         let reap_workspaces = |config: Option<Res<Config>>| {
             config.is_some_and(|config| config.reap_empty_workspaces())
         };
@@ -56,14 +54,8 @@ impl Plugin for WorkspaceEventsPlugin {
                 show_active_workspace,
                 handle_virtual_window_moves,
                 detect_moved_windows.run_if(not(resource_exists::<Initializing>)),
-                refresh_workspace_window_sizes.run_if(on_timer(Duration::from_millis(
-                    REFRESH_WINDOW_CHECK_FREQ_MS,
-                ))),
-                find_orphaned_workspaces
-                    .after(crate::ecs::display::reconcile_displays)
-                    .run_if(on_timer(Duration::from_millis(
-                        DISPLAY_CHANGE_CHECK_FREQ_MS,
-                    ))),
+                refresh_workspace_window_sizes,
+                find_orphaned_workspaces.after(crate::ecs::display::reconcile_displays),
             ),
         );
         app.add_systems(PostUpdate, workspace_destroyed_handler);
@@ -176,6 +168,7 @@ fn workspace_change_handler(
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 fn detect_moved_windows(
+    _main_thread: NonSend<AxMainThread>,
     activated_workspace: Single<Entity, Added<ActiveWorkspaceMarker>>,
     windows: Windows,
     mut workspaces: Query<(&mut LayoutStrip, Entity, Has<NativeFullscreenMarker>)>,
@@ -379,17 +372,28 @@ fn windows_not_in_strips<F: Fn(WinID) -> Option<Entity>>(
         })
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::DEBUG, skip_all)]
 fn find_orphaned_workspaces(
-    orphans: Populated<(&LayoutStrip, Entity, &Timeout, Option<&ChildOf>), With<Timeout>>,
+    _main_thread: NonSend<AxMainThread>,
+    orphans: Populated<
+        (
+            &LayoutStrip,
+            Entity,
+            &Timeout,
+            &mut OrphanReconcileDeadline,
+            Option<&ChildOf>,
+        ),
+        With<Timeout>,
+    >,
     displays: Populated<(&Display, Entity)>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     let present = window_manager.present_displays();
 
-    for (orphan, orphan_entity, timeout, child) in orphans {
+    let now = std::time::Instant::now();
+    for (orphan, orphan_entity, timeout, mut reconcile, child) in orphans {
         if orphan.len() == 0 {
             if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
                 cmd.try_despawn();
@@ -401,6 +405,7 @@ fn find_orphaned_workspaces(
             // Was reparented, remove timer.
             if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
                 cmd.try_remove::<Timeout>();
+                cmd.try_remove::<OrphanReconcileDeadline>();
                 cmd.insert(RefreshWindowSizes::default());
             }
             debug!(
@@ -410,7 +415,7 @@ fn find_orphaned_workspaces(
             continue;
         }
 
-        if timeout.timer.is_finished() {
+        if timeout.due(now) {
             // Rescue windows from orphaned strips before despawning by floating them.
             debug!("Rescue windows from timed out orphan {}.", orphan.id());
             for lost_window in orphan.all_windows() {
@@ -420,6 +425,11 @@ fn find_orphaned_workspaces(
             }
             continue;
         }
+
+        if !reconcile.due(now) {
+            continue;
+        }
+        reconcile.schedule_next(now);
 
         // Find which display now owns this space ID.
         let target = present.iter().find_map(|(present_display, spaces)| {
@@ -443,6 +453,7 @@ fn find_orphaned_workspaces(
 
         if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
             cmd.try_remove::<Timeout>()
+                .try_remove::<OrphanReconcileDeadline>()
                 .insert(ChildOf(target_entity))
                 .insert(RefreshWindowSizes::default());
         }
@@ -451,6 +462,7 @@ fn find_orphaned_workspaces(
 
 #[allow(clippy::needless_pass_by_value)]
 fn refresh_workspace_window_sizes(
+    _main_thread: NonSend<AxMainThread>,
     layout_strip: Single<(&LayoutStrip, Entity, &RefreshWindowSizes), With<ActiveWorkspaceMarker>>,
     mut windows: Query<(Entity, &mut Window, &mut Bounds, Option<&Unmanaged>)>,
     active_display: ActiveDisplay,
@@ -458,7 +470,7 @@ fn refresh_workspace_window_sizes(
     mut commands: Commands,
 ) {
     let (strip, strip_entity, marker) = *layout_strip;
-    if !marker.ready() {
+    if !marker.ready(std::time::Instant::now()) {
         return;
     }
 
@@ -1139,5 +1151,100 @@ fn reap_empty_virtual_workspaces(
                 entity_commands.try_despawn();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod main_thread_tests {
+    use std::time::{Duration, Instant};
+
+    use bevy::prelude::*;
+
+    use super::{LayoutStrip, find_orphaned_workspaces, refresh_workspace_window_sizes};
+    use crate::ecs::runtime::OrphanReconcileDeadline;
+    use crate::ecs::{
+        ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, RefreshWindowSizes, Timeout,
+    };
+    use crate::manager::{
+        Display, MockWindowApi, MockWindowManagerApi, Size, Window, WindowManager,
+    };
+    use crate::platform::AxMainThread;
+
+    #[test]
+    fn refresh_window_sizes_runs_ax_on_main_thread() {
+        let expected_thread = std::thread::current().id();
+        let mut window = MockWindowApi::new();
+        window.expect_id().return_const(7);
+        window.expect_update_frame().times(1).returning(move || {
+            assert_eq!(std::thread::current().id(), expected_thread);
+            Ok(IRect::new(0, 0, 400, 300))
+        });
+        let mut manager = MockWindowManagerApi::new();
+        manager
+            .expect_windows_in_workspace()
+            .times(1)
+            .returning(|_| Ok(vec![7]));
+
+        let mut app = App::new();
+        app.insert_non_send_resource(AxMainThread::for_tests())
+            .insert_resource(WindowManager(Box::new(manager)))
+            .add_systems(Update, refresh_workspace_window_sizes);
+        let display = app
+            .world_mut()
+            .spawn((
+                Display::new(1, IRect::new(0, 0, 1_000, 800), 0),
+                ActiveDisplayMarker,
+            ))
+            .id();
+        let window = app
+            .world_mut()
+            .spawn((Window::new(Box::new(window)), Bounds(Size::new(1, 1))))
+            .id();
+        let mut strip = LayoutStrip::new(1, 0);
+        strip.append(window);
+        let strip = app
+            .world_mut()
+            .spawn((
+                strip,
+                ActiveWorkspaceMarker,
+                RefreshWindowSizes(Instant::now()),
+                ChildOf(display),
+            ))
+            .id();
+
+        app.update();
+
+        assert!(!app.world().entity(strip).contains::<RefreshWindowSizes>());
+    }
+
+    fn spawn_orphan(mut commands: Commands) {
+        let timeout = Timeout::new(Duration::from_secs(30), None, &mut commands);
+        commands.spawn((
+            LayoutStrip::new(99, 0),
+            timeout,
+            OrphanReconcileDeadline::default(),
+        ));
+    }
+
+    #[test]
+    fn orphan_reconciliation_runs_cg_query_on_main_thread() {
+        let expected_thread = std::thread::current().id();
+        let mut manager = MockWindowManagerApi::new();
+        manager
+            .expect_present_displays()
+            .times(1)
+            .returning(move || {
+                assert_eq!(std::thread::current().id(), expected_thread);
+                Vec::new()
+            });
+        let mut app = App::new();
+        app.insert_non_send_resource(AxMainThread::for_tests())
+            .insert_resource(WindowManager(Box::new(manager)))
+            .add_systems(Startup, spawn_orphan)
+            .add_systems(Update, find_orphaned_workspaces);
+        app.world_mut()
+            .spawn(Display::new(1, IRect::new(0, 0, 1_000, 800), 0));
+
+        app.update();
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,9 +1,14 @@
 use bevy::ecs::message::Message;
 use objc2::rc::Retained;
-use objc2_core_foundation::{CFRetained, CGPoint};
+use objc2_core_foundation::{
+    CFRetained, CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, CGPoint, kCFRunLoopDefaultMode,
+};
 use objc2_core_graphics::CGDirectDisplayID;
+use std::ffi::c_void;
 use std::os::unix::net::UnixStream;
-use std::sync::mpsc::{Receiver, Sender, channel};
+use std::ptr::{from_ref, null_mut};
+use std::sync::atomic::{AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, RecvError, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
 
 use crate::commands::Command;
@@ -142,6 +147,10 @@ pub enum Event {
     MenuClosed { window_id: WinID },
     /// The visibility of the menu bar has changed.
     MenuBarHiddenChanged { msg: String },
+    /// Paneru's own status menu is about to open and needs a fresh snapshot.
+    StatusMenuOpened,
+    /// Sparkle updater state changed and the status menu label/item is stale.
+    UpdaterStatusChanged,
     /// The system has woken from sleep.
     SystemWoke { msg: String },
 
@@ -166,7 +175,67 @@ pub enum Event {
 #[derive(Clone, Debug)]
 pub struct EventSender {
     tx: Sender<Event>,
+    wake: Arc<EventWake>,
 }
+
+#[derive(Debug)]
+struct EventWake {
+    generation: AtomicU64,
+    source: AtomicPtr<CFRunLoopSource>,
+    active_signals: AtomicUsize,
+}
+
+impl Default for EventWake {
+    fn default() -> Self {
+        Self {
+            generation: AtomicU64::new(0),
+            source: AtomicPtr::new(null_mut()),
+            active_signals: AtomicUsize::new(0),
+        }
+    }
+}
+
+/// Receiver paired with [`EventSender`]. The generation counter makes the
+/// queue-before-sleep protocol testable; the registered run-loop source closes
+/// the final check-to-sleep race because its signalled state is latched.
+pub struct EventReceiver {
+    rx: Receiver<Event>,
+    wake: Arc<EventWake>,
+}
+
+impl EventReceiver {
+    pub fn recv(&self) -> std::result::Result<Event, RecvError> {
+        self.rx.recv()
+    }
+
+    pub fn try_recv(&self) -> std::result::Result<Event, TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.wake.generation.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) struct EventWakeSource {
+    source: CFRetained<CFRunLoopSource>,
+    wake: Arc<EventWake>,
+}
+
+impl Drop for EventWakeSource {
+    fn drop(&mut self) {
+        self.wake.source.swap(null_mut(), Ordering::AcqRel);
+        while self.wake.active_signals.load(Ordering::Acquire) != 0 {
+            std::thread::yield_now();
+        }
+        if let Some(main_loop) = CFRunLoop::main() {
+            main_loop.remove_source(Some(&self.source), unsafe { kCFRunLoopDefaultMode });
+        }
+        self.source.invalidate();
+    }
+}
+
+unsafe extern "C-unwind" fn consume_event_wake(_: *mut c_void) {}
 
 impl EventSender {
     /// Creates a new `EventSender` and its corresponding `Receiver`.
@@ -175,9 +244,42 @@ impl EventSender {
     /// # Returns
     ///
     /// A tuple containing the `EventSender` and `Receiver` for the created channel.
-    pub fn new() -> (Self, Receiver<Event>) {
+    pub fn new() -> (Self, EventReceiver) {
         let (tx, rx) = channel::<Event>();
-        (Self { tx }, rx)
+        let wake = Arc::new(EventWake::default());
+        (
+            Self {
+                tx,
+                wake: Arc::clone(&wake),
+            },
+            EventReceiver { rx, wake },
+        )
+    }
+
+    pub(crate) fn install_main_run_loop_source(&self) -> Option<EventWakeSource> {
+        let mut context = CFRunLoopSourceContext {
+            version: 0,
+            info: null_mut(),
+            retain: None,
+            release: None,
+            copyDescription: None,
+            equal: None,
+            hash: None,
+            schedule: None,
+            cancel: None,
+            perform: Some(consume_event_wake),
+        };
+        let source = unsafe { CFRunLoopSource::new(None, 0, &raw mut context) }?;
+        let main_loop = CFRunLoop::main()?;
+        main_loop.add_source(Some(&source), unsafe { kCFRunLoopDefaultMode });
+        self.wake.source.store(
+            from_ref::<CFRunLoopSource>(&source).cast_mut(),
+            Ordering::Release,
+        );
+        Some(EventWakeSource {
+            source,
+            wake: Arc::clone(&self.wake),
+        })
     }
 
     /// Sends an `Event` through the internal channel.
@@ -190,6 +292,60 @@ impl EventSender {
     ///
     /// `Ok(())` if the event is sent successfully, otherwise `Err(Error)` if the receiver has disconnected.
     pub fn send(&self, event: Event) -> Result<()> {
-        Ok(self.tx.send(event)?)
+        self.tx.send(event)?;
+        self.wake.generation.fetch_add(1, Ordering::Release);
+        self.wake.active_signals.fetch_add(1, Ordering::AcqRel);
+        let source = self.wake.source.load(Ordering::Acquire);
+        if !source.is_null() {
+            // Main-thread sends must signal too: AppKit callbacks can run while
+            // PlatformCallbacks is draining queued NSEvents immediately before
+            // entering CFRunLoop::run_in_mode. Without a latched source, that
+            // subsequent run could sleep despite the newly queued ECS event.
+            // The source callback itself is empty and channel draining coalesces
+            // events, so it adds at most one wake turn, not persistent frame work.
+            // SAFETY: `EventWakeSource` owns the source until it first clears
+            // this pointer with Release ordering. Core Foundation permits
+            // signalling a run-loop source from arbitrary threads.
+            unsafe { &*source }.signal();
+        }
+        self.wake.active_signals.fetch_sub(1, Ordering::Release);
+        if let Some(main_loop) = CFRunLoop::main() {
+            main_loop.wake_up();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Event, EventSender};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn generation_latches_queued_before_sleep_and_during_ecs() {
+        let (sender, receiver) = EventSender::new();
+        let before = receiver.generation();
+        sender.send(Event::ApplicationActivated).unwrap();
+        assert!(receiver.generation() > before);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Event::ApplicationActivated)
+        ));
+
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = Arc::clone(&barrier);
+        let worker = thread::spawn(move || {
+            worker_barrier.wait();
+            sender.send(Event::ApplicationDeactivated).unwrap();
+        });
+        let before_ecs = receiver.generation();
+        barrier.wait();
+        worker.join().unwrap();
+        assert!(receiver.generation() > before_ecs);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Event::ApplicationDeactivated)
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod menubar;
 mod overlay;
 mod platform;
 mod reader;
+mod updater;
 mod util;
 
 #[cfg(test)]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -6,8 +6,8 @@ use derive_more::{DerefMut, with_trait::Deref};
 use mockall::automock;
 use notify::{RecursiveMode, Watcher};
 use objc2_core_foundation::{
-    CFArray, CFDictionary, CFMutableData, CFNumber, CFNumberType, CFRetained, CFString, CFType,
-    CGPoint, CGRect, CGSize, kCFBooleanTrue,
+    CFArray, CFDictionary, CFNumber, CFNumberType, CFRetained, CFString, CFType, CGPoint, CGRect,
+    CGSize, kCFBooleanTrue,
 };
 use objc2_core_graphics::{
     CGAssociateMouseAndMouseCursorPosition, CGDirectDisplayID, CGDisplayBounds,
@@ -16,30 +16,29 @@ use objc2_core_graphics::{
 };
 use std::path::Path;
 use std::ptr::null_mut;
-use std::slice::from_raw_parts_mut;
 use std::time::Duration;
 use stdext::function_name;
-use tracing::{Level, debug, error, instrument, trace, warn};
+use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::config::Config;
 use crate::errors::{Error, Result};
 use crate::events::{Event, EventSender};
 use crate::manager::skylight::SLSSetWindowListBrightness;
-use crate::platform::{ConnID, Pid, ProcessSerialNumber, WinID, WorkspaceId};
-use crate::util::{AXUIWrapper, MacResult, create_array, symlink_target};
+use crate::platform::{ConnID, ProcessSerialNumber, WinID, WorkspaceId};
+use crate::util::{MacResult, create_array, symlink_target};
 use app::ApplicationOS;
 pub use app::{Application, ApplicationApi};
 pub use display::Display;
 pub use process::{Process, ProcessApi};
 pub use skylight::AXUIElementCopyAttributeValue;
 use skylight::{
-    _AXUIElementCreateWithRemoteToken, SLSCopyActiveMenuBarDisplayIdentifier,
-    SLSCopyAssociatedWindows, SLSCopyManagedDisplaySpaces, SLSCopyWindowsWithOptionsAndTags,
-    SLSFindWindowAndOwner, SLSGetConnectionIDForPSN, SLSGetCurrentCursorLocation,
-    SLSGetDisplayMenubarHeight, SLSGetSpaceManagementMode, SLSMainConnectionID,
-    SLSManagedDisplayGetCurrentSpace, SLSSpaceGetType, SLSWindowIteratorAdvance,
-    SLSWindowIteratorGetAttributes, SLSWindowIteratorGetParentID, SLSWindowIteratorGetTags,
-    SLSWindowIteratorGetWindowID, SLSWindowQueryResultCopyWindows, SLSWindowQueryWindows,
+    SLSCopyActiveMenuBarDisplayIdentifier, SLSCopyAssociatedWindows, SLSCopyManagedDisplaySpaces,
+    SLSCopyWindowsWithOptionsAndTags, SLSFindWindowAndOwner, SLSGetConnectionIDForPSN,
+    SLSGetCurrentCursorLocation, SLSGetDisplayMenubarHeight, SLSGetSpaceManagementMode,
+    SLSMainConnectionID, SLSManagedDisplayGetCurrentSpace, SLSSpaceGetType,
+    SLSWindowIteratorAdvance, SLSWindowIteratorGetAttributes, SLSWindowIteratorGetParentID,
+    SLSWindowIteratorGetTags, SLSWindowIteratorGetWindowID, SLSWindowQueryResultCopyWindows,
+    SLSWindowQueryWindows,
 };
 pub use windows::{Window, WindowApi, WindowOS, WindowPadding, ax_window_id};
 
@@ -710,76 +709,6 @@ fn existing_application_window_list(
         )));
     }
     space_window_list_for_connection(cid, spaces, app.connection(), true)
-}
-
-/// Attempts to find and add unresolved windows for a given application by brute-forcing `element_id` values.
-/// This is a workaround for macOS API limitations that do not return `AXUIElementRef` for windows on inactive spaces.
-///
-/// # Arguments
-///
-/// * `pid` - The process ID of the application whose windows are to be brute-forced.
-/// * `bundle_id` - The bundle identifier of the application, if known.
-/// * `window_list` - A mutable vector of `WinID`s representing the expected global window list; found windows are removed from this list.
-/// * `config` - The current Paneru configuration, used to evaluate window rules.
-pub fn bruteforce_windows(
-    pid: Pid,
-    bundle_id: Option<&str>,
-    mut window_list: Vec<WinID>,
-    config: &Config,
-) -> Vec<Window> {
-    const MAGIC: u32 = 0x636f_636f;
-    const BUFSIZE: isize = 0x14;
-    let mut found_windows = Vec::new();
-    debug!("{pid} has unresolved window on other desktops, bruteforcing them.");
-
-    //
-    // NOTE: MacOS API does not return AXUIElementRef of windows on inactive spaces. However,
-    // we can just brute-force the element_id and create the AXUIElementRef ourselves.
-    //  https://github.com/decodism
-    //  https://github.com/lwouis/alt-tab-macos/issues/1324#issuecomment-2631035482
-    //
-
-    let Some(data_ref) = CFMutableData::new(None, BUFSIZE) else {
-        error!("error creating mutable data");
-        return found_windows;
-    };
-    CFMutableData::increase_length(data_ref.deref().into(), BUFSIZE);
-
-    let data = unsafe {
-        from_raw_parts_mut(
-            CFMutableData::mutable_byte_ptr(data_ref.deref().into()),
-            BUFSIZE as usize,
-        )
-    };
-    let bytes = pid.to_ne_bytes();
-    data[0x0..bytes.len()].copy_from_slice(&bytes);
-    let bytes = MAGIC.to_ne_bytes();
-    data[0x8..0x8 + bytes.len()].copy_from_slice(&bytes);
-
-    for element_id in 0..0x7fffu64 {
-        let bytes = element_id.to_ne_bytes();
-        data[0xc..0xc + bytes.len()].copy_from_slice(&bytes);
-
-        let Ok(element_ref) =
-            AXUIWrapper::retain(unsafe { _AXUIElementCreateWithRemoteToken(data_ref.as_ref()) })
-        else {
-            continue;
-        };
-        let Ok(window_id) = ax_window_id(element_ref.as_ptr()) else {
-            continue;
-        };
-
-        if let Some(index) = window_list.iter().position(|&id| id == window_id) {
-            window_list.remove(index);
-            debug!("Found window {window_id:?}");
-            if let Ok(window) = WindowOS::new_with_config(&element_ref, config, bundle_id)
-                .inspect_err(|err| warn!("{err}"))
-            {
-                found_windows.push(Window::new(Box::new(window)));
-            }
-        }
-    }
-    found_windows
 }
 
 /// Checks if the application has Accessibility privileges.

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -1,5 +1,6 @@
 use accessibility_sys::{
-    AXObserverRef, AXUIElementCreateApplication, AXUIElementRef, kAXErrorSuccess,
+    AXError, AXObserverRef, AXUIElementCreateApplication, AXUIElementRef,
+    kAXErrorNotificationNotRegistered, kAXErrorSuccess,
 };
 use bevy::ecs::component::Component;
 use core::ptr::NonNull;
@@ -83,6 +84,9 @@ pub trait ApplicationApi: Send + Sync {
     ///
     /// Returns an `Error` if observers cannot be registered.
     fn observe(&mut self) -> Result<bool>;
+    /// Stops application-level accessibility notifications while preserving
+    /// any explicit managed-window observers.
+    fn unobserve(&mut self) -> bool;
     /// Starts observing window-specific accessibility notifications for a given window.
     ///
     /// # Arguments
@@ -98,7 +102,10 @@ pub trait ApplicationApi: Send + Sync {
     /// # Arguments
     ///
     /// * `window` - The `Window` to unobserve.
-    fn unobserve_window(&mut self, window: &Window);
+    fn unobserve_window(&mut self, window: &Window) -> bool;
+    /// Retries AX removals that previously returned an ambiguous error.
+    /// Returns `true` once no retained registrations remain pending.
+    fn retry_observer_removals(&mut self) -> bool;
     /// Checks if the application is currently the frontmost application.
     fn is_frontmost(&self) -> bool;
     /// Returns the bundle identifier of the application.
@@ -269,6 +276,11 @@ impl ApplicationApi for ApplicationOS {
             .map(|retry| retry.is_empty())
     }
 
+    fn unobserve(&mut self) -> bool {
+        self.handler
+            .remove_observer(&ObserverType::Application, &self.element, &AX_NOTIFICATIONS)
+    }
+
     /// Registers observers for specific window-level accessibility notifications (e.g., `kAXUIElementDestroyedNotification`).
     ///
     /// # Arguments
@@ -297,14 +309,20 @@ impl ApplicationApi for ApplicationOS {
     /// # Arguments
     ///
     /// * `window` - A reference to the `Window` object to unobserve.
-    fn unobserve_window(&mut self, window: &Window) {
+    fn unobserve_window(&mut self, window: &Window) -> bool {
         if let Some(element) = window.element() {
             self.handler.remove_observer(
                 &ObserverType::Window(window.id()),
                 &element,
                 &AX_WINDOW_NOTIFICATIONS,
-            );
+            )
+        } else {
+            true
         }
+    }
+
+    fn retry_observer_removals(&mut self) -> bool {
+        self.handler.retry_pending_removals()
     }
 
     /// Checks if the application is currently the frontmost application.
@@ -337,9 +355,20 @@ impl ApplicationApi for ApplicationOS {
 /// An enum representing the type of observer being used.
 /// `Application` refers to an observer for application-level events.
 /// `Window(WinID)` refers to an observer for a specific window, identified by its `WinID`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ObserverType {
     Application,
     Window(WinID),
+}
+
+fn should_store_new_context(has_existing: bool, newly_registered: bool) -> bool {
+    !has_existing && newly_registered
+}
+
+fn removal_allows_context_release(results: impl IntoIterator<Item = AXError>) -> bool {
+    results
+        .into_iter()
+        .all(|result| result == kAXErrorSuccess || result == kAXErrorNotificationNotRegistered)
 }
 
 /// `ObserverContext` holds the `EventSender` and the `ObserverType`,
@@ -372,21 +401,14 @@ impl ObserverContext {
     /// * `notification` - The name of the accessibility notification as a `&str`.
     /// * `element` - The `AXUIElementRef` associated with the notification.
     fn notify_app(&self, notification: &str, element: AXUIElementRef) {
-        match notification {
-            accessibility_sys::kAXTitleChangedNotification => {
-                // TODO: WindowTitleChanged does not have a valid window as its element reference.
+        if notification == accessibility_sys::kAXCreatedNotification {
+            let Ok(element) = AXUIWrapper::retain(element).inspect_err(|err| {
+                error!("invalid element {element:?}: {err}");
+            }) else {
                 return;
-            }
-            accessibility_sys::kAXCreatedNotification => {
-                let Ok(element) = AXUIWrapper::retain(element).inspect_err(|err| {
-                    error!("invalid element {element:?}: {err}");
-                }) else {
-                    return;
-                };
-                _ = self.events.send(Event::WindowCreated { element });
-                return;
-            }
-            _ => (),
+            };
+            _ = self.events.send(Event::WindowCreated { element });
+            return;
         }
 
         let Ok(window_id) =
@@ -401,6 +423,9 @@ impl ObserverContext {
             }
             accessibility_sys::kAXWindowMovedNotification => Event::WindowMoved { window_id },
             accessibility_sys::kAXWindowResizedNotification => Event::WindowResized { window_id },
+            accessibility_sys::kAXTitleChangedNotification => {
+                Event::WindowTitleChanged { window_id }
+            }
             accessibility_sys::kAXMenuOpenedNotification => Event::MenuOpened { window_id },
             accessibility_sys::kAXMenuClosedNotification => Event::MenuClosed { window_id },
             _ => {
@@ -445,6 +470,13 @@ struct AxObserverHandler {
     observer: CFRetained<AXUIWrapper>,
     events: EventSender,
     contexts: Arc<RwLock<Vec<Pin<Box<ObserverContext>>>>>,
+    pending_removals: Vec<PendingObserverRemoval>,
+}
+
+struct PendingObserverRemoval {
+    which: ObserverType,
+    element: CFRetained<AXUIWrapper>,
+    notifications: Vec<&'static str>,
 }
 
 impl Drop for AxObserverHandler {
@@ -484,6 +516,7 @@ impl AxObserverHandler {
             observer,
             events,
             contexts: Arc::new(RwLock::new(Vec::new())),
+            pending_removals: Vec::new(),
         })
     }
 
@@ -505,47 +538,62 @@ impl AxObserverHandler {
         which: ObserverType,
     ) -> Result<Vec<&str>> {
         let observer: AXObserverRef = self.observer.as_ptr();
-        let context = Box::pin(ObserverContext {
-            events: self.events.clone(),
-            which,
+        let mut contexts = self.contexts.force_write();
+        let existing_context = contexts.iter().find(|context| context.which == which);
+        let new_context = existing_context.is_none().then(|| {
+            Box::pin(ObserverContext {
+                events: self.events.clone(),
+                which,
+            })
         });
-        let context_ptr = NonNull::from_ref(&*context).as_ptr();
-        self.contexts.force_write().push(context);
+        let context_ptr = existing_context.map_or_else(
+            || NonNull::from_ref(&**new_context.as_ref().expect("new context exists")).as_ptr(),
+            |context| NonNull::from_ref(context.as_ref().get_ref()).as_ptr(),
+        );
 
         // TODO: retry re-registering these.
         let mut retry = vec![];
-        let added = notifications
-            .iter()
-            .filter_map(|name| {
-                debug!("adding {name} {element:x?} {observer:?}");
-                let notification = CFString::from_static_str(name);
-                match unsafe {
-                    AXObserverAddNotification(
-                        observer,
-                        element.as_ptr(),
-                        &notification,
-                        context_ptr.cast(),
-                    )
-                } {
-                    accessibility_sys::kAXErrorSuccess
-                    | accessibility_sys::kAXErrorNotificationAlreadyRegistered => Some(*name),
-                    accessibility_sys::kAXErrorCannotComplete => {
-                        retry.push(*name);
-                        None
-                    }
-                    result => {
-                        error!("error adding {name} {element:x?} {observer:?}: {result}");
-                        None
-                    }
+        let mut registered = 0;
+        let mut newly_registered = false;
+        for name in notifications {
+            debug!("adding {name} {element:x?} {observer:?}");
+            let notification = CFString::from_static_str(name);
+            match unsafe {
+                AXObserverAddNotification(
+                    observer,
+                    element.as_ptr(),
+                    &notification,
+                    context_ptr.cast(),
+                )
+            } {
+                accessibility_sys::kAXErrorSuccess => {
+                    registered += 1;
+                    newly_registered = true;
                 }
-            })
-            .collect::<Vec<_>>();
-        if added.is_empty() {
+                accessibility_sys::kAXErrorNotificationAlreadyRegistered => {
+                    registered += 1;
+                }
+                accessibility_sys::kAXErrorCannotComplete => {
+                    retry.push(*name);
+                }
+                result => {
+                    error!("error adding {name} {element:x?} {observer:?}: {result}");
+                }
+            }
+        }
+        if registered == 0 {
             Err(Error::PermissionDenied(format!(
                 "{}: unable to register any observers!",
                 function_name!()
             )))
         } else {
+            // `AlreadyRegistered` retains the refcon supplied by the original
+            // registration. Never add another context in that case.
+            if should_store_new_context(existing_context.is_some(), newly_registered)
+                && let Some(context) = new_context
+            {
+                contexts.push(context);
+            }
             Ok(retry)
         }
     }
@@ -562,31 +610,72 @@ impl AxObserverHandler {
         which: &ObserverType,
         element: &AXUIWrapper,
         notifications: &[&'static str],
-    ) {
+    ) -> bool {
         let mut existing = self.contexts.force_write();
-        if let ObserverType::Window(removed) = which &&
-                !existing.iter().any(
-                    |context| matches!(context.which, ObserverType::Window(window_id) if window_id == *removed),
-                ) {
-                    debug!("window {removed} ({element}) already un-observed, skipping!");
-                    return;
-            }
+        if !existing.iter().any(|context| context.which == *which) {
+            debug!("{which:?} ({element}) already un-observed, skipping!");
+            return true;
+        }
 
+        let mut results = Vec::with_capacity(notifications.len());
         for name in notifications {
             let observer: AXObserverRef = self.observer.deref().as_ptr();
             let notification = CFString::from_static_str(name);
             debug!("removing {name} {element:x?} {observer:?}");
             let result =
                 unsafe { AXObserverRemoveNotification(observer, element.as_ptr(), &notification) };
-            if result != kAXErrorSuccess {
+            results.push(result);
+            if result != kAXErrorSuccess && result != kAXErrorNotificationNotRegistered {
                 debug!("error removing {name} {element:x?} {observer:?}: {result}");
             }
         }
-        if let ObserverType::Window(removed) = which {
-            existing.retain(
-                    |context| !matches!(context.which, ObserverType::Window(window_id) if window_id == *removed),
-                );
+        if removal_allows_context_release(results) {
+            existing.retain(|context| context.which != *which);
+            self.pending_removals
+                .retain(|pending| pending.which != *which);
+            true
+        } else {
+            if !self
+                .pending_removals
+                .iter()
+                .any(|pending| pending.which == *which)
+            {
+                match AXUIWrapper::retain(element.as_ptr::<c_void>()) {
+                    Ok(element) => self.pending_removals.push(PendingObserverRemoval {
+                        which: *which,
+                        element,
+                        notifications: notifications.to_vec(),
+                    }),
+                    Err(err) => {
+                        error!("unable to retain {which:?} for observer removal retry: {err}");
+                    }
+                }
+            }
+            debug!("retaining {which:?} observer context after ambiguous removal failure");
+            false
         }
+    }
+
+    fn retry_pending_removals(&mut self) -> bool {
+        let observer: AXObserverRef = self.observer.deref().as_ptr();
+        let mut still_pending = Vec::new();
+        let mut contexts = self.contexts.force_write();
+        for pending in self.pending_removals.drain(..) {
+            let results = pending.notifications.iter().map(|name| {
+                let notification = CFString::from_static_str(name);
+                unsafe {
+                    AXObserverRemoveNotification(observer, pending.element.as_ptr(), &notification)
+                }
+            });
+            if removal_allows_context_release(results) {
+                contexts.retain(|context| context.which != pending.which);
+                debug!("observer removal retry completed for {:?}", pending.which);
+            } else {
+                still_pending.push(pending);
+            }
+        }
+        self.pending_removals = still_pending;
+        self.pending_removals.is_empty()
     }
 
     /// The static callback function for `AXObserver`. This function is called by the macOS Accessibility API
@@ -614,5 +703,46 @@ impl AxObserverHandler {
         };
 
         context.notify(&notification, element);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr::NonNull;
+
+    use accessibility_sys::{kAXErrorCannotComplete, kAXErrorNotificationNotRegistered};
+
+    use super::{
+        ObserverContext, ObserverType, removal_allows_context_release, should_store_new_context,
+    };
+    use crate::events::EventSender;
+
+    #[test]
+    fn already_registered_notifications_never_allocate_an_extra_context() {
+        assert!(!should_store_new_context(false, false));
+        assert!(!should_store_new_context(true, false));
+        assert!(!should_store_new_context(true, true));
+        assert!(should_store_new_context(false, true));
+    }
+
+    #[test]
+    fn ambiguous_removal_retains_callback_context_until_retry_is_safe() {
+        let (events, _receiver) = EventSender::new();
+        let mut contexts = vec![Box::pin(ObserverContext {
+            events,
+            which: ObserverType::Application,
+        })];
+        let pointer = NonNull::from_ref(contexts[0].as_ref().get_ref());
+
+        let release = removal_allows_context_release([kAXErrorCannotComplete]);
+        if release {
+            contexts.clear();
+        }
+        assert!(!release);
+        assert_eq!(unsafe { pointer.as_ref().which }, ObserverType::Application);
+
+        assert!(removal_allows_context_release([
+            kAXErrorNotificationNotRegistered
+        ]));
     }
 }

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -38,6 +38,25 @@ use crate::util::{AXUIAttributes, AXUIWrapper, MacResult};
 static ENHANCED_UI_REFCOUNT: LazyLock<Mutex<HashMap<Pid, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// macOS may partially apply an AX width increase when the requested right edge
+/// would be far outside the display. Moving the partial result left by the
+/// missing width before retrying gives `WindowServer` enough offscreen room.
+///
+/// Only retry when the first attempt actually grew the window. Fixed-size apps
+/// otherwise look identical to this failure mode and must not be moved offscreen.
+fn resize_staging_origin(
+    previous_frame: IRect,
+    actual_frame: IRect,
+    target_width: i32,
+) -> Option<Origin> {
+    let actual_width = actual_frame.width();
+    (actual_width > previous_frame.width() && actual_width < target_width).then(|| {
+        actual_frame
+            .min
+            .with_x(actual_frame.min.x - (target_width - actual_width))
+    })
+}
+
 #[derive(Debug)]
 pub enum WindowPadding {
     Vertical(i32),
@@ -313,6 +332,56 @@ impl WindowOS {
         }
     }
 
+    fn set_ax_position(&mut self, origin: Origin) {
+        let mut point = CGPoint::new(
+            f64::from(origin.x + self.horizontal_padding),
+            f64::from(origin.y + self.vertical_padding),
+        );
+        let position_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGPoint,
+                NonNull::from(&mut point).as_ptr().cast(),
+            )
+        };
+        if let Ok(position) = AXUIWrapper::retain(position_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
+                    position.as_ref(),
+                )
+            };
+            let size = self.frame.size();
+            self.frame.min = origin;
+            self.frame.max = origin + size;
+        }
+    }
+
+    fn set_ax_size(&mut self, size: Size) {
+        let width_padding = 2 * self.horizontal_padding;
+        let height_padding = 2 * self.vertical_padding;
+        let mut cgsize = CGSize::new(
+            f64::from(size.x - width_padding),
+            f64::from(size.y - height_padding),
+        );
+        let size_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGSize,
+                NonNull::from(&mut cgsize).as_ptr().cast(),
+            )
+        };
+        if let Ok(size_value) = AXUIWrapper::retain(size_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
+                    size_value.as_ref(),
+                )
+            };
+            self.frame.max = self.frame.min + size;
+        }
+    }
+
     /// Makes the window the key window for its application by sending synthesized events.
     ///
     /// # Arguments
@@ -424,28 +493,7 @@ impl WindowApi for WindowOS {
             return;
         }
         self.disable_enhanced_ui();
-        let mut point = CGPoint::new(
-            f64::from(origin.x + self.horizontal_padding),
-            f64::from(origin.y + self.vertical_padding),
-        );
-        let position_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGPoint,
-                NonNull::from(&mut point).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(position_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
-                    position.as_ref(),
-                )
-            };
-            let size = self.frame.size();
-            self.frame.min = origin;
-            self.frame.max = origin + size;
-        }
+        self.set_ax_position(origin);
         self.reenable_enhanced_ui();
     }
 
@@ -455,28 +503,44 @@ impl WindowApi for WindowOS {
             trace!("already correct size.");
             return;
         }
+        let previous_frame = self.frame;
+        let target_origin = previous_frame.min;
         self.disable_enhanced_ui();
-        let width_padding = 2 * self.horizontal_padding;
-        let height_padding = 2 * self.vertical_padding;
-        let mut cgsize = CGSize::new(
-            f64::from(size.x - width_padding),
-            f64::from(size.y - height_padding),
-        );
-        let size_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGSize,
-                NonNull::from(&mut cgsize).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(size_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
-                    position.as_ref(),
-                )
+        self.set_ax_size(size);
+
+        let mut previous_observed_frame = previous_frame;
+        let mut staged = false;
+        for attempt in 1..=3 {
+            let Ok(actual_frame) = self.update_frame() else {
+                break;
             };
-            self.frame.max = self.frame.min + size;
+            let Some(staging_origin) =
+                resize_staging_origin(previous_observed_frame, actual_frame, size.x)
+            else {
+                break;
+            };
+            debug!(
+                attempt,
+                requested_width = size.x,
+                actual_width = actual_frame.width(),
+                staging_x = staging_origin.x,
+                "retrying partially constrained AX resize from an offscreen origin"
+            );
+            staged = true;
+            previous_observed_frame = actual_frame;
+            self.set_ax_position(staging_origin);
+            self.set_ax_size(size);
+        }
+
+        if staged {
+            if let Ok(final_frame) = self.update_frame() {
+                debug!(
+                    requested_width = size.x,
+                    actual_width = final_frame.width(),
+                    "completed staged AX resize"
+                );
+            }
+            self.set_ax_position(target_origin);
         }
         self.reenable_enhanced_ui();
     }
@@ -664,5 +728,37 @@ impl WindowApi for WindowOS {
             // Get first corner radius (usually all corners are the same)
             radii.get(0)?.as_i64().map(|v| v as f64)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stages_partially_applied_width_growth() {
+        let previous = IRect::new(-400, 40, 400, 640);
+        let actual = IRect::new(-400, 40, 2416, 640);
+
+        assert_eq!(
+            resize_staging_origin(previous, actual, 4112),
+            Some(Origin::new(-1696, 40))
+        );
+
+        let nearly_complete = IRect::new(-2056, 40, 2016, 640);
+        assert_eq!(
+            resize_staging_origin(actual, nearly_complete, 4112),
+            Some(Origin::new(-2096, 40))
+        );
+    }
+
+    #[test]
+    fn does_not_stage_fixed_size_or_completed_resizes() {
+        let fixed = IRect::new(0, 40, 230, 448);
+        assert_eq!(resize_staging_origin(fixed, fixed, 4112), None);
+
+        let previous = IRect::new(0, 40, 800, 640);
+        let completed = IRect::new(0, 40, 4112, 640);
+        assert_eq!(resize_staging_origin(previous, completed, 4112), None);
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -80,13 +80,30 @@ pub struct MenuBarManager {
     menu: Retained<NSMenu>,
     action_target: Retained<MenuActionTarget>,
     width_items: Vec<(i32, Retained<NSMenuItem>)>,
-    window_items: Vec<Retained<NSMenuItem>>,
+    managed_window_items: Vec<Retained<NSMenuItem>>,
+    manage_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
     current_label: Option<String>,
 }
 
 const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
 const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
+
+#[derive(Debug, Eq, PartialEq)]
+struct WindowMenuEnablement {
+    managed_actions: bool,
+    toggle_managed: bool,
+}
+
+fn window_menu_enablement(
+    has_focused_window: bool,
+    focused_width_ratio: Option<f64>,
+) -> WindowMenuEnablement {
+    WindowMenuEnablement {
+        managed_actions: focused_width_ratio.is_some(),
+        toggle_managed: has_focused_window,
+    }
+}
 
 impl MenuBarManager {
     pub fn new(mtm: MainThreadMarker, events: EventSender) -> Self {
@@ -106,7 +123,8 @@ impl MenuBarManager {
             menu,
             action_target,
             width_items: Vec::new(),
-            window_items: Vec::new(),
+            managed_window_items: Vec::new(),
+            manage_item: None,
             configured_widths: Vec::new(),
             current_label: None,
         }
@@ -117,6 +135,7 @@ impl MenuBarManager {
         virtual_index: u32,
         show_virtual_workspace: bool,
         preset_widths: &[f64],
+        has_focused_window: bool,
         focused_width_ratio: Option<f64>,
     ) {
         let widths = normalized_width_percentages(preset_widths);
@@ -124,9 +143,12 @@ impl MenuBarManager {
             self.rebuild_menu(&widths);
         }
 
-        let has_focused_window = focused_width_ratio.is_some();
-        for item in &self.window_items {
-            item.setEnabled(has_focused_window);
+        let enablement = window_menu_enablement(has_focused_window, focused_width_ratio);
+        for item in &self.managed_window_items {
+            item.setEnabled(enablement.managed_actions);
+        }
+        if let Some(manage_item) = &self.manage_item {
+            manage_item.setEnabled(enablement.toggle_managed);
         }
         for (percentage, item) in &self.width_items {
             let selected = focused_width_ratio
@@ -149,7 +171,8 @@ impl MenuBarManager {
     fn rebuild_menu(&mut self, widths: &[i32]) {
         self.menu.removeAllItems();
         self.width_items.clear();
-        self.window_items.clear();
+        self.managed_window_items.clear();
+        self.manage_item = None;
 
         let status = self.add_item("Paneru — Running", None);
         status.setEnabled(false);
@@ -160,14 +183,15 @@ impl MenuBarManager {
         for &percentage in widths {
             let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
             item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
-            self.window_items.push(item.clone());
+            self.managed_window_items.push(item.clone());
             self.width_items.push((percentage, item));
         }
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
         let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
-        self.window_items.extend([center, manage]);
+        self.managed_window_items.push(center);
+        self.manage_item = Some(manage);
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
@@ -236,21 +260,21 @@ pub fn update_menu_bar(
         return;
     };
 
-    let focused_width_ratio = active_display
-        .iter()
-        .next()
-        .zip(focused.iter().next())
-        .and_then(|((display, dock), (bounds, unmanaged))| {
+    let focused_window = focused.iter().next();
+    let focused_width_ratio = active_display.iter().next().zip(focused_window).and_then(
+        |((display, dock), (bounds, unmanaged))| {
             (!unmanaged).then(|| {
                 f64::from(bounds.0.x)
                     / f64::from(display.actual_display_bounds(dock, &config).width())
             })
-        });
+        },
+    );
 
     menu_bar.update(
         strip.virtual_index,
         config.workspace_menu_status(),
         &config.preset_column_widths(),
+        focused_window.is_some(),
         focused_width_ratio,
     );
 }
@@ -274,7 +298,10 @@ fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_virtual_workspace_label, normalized_width_percentages};
+    use super::{
+        WindowMenuEnablement, format_virtual_workspace_label, normalized_width_percentages,
+        window_menu_enablement,
+    };
 
     #[test]
     fn label_is_one_based() {
@@ -287,6 +314,31 @@ mod tests {
         assert_eq!(
             normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
             vec![50, 150, 200]
+        );
+    }
+
+    #[test]
+    fn unmanaged_focus_only_enables_toggle_managed() {
+        assert_eq!(
+            window_menu_enablement(true, None),
+            WindowMenuEnablement {
+                managed_actions: false,
+                toggle_managed: true,
+            }
+        );
+        assert_eq!(
+            window_menu_enablement(false, None),
+            WindowMenuEnablement {
+                managed_actions: false,
+                toggle_managed: false,
+            }
+        );
+        assert_eq!(
+            window_menu_enablement(true, Some(1.0)),
+            WindowMenuEnablement {
+                managed_actions: true,
+                toggle_managed: true,
+            }
         );
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,20 +1,87 @@
 use bevy::ecs::entity::Entity;
-use bevy::ecs::query::With;
-use bevy::ecs::system::{Local, NonSendMut, Query};
-use objc2::MainThreadMarker;
+use bevy::ecs::query::{Has, With};
+use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
-use objc2_app_kit::{NSColor, NSStatusBar, NSStatusItem, NSVariableStatusItemLength};
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+use objc2_app_kit::{
+    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSStatusBar,
+    NSStatusItem, NSVariableStatusItemLength,
+};
 use objc2_core_foundation::CGFloat;
-use objc2_foundation::NSString;
+use objc2_foundation::{NSObject, NSString};
 use tracing::warn;
 
-use crate::ecs::ActiveWorkspaceMarker;
+use crate::commands::{Command, Operation};
+use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
+use crate::ecs::{
+    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Unmanaged,
+};
+use crate::events::{Event, EventSender};
+use crate::manager::Display;
+
+#[derive(Debug, Clone)]
+struct MenuActionTargetIvars {
+    events: EventSender,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PaneruMenuActionTarget"]
+    #[ivars = MenuActionTargetIvars]
+    #[derive(Debug)]
+    struct MenuActionTarget;
+
+    impl MenuActionTarget {
+        #[unsafe(method(setWidth:))]
+        fn set_width(&self, item: &NSMenuItem) {
+            let Ok(percentage) = i32::try_from(item.tag()) else {
+                return;
+            };
+            let ratio = f64::from(percentage) / 100.0;
+            self.send_command(Command::Window(Operation::SetWidth(ratio)));
+        }
+
+        #[unsafe(method(centerWindow:))]
+        fn center_window(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::Center));
+        }
+
+        #[unsafe(method(toggleManaged:))]
+        fn toggle_managed(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::Manage));
+        }
+
+        #[unsafe(method(quitPaneru:))]
+        fn quit_paneru(&self, _: &NSMenuItem) {
+            self.send_command(Command::Quit);
+        }
+    }
+);
+
+impl MenuActionTarget {
+    fn new(mtm: MainThreadMarker, events: EventSender) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(MenuActionTargetIvars { events });
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn send_command(&self, command: Command) {
+        if let Err(error) = self.ivars().events.send(Event::Command { command }) {
+            warn!(%error, "unable to send menu bar command");
+        }
+    }
+}
 
 pub struct MenuBarManager {
     mtm: MainThreadMarker,
     status_bar: Retained<NSStatusBar>,
     status_item: Retained<NSStatusItem>,
+    menu: Retained<NSMenu>,
+    action_target: Retained<MenuActionTarget>,
+    width_items: Vec<(i32, Retained<NSMenuItem>)>,
+    window_items: Vec<Retained<NSMenuItem>>,
+    configured_widths: Vec<i32>,
     current_label: Option<String>,
 }
 
@@ -22,27 +89,112 @@ const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
 const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
 
 impl MenuBarManager {
-    pub fn new(mtm: MainThreadMarker) -> Self {
+    pub fn new(mtm: MainThreadMarker, events: EventSender) -> Self {
         let status_bar = NSStatusBar::systemStatusBar();
         let status_item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
+        let menu = NSMenu::new(mtm);
+        let action_target = MenuActionTarget::new(mtm, events);
+
+        menu.setAutoenablesItems(false);
+        status_item.setMenu(Some(&menu));
         status_item.setVisible(true);
 
         Self {
             mtm,
             status_bar,
             status_item,
+            menu,
+            action_target,
+            width_items: Vec::new(),
+            window_items: Vec::new(),
+            configured_widths: Vec::new(),
             current_label: None,
         }
     }
 
-    pub fn show_virtual_workspace(&mut self, virtual_index: u32) {
-        let label = format_virtual_workspace_label(virtual_index);
+    pub fn update(
+        &mut self,
+        virtual_index: u32,
+        show_virtual_workspace: bool,
+        preset_widths: &[f64],
+        focused_width_ratio: Option<f64>,
+    ) {
+        let widths = normalized_width_percentages(preset_widths);
+        if self.configured_widths != widths {
+            self.rebuild_menu(&widths);
+        }
+
+        let has_focused_window = focused_width_ratio.is_some();
+        for item in &self.window_items {
+            item.setEnabled(has_focused_window);
+        }
+        for (percentage, item) in &self.width_items {
+            let selected = focused_width_ratio
+                .is_some_and(|ratio| (ratio.mul_add(100.0, -f64::from(*percentage))).abs() < 1.0);
+            item.setState(if selected {
+                NSControlStateValueOn
+            } else {
+                NSControlStateValueOff
+            });
+        }
+
+        let label = if show_virtual_workspace {
+            format_virtual_workspace_label(virtual_index)
+        } else {
+            "Paneru".to_owned()
+        };
+        self.show_label(label);
+    }
+
+    fn rebuild_menu(&mut self, widths: &[i32]) {
+        self.menu.removeAllItems();
+        self.width_items.clear();
+        self.window_items.clear();
+
+        let status = self.add_item("Paneru — Running", None);
+        status.setEnabled(false);
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+
+        let width_header = self.add_item("Window width", None);
+        width_header.setEnabled(false);
+        for &percentage in widths {
+            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
+            item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
+            self.window_items.push(item.clone());
+            self.width_items.push((percentage, item));
+        }
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
+        let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
+        self.window_items.extend([center, manage]);
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
+        self.configured_widths = widths.to_vec();
+    }
+
+    fn add_item(&self, title: &str, action: Option<objc2::runtime::Sel>) -> Retained<NSMenuItem> {
+        let item = unsafe {
+            self.menu.addItemWithTitle_action_keyEquivalent(
+                &NSString::from_str(title),
+                action,
+                &NSString::from_str(""),
+            )
+        };
+        if action.is_some() {
+            unsafe { item.setTarget(Some(&self.action_target)) };
+        }
+        item
+    }
+
+    fn show_label(&mut self, label: String) {
         if self.current_label.as_deref() == Some(label.as_str()) {
             return;
         }
 
         let title = NSString::from_str(&label);
-        let tooltip = NSString::from_str("Paneru virtual workspace");
+        let tooltip = NSString::from_str("Paneru window manager");
         let Some(button) = self.status_item.button(self.mtm) else {
             warn!("unable to update menu bar: status item has no button");
             return;
@@ -69,41 +221,72 @@ impl Drop for MenuBarManager {
     }
 }
 
-pub fn update_virtual_workspace_status_item(
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub fn update_menu_bar(
     active_workspace: Query<(Entity, &LayoutStrip), With<ActiveWorkspaceMarker>>,
+    active_display: Query<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
+    focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
+    config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
-    mut displayed_workspace: Local<Option<(Entity, u32)>>,
 ) {
     let Some(mut menu_bar) = menu_bar else {
         return;
     };
-    let Some((entity, strip)) = active_workspace.iter().next() else {
+    let Some((_, strip)) = active_workspace.iter().next() else {
         return;
     };
 
-    let next = (entity, strip.virtual_index);
-    if displayed_workspace
-        .as_ref()
-        .is_some_and(|displayed| *displayed == next)
-    {
-        return;
-    }
+    let focused_width_ratio = active_display
+        .iter()
+        .next()
+        .zip(focused.iter().next())
+        .and_then(|((display, dock), (bounds, unmanaged))| {
+            (!unmanaged).then(|| {
+                f64::from(bounds.0.x)
+                    / f64::from(display.actual_display_bounds(dock, &config).width())
+            })
+        });
 
-    menu_bar.show_virtual_workspace(strip.virtual_index);
-    *displayed_workspace = Some(next);
+    menu_bar.update(
+        strip.virtual_index,
+        config.workspace_menu_status(),
+        &config.preset_column_widths(),
+        focused_width_ratio,
+    );
 }
 
 pub(crate) fn format_virtual_workspace_label(virtual_index: u32) -> String {
     format!("VW {}", virtual_index + 1)
 }
 
+fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
+    let mut percentages = widths
+        .iter()
+        .copied()
+        .filter(|ratio| ratio.is_finite() && *ratio > 0.0)
+        .map(|ratio| ratio.mul_add(100.0, 0.0).round() as i32)
+        .filter(|percentage| *percentage > 0)
+        .collect::<Vec<_>>();
+    percentages.sort_unstable();
+    percentages.dedup();
+    percentages
+}
+
 #[cfg(test)]
 mod tests {
-    use super::format_virtual_workspace_label;
+    use super::{format_virtual_workspace_label, normalized_width_percentages};
 
     #[test]
     fn label_is_one_based() {
         assert_eq!(format_virtual_workspace_label(0), "VW 1");
         assert_eq!(format_virtual_workspace_label(4), "VW 5");
+    }
+
+    #[test]
+    fn menu_widths_are_sorted_deduplicated_and_valid() {
+        assert_eq!(
+            normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
+            vec![50, 150, 200]
+        );
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -4,8 +4,8 @@ use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
 use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
 use objc2_app_kit::{
-    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSStatusBar,
-    NSStatusItem, NSVariableStatusItemLength,
+    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSEventModifierFlags, NSMenu,
+    NSMenuItem, NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
 };
 use objc2_core_foundation::CGFloat;
 use objc2_foundation::{NSObject, NSString};
@@ -19,6 +19,7 @@ use crate::ecs::{
 };
 use crate::events::{Event, EventSender};
 use crate::manager::Display;
+use crate::platform::Modifiers;
 
 #[derive(Debug, Clone)]
 struct MenuActionTargetIvars {
@@ -83,6 +84,7 @@ pub struct MenuBarManager {
     managed_window_items: Vec<Retained<NSMenuItem>>,
     manage_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
+    configured_shortcuts: MenuShortcuts,
     current_label: Option<String>,
 }
 
@@ -93,6 +95,20 @@ const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
 struct WindowMenuEnablement {
     managed_actions: bool,
     toggle_managed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MenuShortcut {
+    key: String,
+    modifiers: u8,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct MenuShortcuts {
+    widths: Vec<(i32, Option<MenuShortcut>)>,
+    center: Option<MenuShortcut>,
+    manage: Option<MenuShortcut>,
+    quit: Option<MenuShortcut>,
 }
 
 fn window_menu_enablement(
@@ -126,21 +142,23 @@ impl MenuBarManager {
             managed_window_items: Vec::new(),
             manage_item: None,
             configured_widths: Vec::new(),
+            configured_shortcuts: MenuShortcuts::default(),
             current_label: None,
         }
     }
 
-    pub fn update(
+    fn update(
         &mut self,
         virtual_index: u32,
         show_virtual_workspace: bool,
         preset_widths: &[f64],
         has_focused_window: bool,
         focused_width_ratio: Option<f64>,
+        shortcuts: &MenuShortcuts,
     ) {
         let widths = normalized_width_percentages(preset_widths);
-        if self.configured_widths != widths {
-            self.rebuild_menu(&widths);
+        if self.configured_widths != widths || self.configured_shortcuts != *shortcuts {
+            self.rebuild_menu(&widths, shortcuts);
         }
 
         let enablement = window_menu_enablement(has_focused_window, focused_width_ratio);
@@ -168,37 +186,60 @@ impl MenuBarManager {
         self.show_label(label);
     }
 
-    fn rebuild_menu(&mut self, widths: &[i32]) {
+    fn rebuild_menu(&mut self, widths: &[i32], shortcuts: &MenuShortcuts) {
         self.menu.removeAllItems();
         self.width_items.clear();
         self.managed_window_items.clear();
         self.manage_item = None;
 
-        let status = self.add_item("Paneru — Running", None);
+        let status = self.add_item("Paneru — Running", None, None);
         status.setEnabled(false);
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
 
-        let width_header = self.add_item("Window width", None);
+        let width_header = self.add_item("Window width", None, None);
         width_header.setEnabled(false);
         for &percentage in widths {
-            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
+            let shortcut = shortcuts
+                .widths
+                .iter()
+                .find_map(|(width, shortcut)| (*width == percentage).then_some(shortcut))
+                .and_then(Option::as_ref);
+            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)), shortcut);
             item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
             self.managed_window_items.push(item.clone());
             self.width_items.push((percentage, item));
         }
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
-        let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
-        let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
+        let center = self.add_item(
+            "Center Window",
+            Some(sel!(centerWindow:)),
+            shortcuts.center.as_ref(),
+        );
+        let manage = self.add_item(
+            "Toggle Managed",
+            Some(sel!(toggleManaged:)),
+            shortcuts.manage.as_ref(),
+        );
         self.managed_window_items.push(center);
         self.manage_item = Some(manage);
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
-        self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
+        self.add_item(
+            "Quit Paneru",
+            Some(sel!(quitPaneru:)),
+            shortcuts.quit.as_ref(),
+        );
         self.configured_widths = widths.to_vec();
+        self.configured_shortcuts = shortcuts.clone();
     }
 
-    fn add_item(&self, title: &str, action: Option<objc2::runtime::Sel>) -> Retained<NSMenuItem> {
+    fn add_item(
+        &self,
+        title: &str,
+        action: Option<objc2::runtime::Sel>,
+        shortcut: Option<&MenuShortcut>,
+    ) -> Retained<NSMenuItem> {
         let item = unsafe {
             self.menu.addItemWithTitle_action_keyEquivalent(
                 &NSString::from_str(title),
@@ -208,6 +249,10 @@ impl MenuBarManager {
         };
         if action.is_some() {
             unsafe { item.setTarget(Some(&self.action_target)) };
+        }
+        if let Some(shortcut) = shortcut {
+            item.setKeyEquivalent(&NSString::from_str(&shortcut.key));
+            item.setKeyEquivalentModifierMask(native_modifier_flags(shortcut.modifiers));
         }
         item
     }
@@ -270,12 +315,15 @@ pub fn update_menu_bar(
         },
     );
 
+    let preset_widths = config.preset_column_widths();
+    let shortcuts = menu_shortcuts(&config, &preset_widths);
     menu_bar.update(
         strip.virtual_index,
         config.workspace_menu_status(),
-        &config.preset_column_widths(),
+        &preset_widths,
         focused_window.is_some(),
         focused_width_ratio,
+        &shortcuts,
     );
 }
 
@@ -296,12 +344,88 @@ fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
     percentages
 }
 
+fn menu_shortcuts(config: &Config, widths: &[f64]) -> MenuShortcuts {
+    let widths = normalized_width_percentages(widths)
+        .into_iter()
+        .map(|percentage| {
+            let command_name = format!("window_width_{percentage}");
+            (
+                percentage,
+                config
+                    .first_keybinding(&command_name)
+                    .and_then(|binding| menu_shortcut(&binding.key, binding.modifiers)),
+            )
+        })
+        .collect();
+
+    let shortcut = |command_name| {
+        config
+            .first_keybinding(command_name)
+            .and_then(|binding| menu_shortcut(&binding.key, binding.modifiers))
+    };
+
+    MenuShortcuts {
+        widths,
+        center: shortcut("window_center"),
+        manage: shortcut("window_manage"),
+        quit: shortcut("quit"),
+    }
+}
+
+fn menu_shortcut(key: &str, modifiers: Modifiers) -> Option<MenuShortcut> {
+    let key = match key {
+        "equal" => "=",
+        "minus" => "-",
+        "rightbracket" => "]",
+        "leftbracket" => "[",
+        "quote" => "'",
+        "semicolon" => ";",
+        "backslash" => "\\",
+        "comma" => ",",
+        "slash" => "/",
+        "period" => ".",
+        "grave" => "`",
+        "return" | "keypadenter" => "\r",
+        "tab" => "\t",
+        "space" => " ",
+        "delete" => "\u{8}",
+        "escape" => "\u{1b}",
+        key if key.chars().count() == 1 => key,
+        _ => return None,
+    };
+
+    Some(MenuShortcut {
+        key: key.to_owned(),
+        modifiers: modifiers.bits(),
+    })
+}
+
+fn native_modifier_flags(modifier_bits: u8) -> NSEventModifierFlags {
+    let modifiers = Modifiers::from_bits_retain(modifier_bits);
+    let mut flags = NSEventModifierFlags::empty();
+    if modifiers.intersects(Modifiers::SHIFT) {
+        flags |= NSEventModifierFlags::Shift;
+    }
+    if modifiers.intersects(Modifiers::CTRL) {
+        flags |= NSEventModifierFlags::Control;
+    }
+    if modifiers.intersects(Modifiers::ALT) {
+        flags |= NSEventModifierFlags::Option;
+    }
+    if modifiers.intersects(Modifiers::CMD) {
+        flags |= NSEventModifierFlags::Command;
+    }
+    flags
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        WindowMenuEnablement, format_virtual_workspace_label, normalized_width_percentages,
-        window_menu_enablement,
+        WindowMenuEnablement, format_virtual_workspace_label, menu_shortcut, menu_shortcuts,
+        normalized_width_percentages, window_menu_enablement,
     };
+    use crate::config::Config;
+    use crate::platform::Modifiers;
 
     #[test]
     fn label_is_one_based() {
@@ -314,6 +438,48 @@ mod tests {
         assert_eq!(
             normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
             vec![50, 150, 200]
+        );
+    }
+
+    #[test]
+    fn menu_shortcut_uses_native_key_and_preserves_modifiers() {
+        let shortcut = menu_shortcut("1", Modifiers::LCTRL | Modifiers::RALT | Modifiers::LCMD)
+            .expect("shortcut should be representable");
+        assert_eq!(shortcut.key, "1");
+        assert_eq!(
+            shortcut.modifiers,
+            (Modifiers::LCTRL | Modifiers::RALT | Modifiers::LCMD).bits()
+        );
+    }
+
+    #[test]
+    fn menu_shortcuts_come_from_command_bindings() {
+        let config = Config::try_from(
+            r#"
+[options]
+
+[bindings]
+window_width_150 = "ctrl+alt+cmd-4"
+window_center = "ctrl+alt+cmd-c"
+"#,
+        )
+        .expect("bindings should parse");
+
+        let shortcuts = menu_shortcuts(&config, &[1.0, 1.5]);
+        assert_eq!(shortcuts.widths[0], (100, None));
+        assert_eq!(
+            shortcuts.widths[1]
+                .1
+                .as_ref()
+                .map(|shortcut| shortcut.key.as_str()),
+            Some("4")
+        );
+        assert_eq!(
+            shortcuts
+                .center
+                .as_ref()
+                .map(|shortcut| shortcut.key.as_str()),
+            Some("c")
         );
     }
 

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -20,6 +20,7 @@ use crate::ecs::{
 use crate::events::{Event, EventSender};
 use crate::manager::Display;
 use crate::platform::Modifiers;
+use crate::updater::SparkleUpdater;
 
 #[derive(Debug, Clone)]
 struct MenuActionTargetIvars {
@@ -86,6 +87,8 @@ pub struct MenuBarManager {
     configured_widths: Vec<i32>,
     configured_shortcuts: MenuShortcuts,
     current_label: Option<String>,
+    updater: Option<SparkleUpdater>,
+    check_for_updates_item: Option<Retained<NSMenuItem>>,
 }
 
 const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
@@ -144,6 +147,8 @@ impl MenuBarManager {
             configured_widths: Vec::new(),
             configured_shortcuts: MenuShortcuts::default(),
             current_label: None,
+            updater: SparkleUpdater::load(mtm),
+            check_for_updates_item: None,
         }
     }
 
@@ -156,6 +161,10 @@ impl MenuBarManager {
         focused_width_ratio: Option<f64>,
         shortcuts: &MenuShortcuts,
     ) {
+        if let Some(updater) = &mut self.updater {
+            updater.maybe_check_silently();
+        }
+
         let widths = normalized_width_percentages(preset_widths);
         if self.configured_widths != widths || self.configured_shortcuts != *shortcuts {
             self.rebuild_menu(&widths, shortcuts);
@@ -168,6 +177,25 @@ impl MenuBarManager {
         if let Some(manage_item) = &self.manage_item {
             manage_item.setEnabled(enablement.toggle_managed);
         }
+        if let Some(item) = &self.check_for_updates_item {
+            let status = self.updater.as_ref().map(SparkleUpdater::status);
+            let title = match status.as_ref() {
+                Some(status) if status.is_checking => "Checking for Updates…".to_owned(),
+                Some(status) if status.available_version.is_some() => {
+                    format!(
+                        "Update {}…",
+                        status.available_version.as_deref().unwrap_or_default()
+                    )
+                }
+                _ => "Check for Updates…".to_owned(),
+            };
+            item.setTitle(&NSString::from_str(&title));
+            item.setEnabled(
+                self.updater
+                    .as_ref()
+                    .is_some_and(SparkleUpdater::can_check_for_updates),
+            );
+        }
         for (percentage, item) in &self.width_items {
             let selected = focused_width_ratio
                 .is_some_and(|ratio| (ratio.mul_add(100.0, -f64::from(*percentage))).abs() < 1.0);
@@ -178,11 +206,18 @@ impl MenuBarManager {
             });
         }
 
-        let label = if show_virtual_workspace {
+        let mut label = if show_virtual_workspace {
             format_virtual_workspace_label(virtual_index)
         } else {
             "Paneru".to_owned()
         };
+        if self
+            .updater
+            .as_ref()
+            .is_some_and(|updater| updater.status().available_version.is_some())
+        {
+            label.push_str(" •");
+        }
         self.show_label(label);
     }
 
@@ -191,6 +226,7 @@ impl MenuBarManager {
         self.width_items.clear();
         self.managed_window_items.clear();
         self.manage_item = None;
+        self.check_for_updates_item = None;
 
         let status = self.add_item("Paneru — Running", None, None);
         status.setEnabled(false);
@@ -225,6 +261,17 @@ impl MenuBarManager {
         self.manage_item = Some(manage);
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        let check_for_updates =
+            self.add_item("Check for Updates…", Some(sel!(checkForUpdates:)), None);
+        if let Some(updater) = &self.updater {
+            unsafe { check_for_updates.setTarget(Some(updater.controller_target())) };
+            check_for_updates.setEnabled(updater.can_check_for_updates());
+        } else {
+            unsafe { check_for_updates.setTarget(None) };
+            check_for_updates.setEnabled(false);
+        }
+        self.check_for_updates_item = Some(check_for_updates);
+
         self.add_item(
             "Quit Paneru",
             Some(sel!(quitPaneru:)),

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,24 +1,26 @@
+use bevy::ecs::change_detection::DetectChanges;
 use bevy::ecs::entity::Entity;
-use bevy::ecs::query::{Has, With};
-use bevy::ecs::system::{NonSendMut, Query, Res};
+use bevy::ecs::lifecycle::RemovedComponents;
+use bevy::ecs::message::MessageReader;
+use bevy::ecs::query::{Added, Changed, Has, Or, With};
+use bevy::ecs::system::{Local, NonSendMut, Query, Res};
 use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
 use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
 use objc2_app_kit::{
     NSColor, NSControlStateValueOff, NSControlStateValueOn, NSEventModifierFlags, NSMenu,
-    NSMenuItem, NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
+    NSMenuDelegate, NSMenuItem, NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
 };
 use objc2_core_foundation::CGFloat;
-use objc2_foundation::{NSObject, NSString};
+use objc2_foundation::{NSObject, NSObjectProtocol, NSString};
+use std::time::Instant;
 use tracing::warn;
 
 use crate::commands::{Command, Operation};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
-use crate::ecs::{
-    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Unmanaged,
-};
+use crate::ecs::{ActiveWorkspaceMarker, FocusedMarker, Unmanaged, WidthRatio};
 use crate::events::{Event, EventSender};
-use crate::manager::Display;
 use crate::platform::Modifiers;
 use crate::updater::SparkleUpdater;
 
@@ -34,6 +36,8 @@ define_class!(
     #[ivars = MenuActionTargetIvars]
     #[derive(Debug)]
     struct MenuActionTarget;
+
+    unsafe impl NSObjectProtocol for MenuActionTarget {}
 
     impl MenuActionTarget {
         #[unsafe(method(setWidth:))]
@@ -58,6 +62,15 @@ define_class!(
         #[unsafe(method(quitPaneru:))]
         fn quit_paneru(&self, _: &NSMenuItem) {
             self.send_command(Command::Quit);
+        }
+    }
+
+    unsafe impl NSMenuDelegate for MenuActionTarget {
+        #[unsafe(method(menuWillOpen:))]
+        fn menu_will_open(&self, _: &NSMenu) {
+            if let Err(error) = self.ivars().events.send(Event::StatusMenuOpened) {
+                warn!(%error, "unable to request menu refresh");
+            }
         }
     }
 );
@@ -87,6 +100,7 @@ pub struct MenuBarManager {
     configured_widths: Vec<i32>,
     configured_shortcuts: MenuShortcuts,
     current_label: Option<String>,
+    publication: MenuPublicationGate,
     updater: Option<SparkleUpdater>,
     check_for_updates_item: Option<Retained<NSMenuItem>>,
 }
@@ -98,6 +112,35 @@ const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
 struct WindowMenuEnablement {
     managed_actions: bool,
     toggle_managed: bool,
+}
+
+#[derive(Default)]
+struct MenuPublicationGate {
+    published: bool,
+}
+
+impl MenuPublicationGate {
+    fn publish_after_update(&mut self) -> bool {
+        if self.published {
+            false
+        } else {
+            self.published = true;
+            true
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct MenuDirtyGate {
+    initialized: bool,
+}
+
+impl MenuDirtyGate {
+    fn should_update(&mut self, changed: bool) -> bool {
+        let first = !self.initialized;
+        self.initialized = true;
+        first || changed
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -129,11 +172,15 @@ impl MenuBarManager {
         let status_bar = NSStatusBar::systemStatusBar();
         let status_item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
         let menu = NSMenu::new(mtm);
-        let action_target = MenuActionTarget::new(mtm, events);
+        let action_target = MenuActionTarget::new(mtm, events.clone());
 
         menu.setAutoenablesItems(false);
+        menu.setDelegate(Some(ProtocolObject::from_ref(&*action_target)));
         status_item.setMenu(Some(&menu));
-        status_item.setVisible(true);
+        // Keep the status item unclickable until the first ECS snapshot has
+        // built and enabled every menu item. This makes the first native open
+        // synchronous with initialized content rather than an async refresh.
+        status_item.setVisible(false);
 
         Self {
             mtm,
@@ -147,7 +194,8 @@ impl MenuBarManager {
             configured_widths: Vec::new(),
             configured_shortcuts: MenuShortcuts::default(),
             current_label: None,
-            updater: SparkleUpdater::load(mtm),
+            publication: MenuPublicationGate::default(),
+            updater: SparkleUpdater::load(mtm, events),
             check_for_updates_item: None,
         }
     }
@@ -161,10 +209,6 @@ impl MenuBarManager {
         focused_width_ratio: Option<f64>,
         shortcuts: &MenuShortcuts,
     ) {
-        if let Some(updater) = &mut self.updater {
-            updater.maybe_check_silently();
-        }
-
         let widths = normalized_width_percentages(preset_widths);
         if self.configured_widths != widths || self.configured_shortcuts != *shortcuts {
             self.rebuild_menu(&widths, shortcuts);
@@ -219,6 +263,19 @@ impl MenuBarManager {
             label.push_str(" •");
         }
         self.show_label(label);
+        if self.publication.publish_after_update() {
+            self.status_item.setVisible(true);
+        }
+    }
+
+    pub(crate) fn updater_deadline(&self) -> Option<Instant> {
+        self.updater.as_ref().map(SparkleUpdater::next_silent_check)
+    }
+
+    fn tick_silent_updater(&mut self, now: Instant) {
+        if let Some(updater) = &mut self.updater {
+            updater.maybe_check_silently(now);
+        }
     }
 
     fn rebuild_menu(&mut self, widths: &[i32], shortcuts: &MenuShortcuts) {
@@ -331,6 +388,12 @@ impl MenuBarManager {
     }
 }
 
+pub(crate) fn tick_silent_updater(menu_bar: Option<NonSendMut<MenuBarManager>>) {
+    if let Some(mut menu_bar) = menu_bar {
+        menu_bar.tick_silent_updater(Instant::now());
+    }
+}
+
 impl Drop for MenuBarManager {
     fn drop(&mut self) {
         self.status_bar.removeStatusItem(&self.status_item);
@@ -340,8 +403,7 @@ impl Drop for MenuBarManager {
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 pub fn update_menu_bar(
     active_workspace: Query<(Entity, &LayoutStrip), With<ActiveWorkspaceMarker>>,
-    active_display: Query<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
-    focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
+    focused: Query<(&WidthRatio, Has<Unmanaged>), With<FocusedMarker>>,
     config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
 ) {
@@ -353,14 +415,9 @@ pub fn update_menu_bar(
     };
 
     let focused_window = focused.iter().next();
-    let focused_width_ratio = active_display.iter().next().zip(focused_window).and_then(
-        |((display, dock), (bounds, unmanaged))| {
-            (!unmanaged).then(|| {
-                f64::from(bounds.0.x)
-                    / f64::from(display.actual_display_bounds(dock, &config).width())
-            })
-        },
-    );
+    let focused_width_ratio = focused_window
+        .filter(|(_, unmanaged)| !unmanaged)
+        .map(|(ratio, _)| ratio.0);
 
     let preset_widths = config.preset_column_widths();
     let shortcuts = menu_shortcuts(&config, &preset_widths);
@@ -372,6 +429,45 @@ pub fn update_menu_bar(
         focused_width_ratio,
         &shortcuts,
     );
+}
+
+/// Gates `AppKit` mutations behind state that can change the visible menu.
+/// The first update initializes the status item; subsequent animation frames
+/// do no menu work unless focus, layout, ownership, updater status, or
+/// configuration changed. Width selection uses the logical `WidthRatio`, so
+/// animation-only `Bounds` changes never require an open-time refresh.
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub fn menu_bar_dirty(
+    mut gate: Local<MenuDirtyGate>,
+    config: Res<Config>,
+    active_workspace: Query<
+        (),
+        (
+            With<ActiveWorkspaceMarker>,
+            Or<(Added<ActiveWorkspaceMarker>, Changed<LayoutStrip>)>,
+        ),
+    >,
+    focused: Query<
+        (),
+        (
+            With<FocusedMarker>,
+            Or<(Added<FocusedMarker>, Changed<Unmanaged>)>,
+        ),
+    >,
+    mut focus_removed: RemovedComponents<FocusedMarker>,
+    mut unmanaged_removed: RemovedComponents<Unmanaged>,
+    mut events: MessageReader<Event>,
+) -> bool {
+    let event_dirty = events
+        .read()
+        .any(|event| matches!(event, Event::StatusMenuOpened | Event::UpdaterStatusChanged));
+    let changed = config.is_changed()
+        || !active_workspace.is_empty()
+        || !focused.is_empty()
+        || focus_removed.read().next().is_some()
+        || unmanaged_removed.read().next().is_some()
+        || event_dirty;
+    gate.should_update(changed)
 }
 
 pub(crate) fn format_virtual_workspace_label(virtual_index: u32) -> String {
@@ -468,16 +564,34 @@ fn native_modifier_flags(modifier_bits: u8) -> NSEventModifierFlags {
 #[cfg(test)]
 mod tests {
     use super::{
-        WindowMenuEnablement, format_virtual_workspace_label, menu_shortcut, menu_shortcuts,
-        normalized_width_percentages, window_menu_enablement,
+        MenuDirtyGate, MenuPublicationGate, WindowMenuEnablement, format_virtual_workspace_label,
+        menu_bar_dirty, menu_shortcut, menu_shortcuts, normalized_width_percentages,
+        window_menu_enablement,
     };
     use crate::config::Config;
+    use crate::ecs::{Bounds, FocusedMarker};
+    use crate::events::Event;
     use crate::platform::Modifiers;
+    use bevy::app::{App, Update};
+    use bevy::ecs::message::Messages;
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::ecs::system::ResMut;
+    use bevy::math::IVec2;
 
     #[test]
     fn label_is_one_based() {
         assert_eq!(format_virtual_workspace_label(0), "VW 1");
         assert_eq!(format_virtual_workspace_label(4), "VW 5");
+    }
+
+    #[test]
+    fn status_item_is_published_only_after_first_content_update() {
+        let mut publication = MenuPublicationGate::default();
+        assert!(!publication.published);
+        assert!(publication.publish_after_update());
+        assert!(publication.published);
+        assert!(!publication.publish_after_update());
     }
 
     #[test]
@@ -553,5 +667,50 @@ window_center = "ctrl+alt+cmd-c"
                 toggle_managed: true,
             }
         );
+    }
+
+    #[test]
+    fn menu_dirty_gate_runs_once_then_only_for_changes() {
+        let mut gate = MenuDirtyGate::default();
+        assert!(gate.should_update(false));
+        assert!(!gate.should_update(false));
+        assert!(gate.should_update(true));
+    }
+
+    #[derive(Default, Resource)]
+    struct MenuUpdateCount(usize);
+
+    fn count_menu_update(mut count: ResMut<MenuUpdateCount>) {
+        count.0 += 1;
+    }
+
+    #[test]
+    fn animated_bounds_do_not_dirty_menu_but_updater_status_does() {
+        let mut app = App::new();
+        app.init_resource::<Messages<Event>>()
+            .init_resource::<MenuUpdateCount>()
+            .insert_resource(Config::default())
+            .add_systems(Update, count_menu_update.run_if(menu_bar_dirty));
+        let window = app
+            .world_mut()
+            .spawn((FocusedMarker, Bounds(IVec2::new(100, 100))))
+            .id();
+        app.update();
+        assert_eq!(app.world().resource::<MenuUpdateCount>().0, 1);
+
+        app.world_mut()
+            .entity_mut(window)
+            .get_mut::<Bounds>()
+            .unwrap()
+            .0
+            .x += 10;
+        app.update();
+        assert_eq!(app.world().resource::<MenuUpdateCount>().0, 1);
+
+        app.world_mut()
+            .resource_mut::<Messages<Event>>()
+            .write(Event::UpdaterStatusChanged);
+        app.update();
+        assert_eq!(app.world().resource::<MenuUpdateCount>().0, 2);
     }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,25 +1,28 @@
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use accessibility_sys::{AXError, AXObserverRef, AXUIElementRef};
 use objc2::MainThreadMarker;
 use objc2::rc::{Retained, autoreleasepool};
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSEventMask};
-use objc2_core_foundation::CFString;
+use objc2_core_foundation::{CFRunLoop, CFString, kCFRunLoopDefaultMode};
 use objc2_foundation::{NSDate, NSDefaultRunLoopMode, NSProcessInfo};
 use std::ffi::c_void;
+use std::marker::PhantomData;
 use std::pin::Pin;
+use std::rc::Rc;
 use tracing::error;
 
 use crate::config::{CONFIGURATION_FILE, Config};
 use crate::errors::{Error, Result};
-use crate::events::{Event, EventSender};
+use crate::events::{Event, EventSender, EventWakeSource};
 use crate::manager::{check_ax_privilege, check_separate_spaces};
 use crate::platform::display::PinnedDisplayHandler;
 use crate::platform::input::PinnedInputHandler;
 use crate::platform::notify::{NotifyHandler, PinnedNotifyHandler};
 use crate::platform::process::PinnedProcessHandler;
 use display::DisplayHandler;
-use input::InputHandler;
+use input::{InputHandler, RunningInputMask};
 use mission_control::MissionControlHandler;
 use process::ProcessHandler;
 pub use process::ProcessSerialNumber;
@@ -45,6 +48,22 @@ pub type Pid = i32;
 pub type CFStringRef = *const CFString;
 
 pub type WorkspaceId = u64;
+
+/// Capability proving that a Bevy system is executing in the AppKit/AX owner
+/// world. It is deliberately `!Send`/`!Sync` and can only be constructed from
+/// a `MainThreadMarker` in production.
+pub struct AxMainThread(PhantomData<Rc<()>>);
+
+impl AxMainThread {
+    pub(crate) fn new(_: MainThreadMarker) -> Self {
+        Self(PhantomData)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_tests() -> Self {
+        Self(PhantomData)
+    }
+}
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq)]
@@ -141,10 +160,12 @@ pub struct PlatformCallbacks {
     cocoa_app: Retained<NSApplication>,
     /// The main `EventSender` for dispatching events across the application.
     events: EventSender,
+    _event_wake: EventWakeSource,
     /// Handler for Carbon process events.
     process_handler: Option<PinnedProcessHandler>,
     /// Handler for low-level input events (keyboard, mouse, gestures).
     event_handler: Option<PinnedInputHandler>,
+    input_mask: Option<RunningInputMask>,
     /// Observer for `NSWorkspace` and distributed notifications.
     workspace_observer: Retained<WorkspaceObserver>,
     /// Handler for Mission Control accessibility events.
@@ -178,16 +199,21 @@ impl PlatformCallbacks {
         NSApplication::load();
 
         let workspace_observer = WorkspaceObserver::new(events.clone());
+        let event_wake = events
+            .install_main_run_loop_source()
+            .expect("main CFRunLoop source should be available");
         Box::pin(PlatformCallbacks {
             main_thread_marker,
             cocoa_app,
             process_handler: None,
             event_handler: None,
+            input_mask: None,
             workspace_observer,
             mission_control_observer: MissionControlHandler::new(events.clone()),
             display_handler: None,
             notify_handler: None,
             events,
+            _event_wake: event_wake,
         })
     }
 
@@ -220,6 +246,7 @@ impl PlatformCallbacks {
 
         let config = Config::new(CONFIGURATION_FILE.as_path())?;
         self.events.send(Event::InitialConfig(config.clone()))?;
+        self.input_mask = Some(RunningInputMask::new(&config));
         self.event_handler = Some(InputHandler::new(self.events.clone(), config).start()?);
 
         self.notify_handler = Some(NotifyHandler::new(self.events.clone()).start()?);
@@ -233,17 +260,47 @@ impl PlatformCallbacks {
         self.events.send(Event::ProcessesLoaded)
     }
 
-    pub fn pump_cocoa_event_loop(&mut self, timeout: f64) {
-        autoreleasepool(|_| {
-            let until_date = NSDate::dateWithTimeIntervalSinceNow(timeout);
+    /// Rebuilds the event tap after a successful config reload. The new tap is
+    /// created before replacing the old guard, so a creation failure preserves
+    /// the currently running handler and all existing hotkeys.
+    pub fn reconfigure_input_handler(&mut self, config: &Config) -> Result<bool> {
+        let transition = self
+            .input_mask
+            .unwrap_or_else(|| RunningInputMask::new(config))
+            .transition(config);
+        let replacement = InputHandler::new(self.events.clone(), config.clone()).start()?;
+        self.event_handler = Some(replacement);
+        let mask = self
+            .input_mask
+            .get_or_insert_with(|| RunningInputMask::new(config));
+        mask.commit(transition);
+        Ok(transition.changed())
+    }
 
-            // nextEventMatchingMask:untilDate:inMode:dequeue:
-            // This is the core of the Cocoa event loop.
+    pub fn pump_cocoa_event_loop(&mut self, timeout: Option<Duration>) {
+        autoreleasepool(|_| {
+            // Drain already queued AppKit events before sleeping. Channel
+            // events are drained by ECS first; their custom run-loop source is
+            // latched, so a signal between that drain and `run_in_mode` cannot
+            // be lost.
+            self.dispatch_pending_cocoa_events();
+            let seconds = timeout.map_or(f64::MAX, |duration| duration.as_secs_f64());
+            CFRunLoop::run_in_mode(unsafe { kCFRunLoopDefaultMode }, seconds, true);
+            self.dispatch_pending_cocoa_events();
+
+            // Housekeeping for UI/Notifications
+            self.cocoa_app.updateWindows();
+        });
+    }
+
+    fn dispatch_pending_cocoa_events(&self) {
+        let poll_date = NSDate::distantPast();
+        autoreleasepool(|_| {
             while let Some(event) = unsafe {
                 self.cocoa_app
                     .nextEventMatchingMask_untilDate_inMode_dequeue(
                         NSEventMask::Any,
-                        Some(&until_date),
+                        Some(&poll_date),
                         NSDefaultRunLoopMode,
                         true, // Dequeue so we can handle it
                     )
@@ -251,9 +308,6 @@ impl PlatformCallbacks {
                 // Dispatch the event to the system
                 self.cocoa_app.sendEvent(&event);
             }
-
-            // Housekeeping for UI/Notifications
-            self.cocoa_app.updateWindows();
         });
     }
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -318,20 +318,20 @@ impl InputHandler {
         const NS_EVENT_PHASE_ENDED: usize = 1 << 3; // 8
         const NS_EVENT_PHASE_CANCELLED: usize = 1 << 4; // 16
 
+        let Some(configured_fingers) = self
+            .config
+            .swipe_gesture_fingers()
+            .filter(|fingers| *fingers >= GESTURE_MINIMAL_FINGERS)
+        else {
+            // No valid gesture is configured, so leave native macOS gestures alone.
+            return false;
+        };
+
         let Some(ns_event) = NSEvent::eventWithCGEvent(event) else {
             error!("{}: Unable to convert CGEvent to NSEvent", function_name!());
             return false;
         };
         if ns_event.r#type() != NSEventType::Gesture {
-            return false;
-        }
-
-        if self
-            .config
-            .swipe_gesture_fingers()
-            .is_some_and(|fingers| fingers < GESTURE_MINIMAL_FINGERS)
-        {
-            // Swipe is disabled, do not intercept the event.
             return false;
         }
 
@@ -345,6 +345,9 @@ impl InputHandler {
         }
 
         let fingers = ns_event.allTouches();
+        if !gesture_should_intercept(Some(configured_fingers), fingers.len()) {
+            return false;
+        }
         if fingers.iter().any(|f| f.phase() == NSTouchPhase::Began)
             && let Some(events) = &self.events
         {
@@ -456,6 +459,12 @@ impl InputHandler {
     }
 }
 
+fn gesture_should_intercept(configured_fingers: Option<usize>, actual_fingers: usize) -> bool {
+    configured_fingers.is_some_and(|configured| {
+        configured >= GESTURE_MINIMAL_FINGERS && configured == actual_fingers
+    })
+}
+
 fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
     const MODIFIER_MASKS: [(Modifiers, u64); 8] = [
         (Modifiers::LALT, 0x0000_0020),
@@ -562,5 +571,14 @@ mod tests {
     fn device_independent_flags_ignored() {
         let generic_alt: u64 = 0x0008_0000;
         assert_eq!(get_modifiers(CGEventFlags(generic_alt)), Modifiers::empty());
+    }
+
+    #[test]
+    fn only_intercepts_the_explicitly_configured_gesture() {
+        assert!(!gesture_should_intercept(None, 3));
+        assert!(!gesture_should_intercept(Some(2), 2));
+        assert!(gesture_should_intercept(Some(3), 3));
+        assert!(!gesture_should_intercept(Some(4), 3));
+        assert!(gesture_should_intercept(Some(4), 4));
     }
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -42,6 +42,91 @@ const VERTICAL_GESTURE_SCROLL_SUPPRESS: Duration = Duration::from_millis(1200);
 const SWIPE_THRESHOLD: f64 = 0.001;
 const GESTURE_MINIMAL_FINGERS: usize = 3;
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct InputEventMaskPolicy {
+    mouse_move: bool,
+    mouse_buttons: bool,
+    mouse_drag: bool,
+    scroll: bool,
+    gesture: bool,
+    key_down: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct InputMaskTransition {
+    previous: u64,
+    next: u64,
+}
+
+impl InputMaskTransition {
+    pub(super) fn changed(self) -> bool {
+        self.previous != self.next
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RunningInputMask(u64);
+
+impl RunningInputMask {
+    pub(super) fn new(config: &Config) -> Self {
+        Self(InputEventMaskPolicy::from_config(config).mask())
+    }
+
+    pub(super) fn transition(self, config: &Config) -> InputMaskTransition {
+        InputMaskTransition {
+            previous: self.0,
+            next: InputEventMaskPolicy::from_config(config).mask(),
+        }
+    }
+
+    pub(super) fn commit(&mut self, transition: InputMaskTransition) {
+        self.0 = transition.next;
+    }
+}
+
+impl InputEventMaskPolicy {
+    fn from_config(config: &Config) -> Self {
+        let mouse_resize = config.mouse_resize_modifier().is_some();
+        Self {
+            mouse_move: config.focus_follows_mouse()
+                || config.horizontal_mouse_warp().is_some()
+                || mouse_resize,
+            // Click-to-reveal is enabled whenever some hidden fraction should
+            // force a managed window back into view.
+            mouse_buttons: config.window_hidden_ratio() < 1.0,
+            // No ECS system consumes MouseDragged; subscribing only burns tap
+            // callbacks during drags.
+            mouse_drag: false,
+            scroll: true,
+            gesture: config
+                .swipe_gesture_fingers()
+                .is_some_and(|fingers| fingers >= GESTURE_MINIMAL_FINGERS),
+            key_down: true,
+        }
+    }
+
+    fn mask(self) -> u64 {
+        let mut mask = 0;
+        let mut add = |enabled: bool, event: usize| {
+            if enabled {
+                mask |= 1_u64 << event;
+            }
+        };
+        add(self.mouse_move, CGEventType::MouseMoved.0 as usize);
+        add(self.mouse_buttons, CGEventType::LeftMouseDown.0 as usize);
+        add(self.mouse_buttons, CGEventType::LeftMouseUp.0 as usize);
+        add(self.mouse_buttons, CGEventType::RightMouseDown.0 as usize);
+        add(self.mouse_buttons, CGEventType::RightMouseUp.0 as usize);
+        add(self.mouse_drag, CGEventType::LeftMouseDragged.0 as usize);
+        add(self.mouse_drag, CGEventType::RightMouseDragged.0 as usize);
+        add(self.scroll, CGEventType::ScrollWheel.0 as usize);
+        add(self.gesture, NSEventType::Gesture.0);
+        add(self.key_down, CGEventType::KeyDown.0 as usize);
+        mask
+    }
+}
+
 /// `InputHandler` manages low-level input events from the macOS `CGEventTap`.
 /// It intercepts keyboard and mouse events, processes gestures, and dispatches them as higher-level `Event`s.
 pub(super) struct InputHandler {
@@ -92,16 +177,7 @@ impl InputHandler {
     ///
     /// `Ok(())` if the event tap is created and started successfully, otherwise `Err(Error)`.
     pub(super) fn start(self) -> Result<PinnedInputHandler> {
-        let mouse_event_mask = (1 << CGEventType::MouseMoved.0)
-            | (1 << CGEventType::LeftMouseDown.0)
-            | (1 << CGEventType::LeftMouseUp.0)
-            | (1 << CGEventType::LeftMouseDragged.0)
-            | (1 << CGEventType::RightMouseDown.0)
-            | (1 << CGEventType::RightMouseUp.0)
-            | (1 << CGEventType::RightMouseDragged.0)
-            | (1 << CGEventType::ScrollWheel.0)
-            | (1 << NSEventType::Gesture.0)
-            | (1 << CGEventType::KeyDown.0);
+        let event_mask = InputEventMaskPolicy::from_config(&self.config).mask();
 
         let mut pinned = Box::pin(self);
         let this = unsafe { NonNull::new_unchecked(pinned.as_mut().get_unchecked_mut()) }.as_ptr();
@@ -110,7 +186,7 @@ impl InputHandler {
                 CGEventTapLocation::HIDEventTap,
                 CGEventTapPlacement::HeadInsertEventTap,
                 CGEventTapOptions::Default,
-                mouse_event_mask,
+                event_mask,
                 Some(Self::callback),
                 this.cast(),
             );
@@ -497,6 +573,94 @@ mod tests {
     const NX_DEVICERCMDKEYMASK: u64 = 0x0000_0010;
     const NX_DEVICELCTLKEYMASK: u64 = 0x0000_0001;
     const NX_DEVICERCTLKEYMASK: u64 = 0x0000_2000;
+
+    fn manual_config() -> Config {
+        Config::try_from(
+            r#"
+[options]
+focus_follows_mouse = false
+mouse_follows_focus = false
+
+[swipe.scroll]
+modifier = "alt"
+
+[bindings]
+"#,
+        )
+        .unwrap()
+    }
+
+    fn feature_config() -> Config {
+        Config::try_from(
+            r"
+[options]
+focus_follows_mouse = true
+window_hidden_ratio = 1.0
+
+[swipe.gesture]
+fingers_count = 3
+
+[bindings]
+",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn manual_use_case_avoids_move_drag_and_gesture_callbacks() {
+        let config = manual_config();
+        let policy = InputEventMaskPolicy::from_config(&config);
+        assert!(!policy.mouse_move);
+        assert!(!policy.mouse_drag);
+        assert!(!policy.gesture);
+        assert!(policy.mouse_buttons, "click-to-reveal remains enabled");
+        assert!(policy.scroll);
+        assert!(policy.key_down);
+    }
+
+    #[test]
+    fn feature_flags_add_only_required_mouse_and_gesture_events() {
+        let config = feature_config();
+        let policy = InputEventMaskPolicy::from_config(&config);
+        assert!(policy.mouse_move);
+        assert!(!policy.mouse_buttons);
+        assert!(!policy.mouse_drag);
+        assert!(policy.gesture);
+    }
+
+    #[test]
+    fn running_mask_reconciles_enable_and_disable_transitions() {
+        let manual = manual_config();
+        let features = feature_config();
+        let mut running = RunningInputMask::new(&manual);
+
+        let enabled = running.transition(&features);
+        assert!(enabled.changed());
+        running.commit(enabled);
+        assert_eq!(
+            running.0,
+            InputEventMaskPolicy::from_config(&features).mask()
+        );
+        assert_ne!(
+            running.0 & (1_u64 << CGEventType::MouseMoved.0),
+            0,
+            "enabling focus-follows-mouse must add mouse movement"
+        );
+        assert_ne!(
+            running.0 & (1_u64 << NSEventType::Gesture.0),
+            0,
+            "enabling gestures must add gesture callbacks"
+        );
+
+        let disabled = running.transition(&manual);
+        assert!(disabled.changed());
+        running.commit(disabled);
+        assert_eq!(running.0, InputEventMaskPolicy::from_config(&manual).mask());
+        assert_eq!(running.0 & (1_u64 << CGEventType::MouseMoved.0), 0);
+        assert_eq!(running.0 & (1_u64 << NSEventType::Gesture.0), 0);
+        assert_ne!(running.0 & (1_u64 << CGEventType::ScrollWheel.0), 0);
+        assert_ne!(running.0 & (1_u64 << CGEventType::KeyDown.0), 0);
+    }
 
     #[test]
     fn no_modifiers() {

--- a/src/platform/notify.rs
+++ b/src/platform/notify.rs
@@ -51,6 +51,7 @@ impl NotifyHandler {
             KnownCGSEvent::SpaceCurrentChanged,
             KnownCGSEvent::SpaceDestroyed,
             KnownCGSEvent::SpaceWindowDestroyed,
+            KnownCGSEvent::WindowTitleChanged,
         ];
         for event in events {
             unsafe {
@@ -121,6 +122,14 @@ impl NotifyHandler {
                 }
             }
 
+            KnownCGSEvent::WindowTitleChanged => {
+                let bytes = (!data.is_null() && len > 0)
+                    .then(|| unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) });
+                if let Some(event) = bytes.and_then(window_title_event_from_bytes) {
+                    _ = self.events.send(event);
+                }
+            }
+
             KnownCGSEvent::SpaceWindowCreated
             | KnownCGSEvent::WindowClosed
             | KnownCGSEvent::WindowMoved
@@ -143,6 +152,12 @@ impl NotifyHandler {
             }
         }
     }
+}
+
+pub(crate) fn window_title_event_from_bytes(bytes: &[u8]) -> Option<Event> {
+    (bytes.len() >= std::mem::size_of::<WinID>()).then(|| Event::WindowTitleChanged {
+        window_id: unsafe { std::ptr::read_unaligned(bytes.as_ptr().cast::<WinID>()) },
+    })
 }
 
 fn from_bytes<T>(data: *const c_void, len: usize) -> Option<T> {

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 use crate::util::exe_path;
 
 /// The bundle identifier for the `paneru` service.
-pub const ID: &str = "com.github.karinushka.paneru";
+pub const ID: &str = "com.github.mrflashaccount.paneru";
 
 /// `Service` manages the installation, uninstallation, starting, and stopping of the `paneru` application as a launchd service.
 /// It encapsulates the `launchctl::Service` and the path to the executable.

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -22,7 +22,7 @@ use crate::ecs::{
 };
 use crate::events::Event;
 use crate::manager::{Window, WindowManager};
-use crate::platform::{Pid, WinID, WorkspaceId};
+use crate::platform::{AxMainThread, Pid, WinID, WorkspaceId};
 
 use super::*;
 
@@ -227,6 +227,7 @@ fn setup_world() -> App {
         .insert_resource(FocusFollowsMouse(None))
         .insert_resource(Config::default())
         .insert_resource(Initializing)
+        .insert_non_send_resource(AxMainThread::for_tests())
         .add_plugins(MouseEventsPlugin)
         .add_plugins(ScrollEventsPlugin)
         .add_plugins(WorkspaceEventsPlugin)

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use bevy::prelude::*;
 use objc2_core_foundation::CGPoint;
@@ -41,6 +42,9 @@ fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
             command: Command::Window(Operation::SetWidth(2.0)),
         },
         Event::Scroll { delta: 1.0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
     ];
 
     TestHarness::new()
@@ -48,8 +52,54 @@ fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
         .on_iteration(2, |world, _state| {
             let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
             let scrolling = query.single(world).expect("active workspace is scrolling");
-            assert_eq!(scrolling.velocity, 0.0);
+            assert!(scrolling.velocity.abs() < f64::EPSILON);
             assert!(scrolling.is_user_swiping);
+        })
+        .run(commands);
+}
+
+#[test]
+fn sticky_modifier_scroll_keeps_snap_pending_until_momentum_settles() {
+    let config = Config::try_from(
+        r"
+[options]
+
+[swipe]
+sticky = true
+
+[bindings]
+",
+    )
+    .expect("sticky swipe config should parse");
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(2.0)),
+        },
+        Event::Scroll { delta: 1.0 },
+    ];
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            let mut query = world.query_filtered::<&mut Scrolling, With<ActiveWorkspaceMarker>>();
+            let mut scrolling = query
+                .single_mut(world)
+                .expect("active workspace is scrolling");
+            assert!(scrolling.snap_pending);
+            assert!(scrolling.velocity.abs() < f64::EPSILON);
+            scrolling.last_event = Instant::now()
+                .checked_sub(Duration::from_millis(100))
+                .expect("100ms must fit before the current instant");
+        })
+        .on_iteration(3, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query
+                .single(world)
+                .expect("pending sticky snap must keep scrolling alive");
+            assert!(!scrolling.is_user_swiping);
+            assert!(scrolling.snap_pending);
         })
         .run(commands);
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -16,6 +16,24 @@ use crate::{assert_focused, assert_window_at, assert_window_size};
 use super::*;
 
 #[test]
+fn frontmost_floating_window_is_focused_after_setup() {
+    let mut params = WindowParams::new(".*", None);
+    params.floating = Some(true);
+    let config: Config = (MainOptions::default(), vec![params]).into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .with_focused_window(0)
+        .on_iteration(0, |world, _state| {
+            assert_focused!(world, 0);
+            let entity = find_window_entity(0, world);
+            assert!(world.entity(entity).contains::<Unmanaged>());
+        })
+        .run(vec![Event::MenuOpened { window_id: 0 }]);
+}
+
+#[test]
 fn test_dont_focus() {
     let commands = vec![
         Event::MenuOpened { window_id: 0 }, // 0

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -6,7 +6,7 @@ use objc2_core_foundation::CGPoint;
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, Position, Unmanaged, layout::LayoutStrip};
+use crate::ecs::{ActiveWorkspaceMarker, Position, Scrolling, Unmanaged, layout::LayoutStrip};
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
@@ -31,6 +31,27 @@ fn frontmost_floating_window_is_focused_after_setup() {
             assert!(world.entity(entity).contains::<Unmanaged>());
         })
         .run(vec![Event::MenuOpened { window_id: 0 }]);
+}
+
+#[test]
+fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(2.0)),
+        },
+        Event::Scroll { delta: 1.0 },
+    ];
+
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query.single(world).expect("active workspace is scrolling");
+            assert_eq!(scrolling.velocity, 0.0);
+            assert!(scrolling.is_user_swiping);
+        })
+        .run(commands);
 }
 
 #[test]

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -7,7 +7,9 @@ use objc2_core_foundation::CGPoint;
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, Position, Scrolling, Unmanaged, layout::LayoutStrip};
+use crate::ecs::{
+    ActiveWorkspaceMarker, LayoutPosition, Position, Scrolling, Unmanaged, layout::LayoutStrip,
+};
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
@@ -266,9 +268,26 @@ fn test_scrolling() {
             assert_window_at!(world, 2, 800, TEST_MENUBAR_HEIGHT);
         })
         .on_iteration(5, move |world, _state| {
-            assert_window_at!(world, 0, -315, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 1, 85, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 2, 485, TEST_MENUBAR_HEIGHT);
+            let mut strip_query = world.query_filtered::<
+                (&Position, &Scrolling),
+                (With<ActiveWorkspaceMarker>, With<LayoutStrip>),
+            >();
+            let (strip_position, scrolling) = strip_query
+                .single(world)
+                .expect("one active scrolling strip");
+            let strip_x = strip_position.0.x;
+            assert_eq!(strip_x, -800);
+            assert_eq!(scrolling.position as i32, -800);
+
+            // Assert the durable layout contract rather than transient mock AX
+            // frames: each window keeps its column spacing while the strip's
+            // offset moves the last window to the viewport origin.
+            for (window_id, layout_x, screen_x) in [(0, 0, -800), (1, 400, -400), (2, 800, 0)] {
+                let entity = find_window_entity(window_id, world);
+                let layout_position = world.get::<LayoutPosition>(entity).unwrap().0.x;
+                assert_eq!(layout_position, layout_x);
+                assert_eq!(strip_x + layout_position, screen_x);
+            }
         })
         .run(commands);
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -536,8 +536,10 @@ impl MockState {
         });
 
         ma.expect_observe().returning(|| Ok(true));
+        ma.expect_unobserve().return_const(true);
         ma.expect_observe_window().returning(|_| Ok(true));
-        ma.expect_unobserve_window().return_const(());
+        ma.expect_unobserve_window().return_const(true);
+        ma.expect_retry_observer_removals().return_const(true);
         ma.expect_window_list().returning(|_| Vec::new());
 
         Application::new(Box::new(ma))

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -8,7 +8,9 @@ use crate::ecs::state::{
     PaneruState, SavedColumn, SavedDisplay, SavedRect, SavedStrip, SavedWindow, SavedWorkspace,
 };
 use crate::ecs::workspace::PreviousStripPosition;
-use crate::ecs::{SpawnWindowTrigger, Unmanaged};
+use crate::ecs::{
+    ApplicationObserved, Bounds, Position, SpawnWindowTrigger, Unmanaged, WidthRatio,
+};
 use crate::events::Event;
 use crate::manager::{Display, Origin, Size};
 use crate::platform::{ProcessSerialNumber, WorkspaceId};
@@ -76,6 +78,57 @@ fn test_startup_restore_rebuilds_virtual_workspace_layout() {
     assert_eq!(columns.len(), 2);
     assert!(matches!(columns[0], Column::Single(_)));
     assert!(matches!(columns[1], Column::Single(_)));
+    assert_eq!(
+        world
+            .query_filtered::<Entity, With<ApplicationObserved>>()
+            .iter(world)
+            .count(),
+        1,
+        "a background owner matched by startup restore must remain broadly observed"
+    );
+}
+
+#[test]
+fn test_startup_restore_reapplies_non_default_width_and_strip_pan() {
+    let mut window = saved_window(0);
+    window.width_ratio = Some(1.5);
+    window.strip_position_x = Some(-321);
+    let state = PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![saved_display(TEST_DISPLAY_ID, true)],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(0),
+            strips: vec![SavedStrip {
+                virtual_index: 0,
+                columns: vec![SavedColumn::Single(window)],
+            }],
+        }],
+    };
+    let mut harness = TestHarness::new().with_windows(1).with_state(state);
+    for _ in 0..10 {
+        harness.app.update();
+    }
+
+    let world = harness.world();
+    let window_entity = find_window_entity(0, world);
+    let (bounds, ratio) = world
+        .query::<(&Bounds, &WidthRatio)>()
+        .get(world, window_entity)
+        .expect("restored window geometry should exist");
+    assert_eq!(bounds.0.x, (f64::from(TEST_DISPLAY_WIDTH) * 1.5) as i32);
+    assert!((ratio.0 - 1.5).abs() < f64::EPSILON);
+
+    let strip_x = world
+        .query::<(&LayoutStrip, &Position)>()
+        .iter(world)
+        .find(|(strip, _)| strip.contains(window_entity))
+        .map(|(_, position)| position.0.x)
+        .expect("restored strip should contain the window");
+    assert_eq!(strip_x, -321);
 }
 
 #[test]
@@ -423,9 +476,12 @@ fn test_restore_resource_is_removed_after_grace_period() {
             .contains_resource::<crate::ecs::restore::SessionRestore>()
     );
 
-    for _ in 0..30 {
-        harness.app.update();
-    }
+    harness
+        .app
+        .world_mut()
+        .resource_mut::<crate::ecs::restore::SessionRestore>()
+        .expire_now();
+    harness.app.update();
 
     assert!(
         !harness
@@ -714,5 +770,7 @@ fn saved_window(window_id: i32) -> SavedWindow {
         identifier: String::new(),
         role: "AXWindow".to_string(),
         subrole: "AXStandardWindow".to_string(),
+        width_ratio: None,
+        strip_position_x: None,
     }
 }

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -7,7 +7,7 @@ use crate::ecs::state::{
     PaneruQueryState, PaneruState, SavedColumn, SavedDisplay, SavedRect, SavedStackItem,
     SavedStrip, SavedWindow, SavedWorkspace,
 };
-use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, Position};
 use crate::manager::{Application, Display};
 use crate::platform::{Pid, ProcessSerialNumber, WinID};
 use crate::tests::{
@@ -25,6 +25,7 @@ type StateExtractionState<'w, 's> = SystemState<(
         (
             Option<&'static ChildOf>,
             &'static LayoutStrip,
+            Option<&'static Position>,
             Has<ActiveWorkspaceMarker>,
         ),
     >,
@@ -59,6 +60,8 @@ fn test_state_serialization() {
         identifier: "finder-main".to_string(),
         role: "AXWindow".to_string(),
         subrole: "AXStandardWindow".to_string(),
+        width_ratio: None,
+        strip_position_x: None,
     };
 
     let state = PaneruState {
@@ -94,6 +97,20 @@ fn test_state_serialization() {
 }
 
 #[test]
+fn saved_window_geometry_is_backward_compatible() {
+    let mut value = serde_json::to_value(saved_window(1, 123, "com.example.app", "Main"))
+        .expect("saved window should serialize");
+    let object = value.as_object_mut().expect("saved window is an object");
+    object.remove("width_ratio");
+    object.remove("strip_position_x");
+
+    let restored: SavedWindow =
+        serde_json::from_value(value).expect("legacy saved window should deserialize");
+    assert_eq!(restored.width_ratio, None);
+    assert_eq!(restored.strip_position_x, None);
+}
+
+#[test]
 fn test_state_restoration() {
     let window = SavedWindow {
         window_id: 1,
@@ -104,6 +121,8 @@ fn test_state_restoration() {
         identifier: "finder-main".to_string(),
         role: "AXWindow".to_string(),
         subrole: "AXStandardWindow".to_string(),
+        width_ratio: None,
+        strip_position_x: None,
     };
 
     let state = PaneruState {
@@ -495,6 +514,8 @@ fn saved_window(window_id: WinID, pid: Pid, bundle_id: &str, title: &str) -> Sav
         identifier: "main".to_string(),
         role: "AXWindow".to_string(),
         subrole: "AXStandardWindow".to_string(),
+        width_ratio: None,
+        strip_position_x: None,
     }
 }
 

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -207,3 +207,60 @@ fn test_window_resize_grow_and_shrink_cycle() {
         })
         .run(commands);
 }
+
+#[test]
+fn test_window_can_resize_to_two_display_widths_and_scroll() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(2.0)),
+        },
+        Event::Swipe {
+            delta: 0.3,
+            fingers: 3,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Snap),
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            swipe_gesture_fingers: Some(3),
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .on_iteration(1, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .on_iteration(2, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .on_iteration(3, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .run(commands);
+}
+
+fn assert_oversized_window_is_pannable(world: &mut World, id: i32) {
+    let mut query = world.query::<&crate::manager::Window>();
+    let window = query
+        .iter(world)
+        .find(|window| window.id() == id)
+        .expect("window not found");
+    let x = window.frame().min.x;
+    assert!(
+        (-TEST_DISPLAY_WIDTH..=0).contains(&x),
+        "oversized window must stay within its pannable range, got x={x}"
+    );
+}

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -252,6 +252,74 @@ fn test_window_can_resize_to_two_display_widths_and_scroll() {
         .run(commands);
 }
 
+#[test]
+fn test_multiple_oversized_windows_scroll_across_the_full_strip() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(1.5)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(1.5)),
+        },
+        Event::TouchpadDown,
+        Event::Swipe {
+            delta: 100.0,
+            fingers: 3,
+        },
+        Event::TouchpadDown,
+        Event::Swipe {
+            delta: -100.0,
+            fingers: 3,
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            swipe_gesture_fingers: Some(3),
+            continuous_swipe: Some(true),
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(2)
+        .on_iteration(3, |world, _state| {
+            assert_window_size!(world, 0, 1536, 748);
+            assert_window_size!(world, 1, 1536, 748);
+            assert_active_strip_x(world, -1536);
+        })
+        .on_iteration(4, |world, _state| {
+            assert_active_strip_x(world, -1536);
+        })
+        .on_iteration(5, |world, _state| {
+            assert_active_strip_x(world, -2048);
+        })
+        .on_iteration(6, |world, _state| {
+            assert_active_strip_x(world, -2048);
+        })
+        .on_iteration(7, |world, _state| {
+            assert_active_strip_x(world, 0);
+        })
+        .run(commands);
+}
+
+fn assert_active_strip_x(world: &mut World, expected: i32) {
+    let mut query = world.query_filtered::<&crate::ecs::Position, (
+        With<crate::ecs::layout::LayoutStrip>,
+        With<crate::ecs::ActiveWorkspaceMarker>,
+    )>();
+    let position = query.single(world).expect("active layout strip not found");
+    assert_eq!(position.0.x, expected);
+}
+
 fn assert_oversized_window_is_pannable(world: &mut World, id: i32) {
     let mut query = world.query::<&crate::manager::Window>();
     let window = query

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -11,6 +11,8 @@ use objc2::{
 use objc2_foundation::{NSBundle, NSObject, NSString};
 use tracing::warn;
 
+use crate::events::{Event, EventSender};
+
 const SILENT_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -22,6 +24,7 @@ pub struct UpdateStatus {
 #[derive(Clone, Debug)]
 struct SparkleUpdaterDelegateIvars {
     status: Rc<RefCell<UpdateStatus>>,
+    events: EventSender,
 }
 
 define_class!(
@@ -39,11 +42,13 @@ define_class!(
                 unsafe { msg_send![item, displayVersionString] };
             let mut status = self.ivars().status.borrow_mut();
             status.available_version = Some(display_version.to_string());
+            _ = self.ivars().events.send(Event::UpdaterStatusChanged);
         }
 
         #[unsafe(method(updaterDidNotFindUpdate:))]
         fn did_not_find_update(&self, _updater: &AnyObject) {
             self.ivars().status.borrow_mut().available_version = None;
+            _ = self.ivars().events.send(Event::UpdaterStatusChanged);
         }
 
         #[unsafe(method(updater:didFinishUpdateCycleForUpdateCheck:error:))]
@@ -54,13 +59,18 @@ define_class!(
             _error: Option<&AnyObject>,
         ) {
             self.ivars().status.borrow_mut().is_checking = false;
+            _ = self.ivars().events.send(Event::UpdaterStatusChanged);
         }
     }
 );
 
 impl SparkleUpdaterDelegate {
-    fn new(mtm: MainThreadMarker, status: Rc<RefCell<UpdateStatus>>) -> Retained<Self> {
-        let this = Self::alloc(mtm).set_ivars(SparkleUpdaterDelegateIvars { status });
+    fn new(
+        mtm: MainThreadMarker,
+        status: Rc<RefCell<UpdateStatus>>,
+        events: EventSender,
+    ) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(SparkleUpdaterDelegateIvars { status, events });
         unsafe { msg_send![super(this), init] }
     }
 }
@@ -126,11 +136,40 @@ pub struct SparkleUpdater {
     _delegate: Retained<SparkleUpdaterDelegate>,
     controller: Retained<SPUStandardUpdaterController>,
     status: Rc<RefCell<UpdateStatus>>,
-    last_silent_check: Option<Instant>,
+    events: EventSender,
+    silent_schedule: SilentUpdateSchedule,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SilentUpdateSchedule {
+    next_check: Instant,
+}
+
+impl SilentUpdateSchedule {
+    fn new(now: Instant) -> Self {
+        Self { next_check: now }
+    }
+
+    fn deadline(self) -> Instant {
+        self.next_check
+    }
+
+    fn due(self, now: Instant) -> bool {
+        now >= self.next_check
+    }
+
+    fn advance(&mut self, now: Instant) {
+        self.next_check = now + SILENT_CHECK_INTERVAL;
+    }
+}
+
+fn mark_silent_check_started(status: &RefCell<UpdateStatus>, events: &EventSender) {
+    status.borrow_mut().is_checking = true;
+    _ = events.send(Event::UpdaterStatusChanged);
 }
 
 impl SparkleUpdater {
-    pub fn load(mtm: MainThreadMarker) -> Option<Self> {
+    pub fn load(mtm: MainThreadMarker, events: EventSender) -> Option<Self> {
         let main_bundle = NSBundle::mainBundle();
         let Some(frameworks_path) = main_bundle.privateFrameworksPath() else {
             warn!("unable to load Sparkle: the main bundle has no private frameworks path");
@@ -164,7 +203,7 @@ impl SparkleUpdater {
         }
 
         let status = Rc::new(RefCell::new(UpdateStatus::default()));
-        let delegate = SparkleUpdaterDelegate::new(mtm, Rc::clone(&status));
+        let delegate = SparkleUpdaterDelegate::new(mtm, Rc::clone(&status), events.clone());
         let controller = SPUStandardUpdaterController::init_with_starting_updater(
             SPUStandardUpdaterController::alloc(mtm),
             true,
@@ -177,7 +216,8 @@ impl SparkleUpdater {
             _delegate: delegate,
             controller,
             status,
-            last_silent_check: None,
+            events,
+            silent_schedule: SilentUpdateSchedule::new(Instant::now()),
         })
     }
 
@@ -193,12 +233,16 @@ impl SparkleUpdater {
         self.status.borrow().clone()
     }
 
-    pub fn maybe_check_silently(&mut self) {
-        if self.status.borrow().is_checking
-            || self
-                .last_silent_check
-                .is_some_and(|last_check| last_check.elapsed() < SILENT_CHECK_INTERVAL)
-        {
+    pub fn next_silent_check(&self) -> Instant {
+        self.silent_schedule.deadline()
+    }
+
+    pub fn maybe_check_silently(&mut self, now: Instant) {
+        if !self.silent_schedule.due(now) {
+            return;
+        }
+        self.silent_schedule.advance(now);
+        if self.status.borrow().is_checking {
             return;
         }
 
@@ -207,13 +251,47 @@ impl SparkleUpdater {
             return;
         }
 
-        self.status.borrow_mut().is_checking = true;
-        self.last_silent_check = Some(Instant::now());
+        mark_silent_check_started(&self.status, &self.events);
         updater.check_for_update_information();
     }
 
     #[allow(dead_code)]
     pub fn check_for_updates(&self) {
         unsafe { self.controller.check_for_updates(None) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SILENT_CHECK_INTERVAL, SilentUpdateSchedule, UpdateStatus, mark_silent_check_started,
+    };
+    use crate::events::{Event, EventSender};
+    use std::cell::RefCell;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn silent_update_schedule_exposes_real_hourly_deadline() {
+        let now = Instant::now();
+        let mut schedule = SilentUpdateSchedule::new(now);
+        assert!(schedule.due(now));
+        schedule.advance(now);
+        assert_eq!(schedule.deadline(), now + SILENT_CHECK_INTERVAL);
+        assert!(!schedule.due(now + Duration::from_secs(3599)));
+        assert!(schedule.due(now + SILENT_CHECK_INTERVAL));
+    }
+
+    #[test]
+    fn silent_check_start_emits_status_transition() {
+        let status = RefCell::new(UpdateStatus::default());
+        let (events, receiver) = EventSender::new();
+
+        mark_silent_check_started(&status, &events);
+
+        assert!(status.borrow().is_checking);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Event::UpdaterStatusChanged)
+        ));
     }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,219 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use objc2::rc::{Allocated, Retained};
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2::{
+    DefinedClass, MainThreadMarker, MainThreadOnly, define_class, extern_class, extern_methods,
+    msg_send,
+};
+use objc2_foundation::{NSBundle, NSObject, NSString};
+use tracing::warn;
+
+const SILENT_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct UpdateStatus {
+    pub is_checking: bool,
+    pub available_version: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct SparkleUpdaterDelegateIvars {
+    status: Rc<RefCell<UpdateStatus>>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PaneruSparkleUpdaterDelegate"]
+    #[ivars = SparkleUpdaterDelegateIvars]
+    #[derive(Debug)]
+    struct SparkleUpdaterDelegate;
+
+    impl SparkleUpdaterDelegate {
+        #[unsafe(method(updater:didFindValidUpdate:))]
+        fn did_find_valid_update(&self, _updater: &AnyObject, item: &AnyObject) {
+            let display_version: Retained<NSString> =
+                unsafe { msg_send![item, displayVersionString] };
+            let mut status = self.ivars().status.borrow_mut();
+            status.available_version = Some(display_version.to_string());
+        }
+
+        #[unsafe(method(updaterDidNotFindUpdate:))]
+        fn did_not_find_update(&self, _updater: &AnyObject) {
+            self.ivars().status.borrow_mut().available_version = None;
+        }
+
+        #[unsafe(method(updater:didFinishUpdateCycleForUpdateCheck:error:))]
+        fn did_finish_update_cycle(
+            &self,
+            _updater: &AnyObject,
+            _update_check: isize,
+            _error: Option<&AnyObject>,
+        ) {
+            self.ivars().status.borrow_mut().is_checking = false;
+        }
+    }
+);
+
+impl SparkleUpdaterDelegate {
+    fn new(mtm: MainThreadMarker, status: Rc<RefCell<UpdateStatus>>) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(SparkleUpdaterDelegateIvars { status });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+extern_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "SPUUpdater"]
+    #[derive(Debug)]
+    struct SPUUpdater;
+);
+
+impl SPUUpdater {
+    extern_methods!(
+        #[unsafe(method(canCheckForUpdates))]
+        #[unsafe(method_family = none)]
+        fn can_check_for_updates(&self) -> bool;
+
+        #[unsafe(method(checkForUpdateInformation))]
+        #[unsafe(method_family = none)]
+        fn check_for_update_information(&self);
+    );
+}
+
+extern_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "SPUStandardUpdaterController"]
+    #[derive(Debug)]
+    struct SPUStandardUpdaterController;
+);
+
+impl SPUStandardUpdaterController {
+    extern_methods!(
+        #[unsafe(method(initWithStartingUpdater:updaterDelegate:userDriverDelegate:))]
+        #[unsafe(method_family = init)]
+        fn init_with_starting_updater(
+            this: Allocated<Self>,
+            starting_updater: bool,
+            updater_delegate: Option<&AnyObject>,
+            user_driver_delegate: Option<&AnyObject>,
+        ) -> Retained<Self>;
+
+        #[unsafe(method(updater))]
+        #[unsafe(method_family = none)]
+        fn updater(&self) -> Retained<SPUUpdater>;
+
+        /// # Safety
+        ///
+        /// The sender, when present, must be a valid Objective-C object.
+        #[unsafe(method(checkForUpdates:))]
+        #[unsafe(method_family = none)]
+        unsafe fn check_for_updates(&self, sender: Option<&AnyObject>);
+    );
+}
+
+/// Owns Sparkle's loaded framework bundle and standard updater controller.
+///
+/// Sparkle is loaded at runtime so regular `cargo` builds do not need a
+/// framework search path or a link-time dependency on Sparkle.
+pub struct SparkleUpdater {
+    _framework_bundle: Retained<NSBundle>,
+    _delegate: Retained<SparkleUpdaterDelegate>,
+    controller: Retained<SPUStandardUpdaterController>,
+    status: Rc<RefCell<UpdateStatus>>,
+    last_silent_check: Option<Instant>,
+}
+
+impl SparkleUpdater {
+    pub fn load(mtm: MainThreadMarker) -> Option<Self> {
+        let main_bundle = NSBundle::mainBundle();
+        let Some(frameworks_path) = main_bundle.privateFrameworksPath() else {
+            warn!("unable to load Sparkle: the main bundle has no private frameworks path");
+            return None;
+        };
+        let framework_path = frameworks_path
+            .stringByAppendingPathComponent(&NSString::from_str("Sparkle.framework"));
+        let Some(framework_bundle) = NSBundle::bundleWithPath(&framework_path) else {
+            warn!(
+                path = %framework_path,
+                "unable to load Sparkle: framework bundle was not found"
+            );
+            return None;
+        };
+
+        if let Err(error) = unsafe { framework_bundle.loadAndReturnError() } {
+            warn!(
+                path = %framework_path,
+                error = %error.localizedDescription(),
+                "unable to load Sparkle framework"
+            );
+            return None;
+        }
+
+        // Check dynamically before using the typed class wrapper. Calling
+        // `SPUStandardUpdaterController::class()` while the class is absent
+        // would panic inside objc2's class lookup.
+        if AnyClass::get(c"SPUStandardUpdaterController").is_none() {
+            warn!("unable to load Sparkle: updater controller class is missing");
+            return None;
+        }
+
+        let status = Rc::new(RefCell::new(UpdateStatus::default()));
+        let delegate = SparkleUpdaterDelegate::new(mtm, Rc::clone(&status));
+        let controller = SPUStandardUpdaterController::init_with_starting_updater(
+            SPUStandardUpdaterController::alloc(mtm),
+            true,
+            Some(&delegate),
+            None,
+        );
+
+        Some(Self {
+            _framework_bundle: framework_bundle,
+            _delegate: delegate,
+            controller,
+            status,
+            last_silent_check: None,
+        })
+    }
+
+    pub fn controller_target(&self) -> &AnyObject {
+        &self.controller
+    }
+
+    pub fn can_check_for_updates(&self) -> bool {
+        self.controller.updater().can_check_for_updates()
+    }
+
+    pub fn status(&self) -> UpdateStatus {
+        self.status.borrow().clone()
+    }
+
+    pub fn maybe_check_silently(&mut self) {
+        if self.status.borrow().is_checking
+            || self
+                .last_silent_check
+                .is_some_and(|last_check| last_check.elapsed() < SILENT_CHECK_INTERVAL)
+        {
+            return;
+        }
+
+        let updater = self.controller.updater();
+        if !updater.can_check_for_updates() {
+            return;
+        }
+
+        self.status.borrow_mut().is_checking = true;
+        self.last_silent_check = Some(Instant::now());
+        updater.check_for_update_information();
+    }
+
+    #[allow(dead_code)]
+    pub fn check_for_updates(&self) {
+        unsafe { self.controller.check_for_updates(None) };
+    }
+}


### PR DESCRIPTION
## What changed

- replace unconditional idle polling with a wake-latched, event-driven AppKit/Bevy runtime and explicit monotonic deadlines
- keep native modifier-scroll smoothing per layout strip, including oversized windows and multiple managed applications
- persist and restore oversized width ratios and horizontal strip positions with trailing debounce, durable writes, and bounded retries
- scope AX observation to frontmost and managed applications, keep AX/CG work on the main thread, and reconcile observer lifecycle failures safely
- rebuild the CGEvent tap transactionally when live configuration changes
- update the menu bar and updater only when their state is dirty
- add regression coverage for lost wakes, synthetic events, idle-time accounting, multi-display width restore, AX lifecycle, persistence, and scroll cleanup

## Why

The previous runtime woke on a fixed cadence even when no work existed. Scroll state and persistence also contained global or timer-driven paths that could keep the process active after a gesture, behave incorrectly with multiple strips or displays, or restore oversized windows incompletely.

The new runtime blocks while idle, wakes for real input or the nearest explicit deadline, and preserves the horizontal oversized-window workflow without adding feature pruning.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- full suite: **210 passed, 2 failed**
  - `tests::display::test_multi_display_lifecycle`
  - `tests::display::test_multi_workspace_orphaning`

The same two display tests fail on the clean base with the same assertions, so this branch introduces no new suite failure.

Independent architecture, performance, and QA review gates passed after five focused fix/re-review cycles.

## Remaining manual validation

- compare idle CPU and wakeups against the pre-change baseline with Instruments
- verify the first scroll/resize after 30-60 seconds of idle does not jump
- exercise two managed applications and sticky scrolling across a long horizontal strip
- unplug/replug a display during active scrolling
- restart with 150-200% windows on displays of different widths and verify width and pan restore
- exercise background managed apps through restart, unmanage, and termination
- verify live input-mask reload and updater status in the menu bar

This is intentionally a draft until the real AppKit/AX runtime checks above are complete. Feature pruning and Accessibility onboarding changes are out of scope.
