### PR TITLE
Add support for Fn/Globe key as a modifier

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -119,6 +119,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 - `ctrl`, `lctrl`, `rctrl`
 - `cmd`, `lcmd`, `rcmd`
 - `shift`, `lshift`, `rshift`
+- `fn`
 
 | Action | Description |
 | :--- | :--- |

--- a/src/config.rs
+++ b/src/config.rs
@@ -1364,6 +1364,7 @@ fn parse_modifiers(input: &str) -> Result<Modifiers> {
             "ctrl" => Modifiers::CTRL,
             "lctrl" => Modifiers::LCTRL,
             "rctrl" => Modifiers::RCTRL,
+            "fn" => Modifiers::FN,
             _ => {
                 return Err(Error::InvalidConfig(format!(
                     "{}: Invalid modifier: {modifier}",
@@ -1678,6 +1679,7 @@ fn test_virtual_keymap() -> Vec<(String, u8)> {
 
 #[test]
 #[allow(clippy::float_cmp)]
+#[allow(clippy::too_many_lines)]
 fn test_config_parsing() {
     let input = r#"
 [options]
@@ -1688,6 +1690,7 @@ quit = "ctrl+alt-q"
 window_manage = "ctrl+alt-t"
 window_stack = ["ctrl-s", "alt-s"]
 window_shrink = "alt-d"
+window_snap = "fn-x"
 
 [windows]
 
@@ -1795,6 +1798,12 @@ index = 1
     let props = config.find_window_properties("picture in picture", "com.something.apple");
     assert_eq!(props[0].floating, Some(true));
     assert_eq!(props[0].index, Some(1));
+
+    let keycode = find_key('x');
+    assert!(matches!(
+        config.find_keybind(keycode, Modifiers::FN),
+        Some(Command::Window(Operation::Snap))
+    ));
 
     let defaults = Config::default();
     assert_eq!(defaults.swipe_sensitivity(), 0.35);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -48,7 +48,7 @@ pub type WorkspaceId = u64;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq)]
-    pub struct Modifiers: u8 {
+    pub struct Modifiers: u16 {
         const LALT   = 1 << 0;
         const RALT   = 1 << 1;
         const LSHIFT = 1 << 2;
@@ -57,6 +57,7 @@ bitflags::bitflags! {
         const RCMD   = 1 << 5;
         const LCTRL  = 1 << 6;
         const RCTRL  = 1 << 7;
+        const FN     = 1 << 8;
         const ALT   = Self::LALT.bits() | Self::RALT.bits();
         const SHIFT = Self::LSHIFT.bits() | Self::RSHIFT.bits();
         const CMD   = Self::LCMD.bits() | Self::RCMD.bits();
@@ -264,11 +265,12 @@ impl Modifiers {
     ///   - If the binding requires the group, the event must have at least one matching side bit.
     ///   - If the binding does NOT require the group, the event must not have any bits from that group.
     pub fn matches(self, event: Modifiers) -> bool {
-        const GROUPS: [Modifiers; 4] = [
+        const GROUPS: [Modifiers; 5] = [
             Modifiers::ALT,
             Modifiers::SHIFT,
             Modifiers::CMD,
             Modifiers::CTRL,
+            Modifiers::FN,
         ];
 
         for group in GROUPS {
@@ -324,6 +326,7 @@ mod tests {
         assert!(!Modifiers::empty().matches(Modifiers::RSHIFT));
         assert!(!Modifiers::empty().matches(Modifiers::LCMD));
         assert!(!Modifiers::empty().matches(Modifiers::RCTRL));
+        assert!(!Modifiers::empty().matches(Modifiers::FN));
     }
 
     #[test]
@@ -347,6 +350,7 @@ mod tests {
         let want_alt = Modifiers::ALT;
         assert!(!want_alt.matches(Modifiers::LALT | Modifiers::LSHIFT));
         assert!(!want_alt.matches(Modifiers::LALT | Modifiers::LCTRL));
+        assert!(!want_alt.matches(Modifiers::LALT | Modifiers::FN));
     }
 
     #[test]
@@ -378,11 +382,36 @@ mod tests {
     }
 
     #[test]
-    fn matches_all_four_groups() {
-        let all = Modifiers::ALT | Modifiers::SHIFT | Modifiers::CMD | Modifiers::CTRL;
+    fn matches_all_five_groups() {
+        let all =
+            Modifiers::ALT | Modifiers::SHIFT | Modifiers::CMD | Modifiers::CTRL | Modifiers::FN;
+        assert!(all.matches(
+            Modifiers::LALT
+                | Modifiers::RSHIFT
+                | Modifiers::LCMD
+                | Modifiers::RCTRL
+                | Modifiers::FN
+        ));
         assert!(
-            all.matches(Modifiers::LALT | Modifiers::RSHIFT | Modifiers::LCMD | Modifiers::RCTRL)
+            !all.matches(Modifiers::LALT | Modifiers::LSHIFT | Modifiers::LCMD | Modifiers::FN)
         );
-        assert!(!all.matches(Modifiers::LALT | Modifiers::LSHIFT | Modifiers::LCMD));
+    }
+
+    #[test]
+    fn matches_fn_modifier() {
+        let want_fn = Modifiers::FN;
+        assert!(want_fn.matches(Modifiers::FN));
+        assert!(!want_fn.matches(Modifiers::empty()));
+        assert!(!want_fn.matches(Modifiers::LALT | Modifiers::FN));
+    }
+
+    #[test]
+    fn matches_fn_combined_with_other_groups() {
+        let fn_alt = Modifiers::FN | Modifiers::ALT;
+        assert!(fn_alt.matches(Modifiers::FN | Modifiers::LALT));
+        assert!(fn_alt.matches(Modifiers::FN | Modifiers::RALT));
+        assert!(!fn_alt.matches(Modifiers::FN));
+        assert!(!fn_alt.matches(Modifiers::LALT));
+        assert!(!fn_alt.matches(Modifiers::FN | Modifiers::LALT | Modifiers::LSHIFT));
     }
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -457,7 +457,7 @@ impl InputHandler {
 }
 
 fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
-    const MODIFIER_MASKS: [(Modifiers, u64); 8] = [
+    const MODIFIER_MASKS: [(Modifiers, u64); 9] = [
         (Modifiers::LALT, 0x0000_0020),
         (Modifiers::RALT, 0x0000_0040),
         (Modifiers::LSHIFT, 0x0000_0002),
@@ -466,6 +466,7 @@ fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
         (Modifiers::RCMD, 0x0000_0010),
         (Modifiers::LCTRL, 0x0000_0001),
         (Modifiers::RCTRL, 0x0000_2000),
+        (Modifiers::FN, 0x0080_0000),
     ];
     let mut mask = Modifiers::empty();
     for (modifier, m) in MODIFIER_MASKS {
@@ -488,10 +489,28 @@ mod tests {
     const NX_DEVICERCMDKEYMASK: u64 = 0x0000_0010;
     const NX_DEVICELCTLKEYMASK: u64 = 0x0000_0001;
     const NX_DEVICERCTLKEYMASK: u64 = 0x0000_2000;
+    const NX_DEVICEFNKEYMASK: u64 = 0x0080_0000;
 
     #[test]
     fn no_modifiers() {
         assert_eq!(get_modifiers(CGEventFlags(0)), Modifiers::empty());
+    }
+
+    #[test]
+    fn fn_modifier() {
+        assert_eq!(
+            get_modifiers(CGEventFlags(NX_DEVICEFNKEYMASK)),
+            Modifiers::FN
+        );
+    }
+
+    #[test]
+    fn fn_with_other_modifiers() {
+        let flags = NX_DEVICEFNKEYMASK | NX_DEVICELCMDKEYMASK | NX_DEVICELALTKEYMASK;
+        assert_eq!(
+            get_modifiers(CGEventFlags(flags)),
+            Modifiers::FN | Modifiers::LCMD | Modifiers::LALT
+        );
     }
 
     #[test]
@@ -562,5 +581,11 @@ mod tests {
     fn device_independent_flags_ignored() {
         let generic_alt: u64 = 0x0008_0000;
         assert_eq!(get_modifiers(CGEventFlags(generic_alt)), Modifiers::empty());
+    }
+
+    #[test]
+    fn secondary_fn_flag_is_not_ignored() {
+        // Ensure we don't accidentally filter out the fn mask as "device independent"
+        assert_eq!(get_modifiers(CGEventFlags(0x0080_0000)), Modifiers::FN);
     }
 }


### PR DESCRIPTION
fixes #193 

# Summary

Add support for the Fn/Globe key on MacOS keyboards as a modifier key. There's no left/right split for this key so it doesn't have the `lfn` `rfn` variants. I expanded the Modifiers type to  a `u16` since the bitmask was full already. There's an issue where macos reports `fn - f3` style keys as the hardware media keys without the fn modifier mask set if you use fn to access the function keys, but you can still bind that combination as just plain `f3` and it should read anyway, the OS handles those remappings before it emits the event.

# Testing

Added fn to the unit tests where it made sense, and then built and tested on my laptop to make sure the key detection works as expected.

I used an agent to help write the code, I don't know if you care but some projects do, all of the changes were reviewed and tested by a human on an M3 Pro.