### PR TITLE
[WIP / NOT READY] Remove managed-window gaps during native fullscreen

### DIFF
--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -85,6 +85,36 @@ pub(crate) struct PreviousStripPosition {
     pub focus: Option<Entity>,
 }
 
+fn fullscreen_window_in_strip(
+    workspace_id: WorkspaceId,
+    strip: &LayoutStrip,
+    windows: &Windows,
+    window_manager: &WindowManager,
+) -> Option<Entity> {
+    window_manager
+        .windows_in_workspace(workspace_id)
+        .ok()
+        .and_then(|window_ids| {
+            window_ids.into_iter().find_map(|window_id| {
+                windows
+                    .find_managed(window_id)
+                    .map(|(_, entity)| entity)
+                    .filter(|entity| strip.contains(*entity))
+            })
+        })
+        .or_else(|| {
+            windows.managed_iter().find_map(|(window, entity, _)| {
+                (strip.contains(entity) && window.is_full_screen()).then_some(entity)
+            })
+        })
+        .or_else(|| {
+            windows
+                .focused()
+                .map(|(_, entity)| entity)
+                .filter(|entity| strip.contains(*entity))
+        })
+}
+
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 fn workspace_change_handler(
@@ -142,19 +172,21 @@ fn workspace_change_handler(
     if insert_into.is_none()
         && let Some(old_space) = remove_from
         && window_manager.is_fullscreen_space(active_display.id())
-        && let Some((_, focused)) = windows.focused()
         && let Ok((mut old_strip, old_strip_entity, _, _)) = workspaces.get_mut(old_space)
+        && let Some(fullscreen_window) =
+            fullscreen_window_in_strip(workspace_id, &old_strip, &windows, &window_manager)
+        && let Ok(original_index) = old_strip.index_of(fullscreen_window)
     {
         debug!("workspace_change: space={workspace_id} fullscreen");
 
         let fullscreen_marker = NativeFullscreenMarker {
             layout_strip: old_strip_entity,
             workspace_id: old_strip.id(),
-            index: old_strip.index_of(focused).unwrap_or(0),
+            index: original_index,
         };
-        old_strip.remove(focused);
+        old_strip.remove(fullscreen_window);
 
-        let fullscreen_strip = LayoutStrip::fullscreen(workspace_id, focused);
+        let fullscreen_strip = LayoutStrip::fullscreen(workspace_id, fullscreen_window);
         let entity = commands
             .spawn((
                 Position(active_display.bounds().min),

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -6,7 +6,10 @@ use objc2_core_foundation::CGPoint;
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, Position, Unmanaged, layout::LayoutStrip};
+use crate::ecs::{
+    ActiveWorkspaceMarker, FocusedMarker, NativeFullscreenMarker, Position, Unmanaged,
+    layout::LayoutStrip,
+};
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
@@ -14,6 +17,85 @@ use crate::platform::Modifiers;
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
+
+#[test]
+fn native_fullscreen_transition_removes_window_from_original_strip_without_focus_marker() {
+    const FULLSCREEN_WORKSPACE_ID: WorkspaceId = TEST_WORKSPACE_ID + 100;
+
+    TestHarness::new()
+        .with_windows(2)
+        .on_iteration(0, |world, state| {
+            let focused = world
+                .query_filtered::<Entity, With<FocusedMarker>>()
+                .iter(world)
+                .collect::<Vec<_>>();
+            for entity in focused {
+                world.entity_mut(entity).remove::<FocusedMarker>();
+            }
+
+            state.update_window(0, |window| {
+                window.workspace_id = FULLSCREEN_WORKSPACE_ID;
+                window.is_full_screen = true;
+            });
+            state.activate_workspace(TEST_DISPLAY_ID, FULLSCREEN_WORKSPACE_ID, true);
+        })
+        .on_iteration(1, |world, _state| {
+            let fullscreen_window = find_window_entity(0, world);
+            let sibling_window = find_window_entity(1, world);
+            let mut strips = world.query::<(&LayoutStrip, Option<&NativeFullscreenMarker>)>();
+
+            let original_strip = strips
+                .iter(world)
+                .find_map(|(strip, marker)| {
+                    (strip.id() == TEST_WORKSPACE_ID && marker.is_none()).then_some(strip)
+                })
+                .expect("original strip");
+            assert!(
+                !original_strip.contains(fullscreen_window),
+                "fullscreen window must not leave a reserved column in the original strip"
+            );
+            assert!(original_strip.contains(sibling_window));
+
+            let (fullscreen_strip, fullscreen_marker) = strips
+                .iter(world)
+                .find(|(strip, _)| strip.id() == FULLSCREEN_WORKSPACE_ID)
+                .expect("fullscreen strip");
+            assert!(fullscreen_strip.contains(fullscreen_window));
+            assert!(fullscreen_marker.is_some());
+        })
+        .on_iteration(2, |world, _state| {
+            let fullscreen_window = find_window_entity(0, world);
+            let sibling_window = find_window_entity(1, world);
+            let mut strips = world.query::<&LayoutStrip>();
+
+            let original_strip = strips
+                .iter(world)
+                .find(|strip| strip.id() == TEST_WORKSPACE_ID)
+                .expect("original strip");
+            assert!(original_strip.contains(fullscreen_window));
+            assert!(original_strip.contains(sibling_window));
+            assert_eq!(
+                original_strip
+                    .index_of(fullscreen_window)
+                    .expect("restored fullscreen window index"),
+                0
+            );
+            assert!(
+                strips
+                    .iter(world)
+                    .all(|strip| strip.id() != FULLSCREEN_WORKSPACE_ID)
+            );
+        })
+        .run(vec![
+            Event::Command {
+                command: Command::PrintState,
+            },
+            Event::SpaceChanged,
+            Event::SpaceDestroyed {
+                space_id: FULLSCREEN_WORKSPACE_ID,
+            },
+        ]);
+}
 
 #[test]
 fn test_dont_focus() {

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, RwLock};
 
 use bevy::prelude::*;
@@ -81,6 +81,7 @@ struct MockStateInner {
     apps: HashMap<Pid, MockAppData>,
     windows: HashMap<WinID, MockWindowData>,
     displays: HashMap<u32, MockDisplayData>,
+    fullscreen_spaces: HashSet<WorkspaceId>,
     active_display_id: u32,
     cursor_position: Origin,
     event_queue: VecDeque<Event>,
@@ -98,6 +99,7 @@ impl MockState {
                 apps: HashMap::new(),
                 windows: HashMap::new(),
                 displays: HashMap::new(),
+                fullscreen_spaces: HashSet::new(),
                 active_display_id: 0,
                 cursor_position: Origin::ZERO,
                 event_queue: VecDeque::new(),
@@ -196,6 +198,28 @@ impl MockState {
 
     pub fn active_display(&self) -> CGDirectDisplayID {
         self.inner.force_read().active_display_id
+    }
+
+    pub(crate) fn activate_workspace(
+        &self,
+        display_id: u32,
+        workspace_id: WorkspaceId,
+        fullscreen: bool,
+    ) {
+        let mut inner = self.inner.force_write();
+        {
+            let display = inner
+                .displays
+                .get_mut(&display_id)
+                .expect("finding display");
+            display.workspaces.retain(|id| *id != workspace_id);
+            display.workspaces.insert(0, workspace_id);
+        }
+        if fullscreen {
+            inner.fullscreen_spaces.insert(workspace_id);
+        } else {
+            inner.fullscreen_spaces.remove(&workspace_id);
+        }
     }
 
     pub fn drain_events(&self) -> Vec<Event> {
@@ -559,6 +583,17 @@ impl MockState {
                 .map(|d| d.workspaces[0])
                 .ok_or(Error::InvalidWindow)
         });
+
+        let s = self.clone();
+        wm.expect_is_fullscreen_space()
+            .returning(move |display_id| {
+                let inner = s.inner.force_read();
+                inner
+                    .displays
+                    .get(&display_id)
+                    .and_then(|display| display.workspaces.first())
+                    .is_some_and(|workspace_id| inner.fullscreen_spaces.contains(workspace_id))
+            });
 
         let s = self.clone();
         wm.expect_present_displays().returning(move || {


### PR DESCRIPTION
> [!CAUTION]
> **WIP — NOT READY FOR REVIEW OR MERGE**
>
> This is an independent lifecycle fix with focused regression coverage.

## Intent

Stop a managed window from leaving a reserved gap in its original layout strip after macOS moves that window into native fullscreen.

## Root cause

The layout could retain stale membership when focus markers no longer represented the window's actual macOS Space/fullscreen state. Unmanaging the window happened to clear the gap, but should not be required.

## Current scope

- reconciles managed layout membership against actual Space/fullscreen state
- removes a fullscreen window from the old strip
- restores normal participation when the window returns
- adds regression coverage for the transition

## Known blockers before ready

- manual verification with native fullscreen entry/exit on multiple Spaces
- confirm behavior for applications that report Accessibility fullscreen state late
- confirm multi-display behavior with “Displays have separate Spaces” enabled and disabled

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --bin paneru -- -D warnings`
- `cargo test tests::interaction::native_fullscreen_window_is_removed_from_strip_and_restored_after_exit -- --exact`

## Explicitly excluded

- oversized widths and scrolling behavior
- runtime/persistence changes
- per-window opt-in management
- Accessibility onboarding and release infrastructure

