### PR TITLE
[WIP / NOT READY] Preserve native gestures and modifier-scroll momentum (#291)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -67,6 +67,8 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | `direction` | String | `"Natural"` | Direction of movement: `"Natural"` or `"Reversed"`. |
 | `vertical` | Boolean | `true` | Interpret the vertical gestures with `fingers_count` or ignore them. Enabling this allows using vertical swipe gestures to change virtual desktops. |
 
+When `fingers_count` is omitted or set below 3, Paneru does not intercept native macOS gestures. If macOS uses three-finger horizontal swipes for Spaces, prefer `[swipe.scroll]` with a modifier or configure a different finger count.
+
 ### `[swipe.scroll]`
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -63,8 +63,10 @@ fn swipe_gesture(
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
     let mut total_delta = 0.0;
+    let mut gesture_delta = 0.0;
     let mut touchpad_down = false;
     let mut has_scroll_event = false;
+    let mut has_gesture_event = false;
 
     // Normalization: Touchpad deltas are typically small fractions.
     // Scroll wheel deltas can be larger. We scale it down slightly
@@ -88,10 +90,12 @@ fn swipe_gesture(
             Event::Swipe { delta, fingers }
                 if config
                     .swipe_gesture_fingers()
-                    .is_none_or(|fingers_configured| fingers_configured == *fingers) =>
+                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 total_delta += delta;
+                gesture_delta += delta;
                 has_scroll_event = true;
+                has_gesture_event = true;
             }
             _ => (),
         }
@@ -117,15 +121,21 @@ fn swipe_gesture(
         };
 
         let dt = time.delta_secs_f64();
-        let new_velocity = if dt > 0.0 {
-            total_delta * swipe_sensitivity / dt
+        let new_velocity = if has_gesture_event && dt > 0.0 {
+            gesture_delta * swipe_sensitivity / dt
         } else {
             0.0
         };
 
         if let Some(scrolling) = scrolling.as_mut() {
-            // Smoothen velocity changes using EMA.
-            scrolling.velocity = 0.3 * new_velocity + 0.7 * scrolling.velocity;
+            // Native modifier-scroll events already include macOS momentum.
+            // Add synthetic inertia only for raw multi-finger gestures.
+            scrolling.velocity = if has_gesture_event {
+                // Smoothen gesture velocity changes using EMA.
+                0.3 * new_velocity + 0.7 * scrolling.velocity
+            } else {
+                0.0
+            };
             scrolling.is_user_swiping = true;
             scrolling.last_event = Instant::now();
             scrolling.position +=
@@ -135,7 +145,7 @@ fn swipe_gesture(
                 velocity: new_velocity,
                 position: f64::from(position.0.x)
                     + total_delta * viewport_width * direction_modifier * swipe_sensitivity,
-                is_user_swiping: touchpad_down,
+                is_user_swiping: true,
                 last_event: Instant::now(),
             });
         }
@@ -386,7 +396,7 @@ fn vertical_swipe_gesture(
             Event::VerticalSwipe { delta, fingers }
                 if config
                     .swipe_gesture_fingers()
-                    .is_none_or(|fingers_configured| fingers_configured == *fingers) =>
+                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 state.last_event = Some(Instant::now());
 

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -318,20 +318,20 @@ impl InputHandler {
         const NS_EVENT_PHASE_ENDED: usize = 1 << 3; // 8
         const NS_EVENT_PHASE_CANCELLED: usize = 1 << 4; // 16
 
+        let Some(configured_fingers) = self
+            .config
+            .swipe_gesture_fingers()
+            .filter(|fingers| *fingers >= GESTURE_MINIMAL_FINGERS)
+        else {
+            // No valid gesture is configured, so leave native macOS gestures alone.
+            return false;
+        };
+
         let Some(ns_event) = NSEvent::eventWithCGEvent(event) else {
             error!("{}: Unable to convert CGEvent to NSEvent", function_name!());
             return false;
         };
         if ns_event.r#type() != NSEventType::Gesture {
-            return false;
-        }
-
-        if self
-            .config
-            .swipe_gesture_fingers()
-            .is_some_and(|fingers| fingers < GESTURE_MINIMAL_FINGERS)
-        {
-            // Swipe is disabled, do not intercept the event.
             return false;
         }
 
@@ -345,6 +345,9 @@ impl InputHandler {
         }
 
         let fingers = ns_event.allTouches();
+        if !gesture_should_intercept(Some(configured_fingers), fingers.len()) {
+            return false;
+        }
         if fingers.iter().any(|f| f.phase() == NSTouchPhase::Began)
             && let Some(events) = &self.events
         {
@@ -454,6 +457,12 @@ impl InputHandler {
             })
             .is_some()
     }
+}
+
+fn gesture_should_intercept(configured_fingers: Option<usize>, actual_fingers: usize) -> bool {
+    configured_fingers.is_some_and(|configured| {
+        configured >= GESTURE_MINIMAL_FINGERS && configured == actual_fingers
+    })
 }
 
 fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
@@ -582,10 +591,18 @@ mod tests {
         let generic_alt: u64 = 0x0008_0000;
         assert_eq!(get_modifiers(CGEventFlags(generic_alt)), Modifiers::empty());
     }
-
     #[test]
     fn secondary_fn_flag_is_not_ignored() {
         // Ensure we don't accidentally filter out the fn mask as "device independent"
         assert_eq!(get_modifiers(CGEventFlags(0x0080_0000)), Modifiers::FN);
+    }
+
+    #[test]
+    fn only_intercepts_the_explicitly_configured_gesture() {
+        assert!(!gesture_should_intercept(None, 3));
+        assert!(!gesture_should_intercept(Some(2), 2));
+        assert!(gesture_should_intercept(Some(3), 3));
+        assert!(!gesture_should_intercept(Some(4), 3));
+        assert!(gesture_should_intercept(Some(4), 4));
     }
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -6,7 +6,7 @@ use objc2_core_foundation::CGPoint;
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, Position, Unmanaged, layout::LayoutStrip};
+use crate::ecs::{ActiveWorkspaceMarker, Position, Scrolling, Unmanaged, layout::LayoutStrip};
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
@@ -14,6 +14,24 @@ use crate::platform::Modifiers;
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
+
+#[test]
+fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Scroll { delta: 1.0 },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(1, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query.single(world).expect("active workspace is scrolling");
+            assert_eq!(scrolling.velocity, 0.0);
+            assert!(scrolling.is_user_swiping);
+        })
+        .run(commands);
+}
 
 #[test]
 fn test_dont_focus() {


### PR DESCRIPTION
> [!CAUTION]
> **WIP — NOT READY FOR REVIEW OR MERGE**
>
> This is a focused behavior slice for native gesture handling. It is intentionally independent from oversized-window support.

## Intent

Preserve macOS-native gesture phases and momentum for modifier-scroll navigation, while intercepting only the explicitly configured Paneru gesture.

## Current scope

- keeps native gesture and momentum metadata instead of synthesizing velocity
- avoids intercepting unrelated system gestures
- preserves expanded modifier bits, including the newer Fn/Globe modifier support on `testing`
- adds regression coverage for modifier-scroll momentum

## Upstream context

This is related to issue #291. The goal is to make modifier-scroll feel closer to native macOS scrolling without changing unrelated gesture behavior.

## Known blockers before ready

- manual trackpad testing on both 60 Hz and ProMotion displays
- confirm the final sensitivity/inversion defaults with the maintainer
- confirm whether this should close #291 or remain a partial fix

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --bin paneru -- -D warnings`
- `cargo test platform::input::tests::only_intercepts_the_explicitly_configured_gesture -- --exact`
- `cargo test tests::interaction::modifier_scroll_uses_native_momentum_without_synthetic_velocity -- --exact`

## Explicitly excluded

- oversized window widths
- sticky/paged navigation
- runtime/persistence changes
- Accessibility and release infrastructure

