### PR TITLE
Event-driven runtime and per-strip scroll scheduling

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -67,6 +67,8 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | `direction` | String | `"Natural"` | Direction of movement: `"Natural"` or `"Reversed"`. |
 | `vertical` | Boolean | `true` | Interpret the vertical gestures with `fingers_count` or ignore them. Enabling this allows using vertical swipe gestures to change virtual desktops. |
 
+When `fingers_count` is omitted or set below 3, Paneru does not intercept native macOS gestures. If macOS uses three-finger horizontal swipes for Spaces, prefer `[swipe.scroll]` with a modifier or configure a different finger count.
+
 ### `[swipe.scroll]`
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -59,7 +59,7 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | `sensitivity` | Float (0.1–2.0) | `0.35` | Multiplier for swipe distance. |
 | `deceleration` | Float (1.0–10.0) | `4.0` | Rate at which inertia slows down after a swipe. |
 | `continuous` | Boolean | `true` | Controls strip edge limits while scrolling; disable to clamp strictly to the full content bounds. |
-| `sticky` | Boolean | `false` | After scrolling ends, smoothly snap the nearest column to the center of the viewport. |
+| `sticky` | Boolean | `false` | After scrolling ends, smoothly snap the nearest column edge to the matching viewport edge, preserving a small outer gap. |
 
 ### `[swipe.gesture]`
 | Option | Type | Default | Description |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -59,7 +59,8 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | `sensitivity` | Float (0.1–2.0) | `0.35` | Multiplier for swipe distance. |
 | `deceleration` | Float (1.0–10.0) | `4.0` | Rate at which inertia slows down after a swipe. |
 | `continuous` | Boolean | `true` | Controls strip edge limits while scrolling; disable to clamp strictly to the full content bounds. |
-| `sticky` | Boolean | `false` | After scrolling ends, smoothly snap the nearest column edge to the matching viewport edge, preserving a small outer gap. |
+| `paging` | Boolean | `true` | Limit one gesture to at most one adjacent stop. A regular column has one stop; an oversized column has exactly two, at its left and right edges. Set to `false` to restore free scrolling. |
+| `sticky` | Boolean | `false` | With `paging = false`, snap exactly to a column edge when scrolling ends inside its 32-point hit zone. This activation zone does not create a visual gap. |
 
 ### `[swipe.gesture]`
 | Option | Type | Default | Description |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,7 +60,7 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | `deceleration` | Float (1.0–10.0) | `4.0` | Rate at which inertia slows down after a swipe. |
 | `continuous` | Boolean | `true` | Controls strip edge limits while scrolling; disable to clamp strictly to the full content bounds. |
 | `paging` | Boolean | `true` | Limit one gesture to at most one adjacent stop. A regular column has one stop; an oversized column has exactly two, at its left and right edges. Set to `false` to restore free scrolling. |
-| `sticky` | Boolean | `false` | With `paging = false`, snap exactly to a column edge when scrolling ends inside its 32-point hit zone. This activation zone does not create a visual gap. |
+| `sticky` | Boolean | `false` | With `paging = false`, snap exactly to a column edge when scrolling ends inside a hit zone equal to 10% of the usable viewport width. This activation zone does not create a visual gap. |
 
 ### `[swipe.gesture]`
 | Option | Type | Default | Description |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -119,6 +119,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 - `ctrl`, `lctrl`, `rctrl`
 - `cmd`, `lcmd`, `rcmd`
 - `shift`, `lshift`, `rshift`
+- `fn`
 
 | Action | Description |
 | :--- | :--- |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -58,7 +58,8 @@ Configure trackpad gestures and scroll-wheel window sliding.
 | :--- | :--- | :--- | :--- |
 | `sensitivity` | Float (0.1–2.0) | `0.35` | Multiplier for swipe distance. |
 | `deceleration` | Float (1.0–10.0) | `4.0` | Rate at which inertia slows down after a swipe. |
-| `continuous` | Boolean | `true` | If enabled, the swipe gesture moves windows smoothly with the fingers. If disabled, it snaps to windows as you swipe. |
+| `continuous` | Boolean | `true` | Controls strip edge limits while scrolling; disable to clamp strictly to the full content bounds. |
+| `sticky` | Boolean | `false` | After scrolling ends, smoothly snap the nearest column to the center of the viewport. |
 
 ### `[swipe.gesture]`
 | Option | Type | Default | Description |
@@ -135,6 +136,7 @@ Format: `"[modifiers-]key"`. Available modifiers are:
 | `window_swap_first` / `_last` | Move current window to start/end of strip. |
 | `window_center` | Center the current window in the viewport. |
 | `window_resize` | Cycle through preset widths (Grow). |
+| `window_width_<percent>` | Set an exact display-width percentage, e.g. `window_width_150`. |
 | `window_grow` | Alias for `window_resize`. |
 | `window_shrink` | Cycle through preset widths (Shrink). |
 | `window_fullwidth` | Toggle full-width mode. |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -21,7 +21,7 @@ General behavior settings for the window manager.
 | `mouse_follows_focus` | Boolean | `true` | If enabled, the mouse cursor will warp to the center of the focused window when focus changes via keyboard. |
 | `horizontal_mouse_warp` | Integer ``(-1, 1)`` | Off | If enabled, the mouse will warp to another screen above or below, when touching the left or right edge. The direction depends on the direction - a negative value will cause the left edge to warp to a screen above and the right edge to a screen below. This allows having horizontal positioning of displays while having them aligned in a virtual layout in macOS settings. The cursor lands at the *opposite* edge of the target display (preserving cursor flow), with the source's relative Y position. Carries pre-warp horizontal velocity to avoid a "standing start", and skips the warp when the equivalent Y has no position on the target — matching macOS's native side-by-side behavior for displays of unequal height. (inspired by https://github.com/mogenson/WarpMouse.spoon) |
 | `horizontal_mouse_warp_offset` | Integer (px) | `0` | Vertical pixel offset applied to the `horizontal_mouse_warp` landing position, signed by warp direction. Positive values shift the cursor lower when warping to a display *below* (in macOS arrangement) and higher when warping to one *above*. Use to compensate for physical desk arrangement differing from the macOS arrangement (e.g. portrait monitor sitting physically higher or lower than the laptop). |
-| `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75]` | Ratios of the screen width used by the `window_resize` command to cycle sizes. |
+| `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75, 1.0, 1.5, 2.0]` | Ratios of the screen width used by the `window_resize` command and the menu bar width picker. Values above `1.0` create a horizontally scrollable oversized window. |
 | `animation_speed` | Float | *None* | Speed of window animations. Comfortable range is from 8 to 20. Unset or set to a very high value to effectively disable animations. |
 | `auto_center` | Boolean | `false` | Automatically center the focused window on the screen when switching focus. |
 | `sliver_height` | Float (0.1–1.0) | `1.0` | Vertical ratio of off-screen windows kept visible to prevent macOS from relocating them. |
@@ -232,7 +232,7 @@ Define specific behaviors for applications based on their Title or Bundle ID.
 | `manage` | Boolean | Force Paneru to manage this app/window even if macOS reports the app as unobservable or the window has a non-standard role/subrole. |
 | `index` | Integer | Preferred position in the strip when spawned. |
 | `dont_focus` | Boolean | Prevent the window from taking focus when spawned. |
-| `width` | Float (0.0–1.0) | Initial width ratio for the window. |
+| `width` | Positive Float | Initial width ratio for the window. Values above `1.0` create an oversized, horizontally scrollable window. |
 | `grid` | String | placement for floating windows: `"cols:rows:x:y:w:h"`. |
 | `horizontal_padding` | Integer | Gaps to the left/right of this window. |
 | `vertical_padding` | Integer | Gaps to the top/bottom of this window. |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Paneru checks for configuration in following locations:
 - `$XDG_CONFIG_HOME/paneru/paneru.toml`
 
 Additionally it allows overriding the location with `$PANERU_CONFIG` environment variable.
+If none of these files exists, Paneru creates
+`$XDG_CONFIG_HOME/paneru/paneru.toml` with the built-in defaults on first launch.
 
 You can use the following basic configuration as a starting point. For a
 complete guide to all available options, keybindings, and window rules, see the
@@ -164,9 +166,9 @@ quit = "ctrl + alt - q"
 
 ### Live reloading
 
-Configuration changes made to your `~/.paneru` file are automatically reloaded
-while Paneru is running. This is useful for tweaking keyboard bindings and
-other settings without restarting the application.
+Changes made to the active configuration file are automatically reloaded while
+Paneru is running. This is useful for tweaking keyboard bindings and other
+settings without restarting the application.
 
 ### Startup session restore
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,7 @@ mod query;
 use crate::config::Config;
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::{Column, LayoutStrip, StackItem};
+use crate::ecs::layout::{Column, LayoutStrip, StackItem, clamp_origin_to_viewport};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker,
@@ -75,6 +75,8 @@ pub enum Operation {
     Center,
     /// Resizes the focused window in the given direction.
     Resize(ResizeDirection),
+    /// Resizes the focused window to an exact display-width ratio.
+    SetWidth(f64),
     /// Toggles the focused window to full width or a preset width.
     FullWidth,
     /// Moves the focused window to the next available display.
@@ -742,9 +744,10 @@ fn resize_window(
     config: Res<Config>,
     mut commands: Commands,
 ) {
-    let Some(Operation::Resize(direction)) =
-        filter_window_operations(&mut messages, |op| matches!(op, Operation::Resize(_))).next()
-    else {
+    let Some(operation) = filter_window_operations(&mut messages, |op| {
+        matches!(op, Operation::Resize(_) | Operation::SetWidth(_))
+    })
+    .next() else {
         return;
     };
 
@@ -765,8 +768,9 @@ fn resize_window(
     let widths = config.preset_column_widths();
     let fallback = *widths.first().unwrap_or(&0.5);
     let cycle = config.window_resize_cycle();
-    let next_ratio = match direction {
-        ResizeDirection::Grow => widths
+    let next_ratio = match operation {
+        Operation::SetWidth(ratio) if ratio.is_finite() && *ratio > 0.0 => *ratio,
+        Operation::Resize(ResizeDirection::Grow) => widths
             .iter()
             .copied()
             .find(|&r| r > current_ratio + 0.05)
@@ -777,7 +781,7 @@ fn resize_window(
                     *widths.last().unwrap_or(&fallback)
                 }
             }),
-        ResizeDirection::Shrink => widths
+        Operation::Resize(ResizeDirection::Shrink) => widths
             .iter()
             .rev()
             .copied()
@@ -789,13 +793,17 @@ fn resize_window(
                     fallback
                 }
             }),
+        _ => return,
     };
 
     let new_width = (next_ratio * f64::from(viewport.width())).round() as i32;
     let size = Size::new(new_width, frame.height());
 
-    let mut origin = IRect::from_center_size(frame.center(), size).min;
-    origin.x = origin.x.clamp(viewport.min.x, viewport.max.x - size.x);
+    let origin = clamp_origin_to_viewport(
+        IRect::from_center_size(frame.center(), size).min,
+        size,
+        viewport,
+    );
     commands.reposition_entity(entity, origin);
 
     // Resize all windows in the column so stacked siblings share the new width.
@@ -1223,9 +1231,7 @@ fn snap_window(
     // Clamp the frame into the display and reposition the *strip* (not the
     // window) so the layout stays consistent.
     let size = frame.size();
-    frame.min = frame
-        .min
-        .clamp(display_bounds.min, display_bounds.max - size);
+    frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
     frame.max = frame.min + size;
 
     let strip_position = frame.min - layout_position.0;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1150,7 +1150,7 @@ pub struct MainOptions {
 
 /// Returns a default set of column widths.
 pub fn default_preset_column_widths() -> Vec<f64> {
-    vec![0.25, 0.33333, 0.50, 0.66667, 0.75]
+    vec![0.25, 0.33333, 0.50, 0.66667, 0.75, 1.0, 1.5, 2.0]
 }
 
 /// `Keybinding` represents a keyboard shortcut and the command it triggers.
@@ -1219,7 +1219,8 @@ pub struct WindowParams {
     pub vertical_padding: Option<i32>,
     pub horizontal_padding: Option<i32>,
     pub dont_focus: Option<bool>,
-    /// An optional initial width ratio (0.0–1.0) relative to the display width.
+    /// An optional positive initial width ratio relative to the display width.
+    /// Values above 1.0 create an oversized, horizontally scrollable window.
     /// Overrides the default column width when the window is first managed.
     pub width: Option<f64>,
     /// Grid placement for floating windows: "cols:rows:x:y:w:h".

--- a/src/config.rs
+++ b/src/config.rs
@@ -730,6 +730,14 @@ impl Config {
             .unwrap_or(false)
     }
 
+    pub fn swipe_paging(&self) -> bool {
+        self.inner()
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.paging)
+            .unwrap_or(true)
+    }
+
     pub fn swipe_deceleration(&self) -> f64 {
         let config = self.inner();
         config
@@ -1840,6 +1848,7 @@ index = 1
     assert_eq!(defaults.swipe_sensitivity(), 0.35);
     assert_eq!(defaults.swipe_deceleration(), 4.0);
     assert!(!defaults.sticky_scroll());
+    assert!(defaults.swipe_paging());
 }
 
 #[test]
@@ -1857,6 +1866,34 @@ sticky = true
     .expect("sticky swipe config should parse");
 
     assert!(config.sticky_scroll());
+}
+
+#[test]
+fn test_swipe_paging_config() {
+    let defaults = Config::try_from("[options]\n\n[bindings]\n")
+        .expect("config without swipe paging should parse");
+    assert!(
+        defaults.swipe_paging(),
+        "paging must be enabled when omitted"
+    );
+
+    let disabled = Config::try_from(
+        r"
+[options]
+
+[swipe]
+paging = false
+sticky = true
+
+[bindings]
+",
+    )
+    .expect("disabled paging config should parse");
+    assert!(!disabled.swipe_paging());
+    assert!(
+        disabled.sticky_scroll(),
+        "disabling paging must not disable edge-sticky scrolling"
+    );
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,8 @@ use std::{
     collections::HashMap,
     env,
     ffi::c_void,
-    fs::read_to_string,
+    fs::{OpenOptions, create_dir_all, read_to_string},
+    io::{ErrorKind, Write},
     path::{Path, PathBuf},
     ptr::NonNull,
     sync::{Arc, LazyLock},
@@ -35,15 +36,59 @@ pub mod swipe;
 
 /// A `LazyLock` that determines the path to the application's configuration file.
 /// It checks the `PANERU_CONFIG` environment variable first, then standard XDG locations and user home directory.
-/// If no configuration file is found, the application will panic.
+/// If no configuration file is found, a minimal one is created in the user's
+/// XDG configuration directory so a fresh app installation can start with the
+/// built-in defaults.
 pub static CONFIGURATION_FILE: LazyLock<PathBuf> = LazyLock::new(|| {
     discover_configuration_file().unwrap_or_else(|| {
-        panic!(
-            "{}: Configuration file not found. Tried: $PANERU_CONFIG, $HOME/.paneru, $HOME/.paneru.toml, $XDG_CONFIG_HOME/paneru/paneru.toml",
-            function_name!()
-        )
+        create_default_configuration_file().unwrap_or_else(|error| {
+            panic!(
+                "{}: Unable to create default configuration: {error}",
+                function_name!()
+            )
+        })
     })
 });
+
+const DEFAULT_CONFIGURATION: &str = "# Paneru configuration\n\n[options]\n\n[bindings]\n";
+
+fn default_configuration_file() -> std::io::Result<PathBuf> {
+    let config_home = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::NotFound,
+                "neither XDG_CONFIG_HOME nor HOME is set",
+            )
+        })?;
+
+    Ok(config_home.join("paneru").join("paneru.toml"))
+}
+
+fn create_default_configuration_file() -> std::io::Result<PathBuf> {
+    let path = default_configuration_file()?;
+    if create_configuration_file_at(&path)? {
+        info!("Created default configuration at {}", path.display());
+    }
+    Ok(path)
+}
+
+fn create_configuration_file_at(path: &Path) -> std::io::Result<bool> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(ErrorKind::InvalidInput, "configuration path has no parent")
+    })?;
+    create_dir_all(parent)?;
+
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut file) => {
+            file.write_all(DEFAULT_CONFIGURATION.as_bytes())?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(false),
+        Err(error) => Err(error),
+    }
+}
 
 /// Finds the first existing configuration file from supported locations.
 /// Unlike [`CONFIGURATION_FILE`], this does not panic when no file is found.
@@ -1948,6 +1993,30 @@ fn test_config_defaults() {
     assert_eq!(config.border_width(), 2.0);
     assert_eq!(config.border_radius(), BorderRadiusOption::Auto);
     assert_eq!(config.menubar_height(), None);
+}
+
+#[test]
+fn test_first_launch_creates_parseable_config_without_overwriting_it() {
+    let unique = format!(
+        "paneru-first-launch-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let directory = std::env::temp_dir().join(unique);
+    let path = directory.join("paneru.toml");
+
+    assert!(create_configuration_file_at(&path).unwrap());
+    Config::new(&path).expect("generated configuration should parse");
+
+    let custom = "[options]\nauto_center = false\n\n[bindings]\n";
+    std::fs::write(&path, custom).unwrap();
+    assert!(!create_configuration_file_at(&path).unwrap());
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), custom);
+
+    std::fs::remove_dir_all(directory).unwrap();
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,6 +252,17 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
             argv.get(1)
                 .map_or(Ok(ResizeDirection::Grow), |arg| parse_resize_direction(arg))?,
         ),
+        "width" => {
+            let percentage = argv
+                .get(1)
+                .ok_or(err.clone())?
+                .parse::<f64>()
+                .map_err(|_| err.clone())?;
+            if !percentage.is_finite() || percentage <= 0.0 {
+                return Err(err);
+            }
+            Operation::SetWidth(percentage / 100.0)
+        }
         "grow" => Operation::Resize(ResizeDirection::Grow),
         "shrink" => Operation::Resize(ResizeDirection::Shrink),
         "fullwidth" => Operation::FullWidth,
@@ -449,6 +460,17 @@ impl Config {
                 (bind.code == keycode && bind.modifiers.matches(mask))
                     .then_some(bind.command.clone())
             })
+    }
+
+    /// Returns the first configured keybinding for a command name.
+    /// Menus use the same source as the global input handler so displayed
+    /// shortcuts cannot drift from the combinations that actually execute.
+    pub fn first_keybinding(&self, command_name: &str) -> Option<Keybinding> {
+        self.inner()
+            .bindings
+            .get(command_name)
+            .and_then(|bindings| bindings.all().into_iter().next())
+            .cloned()
     }
 
     /// Finds window properties for a given `title` and `bundle_id`.
@@ -698,6 +720,14 @@ impl Config {
             .or(config.options.continuous_swipe)
             // Default: true (enabled).
             .unwrap_or(true)
+    }
+
+    pub fn sticky_scroll(&self) -> bool {
+        self.inner()
+            .swipe
+            .as_ref()
+            .and_then(|swipe| swipe.sticky)
+            .unwrap_or(false)
     }
 
     pub fn swipe_deceleration(&self) -> f64 {
@@ -1155,7 +1185,7 @@ pub fn default_preset_column_widths() -> Vec<f64> {
 
 /// `Keybinding` represents a keyboard shortcut and the command it triggers.
 /// It includes the key, its raw keycode, modifier keys, and the associated command.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Keybinding {
     pub key: String,
     pub code: u8,
@@ -1809,6 +1839,24 @@ index = 1
     let defaults = Config::default();
     assert_eq!(defaults.swipe_sensitivity(), 0.35);
     assert_eq!(defaults.swipe_deceleration(), 4.0);
+    assert!(!defaults.sticky_scroll());
+}
+
+#[test]
+fn test_sticky_scroll_config() {
+    let config = Config::try_from(
+        r"
+[options]
+
+[swipe]
+sticky = true
+
+[bindings]
+",
+    )
+    .expect("sticky swipe config should parse");
+
+    assert!(config.sticky_scroll());
 }
 
 #[test]
@@ -1864,6 +1912,16 @@ fn test_parse_resize_commands() {
         parse_command(&["window", "shrink"]).unwrap(),
         Command::Window(Operation::Resize(ResizeDirection::Shrink))
     ));
+}
+
+#[test]
+fn test_parse_exact_width_command() {
+    assert!(matches!(
+        parse_command(&["window", "width", "150"]).unwrap(),
+        Command::Window(Operation::SetWidth(ratio)) if (ratio - 1.5).abs() < f64::EPSILON
+    ));
+    assert!(parse_command(&["window", "width", "0"]).is_err());
+    assert!(parse_command(&["window", "width", "invalid"]).is_err());
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1364,6 +1364,7 @@ fn parse_modifiers(input: &str) -> Result<Modifiers> {
             "ctrl" => Modifiers::CTRL,
             "lctrl" => Modifiers::LCTRL,
             "rctrl" => Modifiers::RCTRL,
+            "fn" => Modifiers::FN,
             _ => {
                 return Err(Error::InvalidConfig(format!(
                     "{}: Invalid modifier: {modifier}",
@@ -1678,6 +1679,7 @@ fn test_virtual_keymap() -> Vec<(String, u8)> {
 
 #[test]
 #[allow(clippy::float_cmp)]
+#[allow(clippy::too_many_lines)]
 fn test_config_parsing() {
     let input = r#"
 [options]
@@ -1688,6 +1690,7 @@ quit = "ctrl+alt-q"
 window_manage = "ctrl+alt-t"
 window_stack = ["ctrl-s", "alt-s"]
 window_shrink = "alt-d"
+window_snap = "fn-x"
 
 [windows]
 
@@ -1795,6 +1798,12 @@ index = 1
     let props = config.find_window_properties("picture in picture", "com.something.apple");
     assert_eq!(props[0].floating, Some(true));
     assert_eq!(props[0].index, Some(1));
+
+    let keycode = find_key('x');
+    assert!(matches!(
+        config.find_keybind(keycode, Modifiers::FN),
+        Some(Command::Window(Operation::Snap))
+    ));
 
     let defaults = Config::default();
     assert_eq!(defaults.swipe_sensitivity(), 0.35);

--- a/src/config/swipe.rs
+++ b/src/config/swipe.rs
@@ -27,6 +27,10 @@ pub struct SwipeOptions {
     /// Default: false.
     pub sticky: Option<bool>,
 
+    /// Limit each physical gesture to one adjacent window-edge stop.
+    /// Default: true.
+    pub paging: Option<bool>,
+
     pub gesture: Option<GestureOptions>,
     pub scroll: Option<ScrollOptions>,
 }

--- a/src/config/swipe.rs
+++ b/src/config/swipe.rs
@@ -23,6 +23,10 @@ pub struct SwipeOptions {
     #[allow(dead_code)]
     pub continuous: Option<bool>,
 
+    /// Snap to the nearest column after native momentum settles.
+    /// Default: false.
+    pub sticky: Option<bool>,
+
     pub gesture: Option<GestureOptions>,
     pub scroll: Option<ScrollOptions>,
 }

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -85,8 +85,6 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 || focus_lost.read().next().is_some()
                 || !focused_moved.is_empty()
         };
-    let workspace_menu_status =
-        |config: Option<Res<Config>>| config.is_some_and(|config| config.workspace_menu_status());
     let native_tabs_enabled =
         |config: Option<Res<Config>>| config.is_none_or(|config| config.native_tabs_enabled());
 
@@ -157,7 +155,7 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 systems::update_flash_messages,
             )
                 .chain(),
-            crate::menubar::update_virtual_workspace_status_item.run_if(workspace_menu_status),
+            crate::menubar::update_menu_bar,
         ),
     );
 }
@@ -566,12 +564,13 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         .add_plugins(display::DisplayEventsPlugin)
         .add_plugins((register_triggers, register_systems, register_commands));
 
+    let menu_events = sender.clone();
     let mut platform_callbacks = PlatformCallbacks::new(sender);
     platform_callbacks.setup_handlers()?;
     let mtm = platform_callbacks.main_thread_marker;
     let overlay_manager = OverlayManager::new(mtm);
     let flash_message_manager = FlashMessageManager::new(mtm);
-    let menu_bar_manager = MenuBarManager::new(mtm);
+    let menu_bar_manager = MenuBarManager::new(mtm, menu_events);
     app.insert_non_send_resource(platform_callbacks)
         .insert_non_send_resource(overlay_manager)
         .insert_non_send_resource(flash_message_manager)

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -241,8 +241,13 @@ pub struct Scrolling {
     pub target_position: Option<f64>,
     /// A physical gesture ended and still needs to choose its sticky anchor.
     pub snap_pending: bool,
-    /// When true, the user's fingers are on the trackpad.
+    /// Movement is still being supplied by the user or native scroll stream.
     pub is_user_swiping: bool,
+    /// An explicit trackpad begin event has not yet received its matching end.
+    /// This prevents the inactivity fallback from ending a paused gesture.
+    pub gesture_active: bool,
+    /// One-hop paging bounds and release decision captured for this gesture.
+    pub paging_gesture: Option<PagingGesture>,
     /// Last time a physical swipe event was received.
     pub last_event: Instant,
 }
@@ -255,9 +260,20 @@ impl Default for Scrolling {
             target_position: None,
             snap_pending: false,
             is_user_swiping: false,
+            gesture_active: false,
+            paging_gesture: None,
             last_event: Instant::now(),
         }
     }
+}
+
+/// Immutable snap neighborhood captured at the beginning of one gesture.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PagingGesture {
+    pub start_stop: f64,
+    pub previous_stop: Option<f64>,
+    pub next_stop: Option<f64>,
+    pub release_velocity: f64,
 }
 
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut)]

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -1,9 +1,8 @@
-use std::sync::mpsc::Receiver;
 use std::time::{Duration, Instant};
 
 use bevy::MinimalPlugins;
 use bevy::app::App as BevyApp;
-use bevy::app::{PostUpdate, PreUpdate, Startup};
+use bevy::app::{First, PostUpdate, PreUpdate, Startup};
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::lifecycle::RemovedComponents;
 use bevy::ecs::message::Messages;
@@ -15,7 +14,7 @@ use bevy::prelude::Event as BevyEvent;
 use bevy::tasks::Task;
 use bevy::time::Timer;
 use bevy::time::common_conditions::on_timer;
-use bevy::time::{Time, Virtual};
+use bevy::time::{Time, TimeSystems, Virtual};
 use bevy::{
     app::Update,
     ecs::{component::Component, entity::Entity, schedule::IntoScheduleConfigs},
@@ -29,20 +28,22 @@ use crate::ecs::display::FloatingLayer;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::state::PaneruState;
 use crate::errors::Result;
-use crate::events::{Event, EventSender};
+use crate::events::{Event, EventReceiver, EventSender};
 use crate::manager::{
     Application, Origin, ProcessApi, Size, Window, WindowManager, WindowManagerApi, WindowManagerOS,
 };
 use crate::menubar::MenuBarManager;
 use crate::overlay::{FlashMessageManager, OverlayManager};
-use crate::platform::{Modifiers, PlatformCallbacks, WinID, WorkspaceId};
+use crate::platform::{AxMainThread, Modifiers, PlatformCallbacks, WinID, WorkspaceId};
 
+mod config_reload;
 pub mod display;
 pub mod focus;
 pub mod layout;
 pub mod mouse;
 pub mod params;
 pub(crate) mod restore;
+pub(crate) mod runtime;
 pub mod scroll;
 pub mod state;
 mod systems;
@@ -60,6 +61,7 @@ pub mod workspace;
 pub fn register_systems(app: &mut bevy::app::App) {
     const LOW_POWER_MODE_CHECK_SEC: u64 = 60;
 
+    app.init_resource::<runtime::SyntheticEventPending>();
     let not_swiping = |scrolling: Query<&Scrolling, With<ActiveWorkspaceMarker>>| {
         scrolling
             .iter()
@@ -92,10 +94,16 @@ pub fn register_systems(app: &mut bevy::app::App) {
         Startup,
         (systems::gather_displays, systems::gather_initial_processes).chain(),
     );
+    // Native events must be published before every MessageReader<Event>.
+    // All readers live in PreUpdate or later; the pump runs in First after
+    // Bevy updates Time so its blocking wait can resync the real clock.
     app.add_systems(
-        PreUpdate,
-        (systems::window_creation_event, systems::pump_events),
+        First,
+        runtime::pump_events
+            .after(TimeSystems)
+            .after(bevy::ecs::message::message_update_system),
     );
+    app.add_systems(PreUpdate, systems::window_creation_event);
     app.add_systems(
         Update,
         (
@@ -171,7 +179,7 @@ pub fn register_triggers(app: &mut bevy::app::App) {
             triggers::application_event_trigger,
             triggers::dispatch_application_messages,
             triggers::window_destroyed_trigger,
-            triggers::refresh_configuration_trigger,
+            config_reload::refresh_configuration_trigger,
             triggers::theme_change_trigger,
             triggers::window_resize_verifier,
         ),
@@ -331,6 +339,7 @@ pub struct BProcess(pub Box<dyn ProcessApi>);
 pub struct Timeout {
     /// The Bevy timer instance.
     pub timer: Timer,
+    deadline: Instant,
     /// An optional system to execute on timeout.
     pub system_id: Option<SystemId>,
 }
@@ -348,17 +357,32 @@ impl Timeout {
     ///
     /// A new `Timeout` instance.
     pub fn new(duration: Duration, message: Option<String>, commands: &mut Commands) -> Self {
+        Self::new_at(Instant::now(), duration, message, commands)
+    }
+
+    fn new_at(
+        now: Instant,
+        duration: Duration,
+        message: Option<String>,
+        commands: &mut Commands,
+    ) -> Self {
         let timer = Timer::from_seconds(duration.as_secs_f32(), bevy::time::TimerMode::Once);
+        let deadline = now + duration;
         if let Some(message) = message {
             let callback = move || {
                 tracing::debug!("{message}");
             };
             let system_id = Some(commands.register_system(callback));
 
-            Self { timer, system_id }
+            Self {
+                timer,
+                deadline,
+                system_id,
+            }
         } else {
             Self {
                 timer,
+                deadline,
                 system_id: None,
             }
         }
@@ -369,8 +393,17 @@ impl Timeout {
         let timer = Timer::from_seconds(duration.as_secs_f32(), bevy::time::TimerMode::Once);
         commands.spawn(Self {
             timer,
+            deadline: Instant::now() + duration,
             system_id: Some(system_id),
         });
+    }
+
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.deadline
+    }
+
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.deadline
     }
 }
 
@@ -381,7 +414,31 @@ pub struct StrayFocusEvent(pub WinID);
 /// Component used as a retry mechanism when `focused_window_id()` fails during
 /// an `ApplicationFrontSwitched` event (e.g. transient `kAXErrorCannotComplete`).
 #[derive(Component)]
-pub struct RetryFrontSwitch(pub Entity);
+pub struct RetryFrontSwitch {
+    pub application: Entity,
+    next_attempt: Instant,
+}
+
+impl RetryFrontSwitch {
+    pub fn new(application: Entity) -> Self {
+        Self {
+            application,
+            next_attempt: Instant::now(),
+        }
+    }
+
+    pub fn due(&self, now: Instant) -> bool {
+        now >= self.next_attempt
+    }
+
+    pub fn schedule_retry(&mut self, now: Instant) {
+        self.next_attempt = now + Duration::from_millis(50);
+    }
+
+    pub fn next_deadline(&self) -> Instant {
+        self.next_attempt
+    }
+}
 
 #[derive(Component)]
 pub struct BruteforceWindows(Task<Vec<Window>>);
@@ -399,32 +456,50 @@ pub struct RefreshWindowSizes(pub Instant);
 
 impl Default for RefreshWindowSizes {
     fn default() -> Self {
-        Self(Instant::now())
+        Self(Instant::now() + Self::DELAY)
     }
 }
 
 impl RefreshWindowSizes {
-    pub fn ready(&self) -> bool {
-        const REFRESH_WINDOW_SIZE_DELAY_SEC: u64 = 5;
-        self.0.elapsed() > Duration::from_secs(REFRESH_WINDOW_SIZE_DELAY_SEC)
+    const DELAY: Duration = Duration::from_secs(5);
+
+    pub fn ready(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn next_deadline(&self) -> Instant {
+        self.0
     }
 }
 
 #[derive(Component)]
 pub struct VerifyWindowPosition {
     remaining: u8,
+    next_attempt: Instant,
 }
 
 impl Default for VerifyWindowPosition {
     fn default() -> Self {
-        Self { remaining: 3 }
+        Self {
+            remaining: 3,
+            next_attempt: Instant::now(),
+        }
     }
 }
 
 impl VerifyWindowPosition {
+    pub fn due(&self, now: Instant) -> bool {
+        now >= self.next_attempt
+    }
+
     pub fn tick(&mut self) -> bool {
         self.remaining = self.remaining.saturating_sub(1);
+        self.next_attempt = Instant::now() + Duration::from_millis(50);
         self.remaining == 0
+    }
+
+    pub fn next_deadline(&self) -> Instant {
+        self.next_attempt
     }
 }
 
@@ -561,7 +636,7 @@ impl SpawnCommandsExt for Commands<'_, '_> {
     }
 }
 
-pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<BevyApp> {
+pub fn setup_bevy_app(sender: EventSender, receiver: EventReceiver) -> Result<BevyApp> {
     let window_manager: Box<dyn WindowManagerApi> = Box::new(WindowManagerOS::new(sender.clone()));
     let watcher = window_manager.setup_config_watcher(CONFIGURATION_FILE.as_path())?;
 
@@ -591,10 +666,12 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
     let mut platform_callbacks = PlatformCallbacks::new(sender);
     platform_callbacks.setup_handlers()?;
     let mtm = platform_callbacks.main_thread_marker;
+    let ax_main_thread = AxMainThread::new(mtm);
     let overlay_manager = OverlayManager::new(mtm);
     let flash_message_manager = FlashMessageManager::new(mtm);
     let menu_bar_manager = MenuBarManager::new(mtm, menu_events);
     app.insert_non_send_resource(platform_callbacks)
+        .insert_non_send_resource(ax_main_thread)
         .insert_non_send_resource(overlay_manager)
         .insert_non_send_resource(flash_message_manager)
         .insert_non_send_resource(menu_bar_manager)

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -236,6 +236,11 @@ pub struct EnsureVisibleMarker;
 pub struct Scrolling {
     pub velocity: f64,
     pub position: f64,
+    /// Target supplied by native modifier-scroll events. The current position
+    /// follows it over a few frames so discrete event delivery is not visible.
+    pub target_position: Option<f64>,
+    /// A physical gesture ended and still needs to choose its sticky anchor.
+    pub snap_pending: bool,
     /// When true, the user's fingers are on the trackpad.
     pub is_user_swiping: bool,
     /// Last time a physical swipe event was received.
@@ -247,6 +252,8 @@ impl Default for Scrolling {
         Self {
             velocity: 0.0,
             position: 0.0,
+            target_position: None,
+            snap_pending: false,
             is_user_swiping: false,
             last_event: Instant::now(),
         }

--- a/src/ecs/config_reload.rs
+++ b/src/ecs/config_reload.rs
@@ -1,0 +1,133 @@
+use std::pin::Pin;
+
+use bevy::ecs::message::MessageReader;
+use bevy::ecs::system::{NonSend, NonSendMut, Query, Res, ResMut};
+use notify::event::{DataChange, MetadataKind, ModifyKind};
+use notify::{EventKind, Watcher};
+use tracing::{debug, error, info};
+
+use super::params::Windows;
+use crate::config::Config;
+use crate::errors::Result;
+use crate::events::Event;
+use crate::manager::{Application, Display, WindowManager};
+use crate::platform::{AxMainThread, PlatformCallbacks};
+use crate::util::symlink_target;
+
+fn replace_config_transactionally(
+    current: &mut Config,
+    candidate: Config,
+    reconfigure: impl FnOnce(&Config) -> Result<()>,
+) -> Result<()> {
+    reconfigure(&candidate)?;
+    *current = candidate;
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub(super) fn refresh_configuration_trigger(
+    _main_thread: NonSend<AxMainThread>,
+    mut messages: MessageReader<Event>,
+    window_manager: Res<WindowManager>,
+    mut config: ResMut<Config>,
+    mut watcher: Option<NonSendMut<Box<dyn Watcher>>>,
+    windows: Windows,
+    mut displays: Query<&mut Display>,
+    applications: Query<&Application>,
+    mut platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
+) {
+    for event in messages.read() {
+        let Event::ConfigRefresh(event) = event else {
+            continue;
+        };
+        let Some(ref mut watcher) = watcher else {
+            continue;
+        };
+        match &event.kind {
+            EventKind::Modify(
+                ModifyKind::Metadata(MetadataKind::WriteTime)
+                | ModifyKind::Data(DataChange::Content),
+            ) => (),
+            EventKind::Remove(_) => {
+                for path in &event.paths {
+                    _ = watcher.unwatch(path).inspect_err(|err| {
+                        error!("unwatching the config '{}': {err}", path.display());
+                    });
+                }
+                continue;
+            }
+            _ => continue,
+        }
+
+        let mut candidate = config.clone();
+        let mut reloaded = false;
+        for path in &event.paths {
+            if let Some(symlink) = symlink_target(path) {
+                debug!(
+                    "symlink '{}' changed, replacing the watcher.",
+                    symlink.display()
+                );
+                if let Ok(new_watcher) =
+                    window_manager
+                        .setup_config_watcher(path)
+                        .inspect_err(|err| {
+                            error!("watching the config '{}': {err}", path.display());
+                        })
+                {
+                    **watcher = new_watcher;
+                }
+            }
+            info!("Reloading configuration file; {}", path.display());
+            reloaded |= candidate
+                .reload_config(path.as_path())
+                .inspect_err(|err| {
+                    error!("loading config '{}': {err}", path.display());
+                })
+                .is_ok();
+        }
+
+        if reloaded
+            && let Err(err) = replace_config_transactionally(&mut config, candidate, |candidate| {
+                platform.as_mut().map_or(Ok(()), |platform| {
+                    platform.reconfigure_input_handler(candidate).map(|_| ())
+                })
+            })
+        {
+            error!("reconfiguring input handler; keeping previous config: {err}");
+            continue;
+        }
+
+        let height = config.menubar_height();
+        for mut display in &mut displays {
+            display.set_menubar_height_override(height);
+        }
+        if let Some((window, _, parent)) = windows
+            .focused()
+            .and_then(|(w, e)| windows.find_parent(w.id()).map(|(w, _, p)| (w, e, p)))
+            && let Ok(app) = applications.get(parent)
+        {
+            super::triggers::update_passthrough(window, app, &config);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::Error;
+
+    #[test]
+    fn failed_input_tap_replacement_keeps_running_config() {
+        let mut current = Config::default();
+        let running_focus_follows_mouse = current.focus_follows_mouse();
+        let candidate = Config::try_from("[options]\nfocus_follows_mouse = true\n\n[bindings]\n")
+            .expect("candidate config should parse");
+
+        let result = replace_config_transactionally(&mut current, candidate, |_| {
+            Err(Error::InvalidInput("injected tap creation failure".into()))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(current.focus_follows_mouse(), running_focus_follows_mouse);
+    }
+}

--- a/src/ecs/display.rs
+++ b/src/ecs/display.rs
@@ -6,7 +6,7 @@ use bevy::ecs::lifecycle::Add;
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
 use bevy::ecs::query::{Has, With};
-use bevy::ecs::system::{Commands, Local, NonSend, Query, Res};
+use bevy::ecs::system::{Commands, Local, NonSend, Query, Res, ResMut};
 use bevy::math::IRect;
 use bevy::platform::collections::HashSet;
 use objc2_app_kit::NSScreen;
@@ -18,13 +18,14 @@ use tracing::{Level, debug, error, instrument, warn};
 
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
+use crate::ecs::runtime::{OrphanReconcileDeadline, SyntheticEventPending};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, ReadDisplayProperties, RefreshWindowSizes,
-    SendMessageTrigger, SpawnCommandsExt, Timeout,
+    Scrolling, SendMessageTrigger, SpawnCommandsExt, Timeout,
 };
 use crate::events::Event;
 use crate::manager::{Display, WindowManager, irect_from};
-use crate::platform::{PlatformCallbacks, WorkspaceId};
+use crate::platform::{AxMainThread, PlatformCallbacks, WorkspaceId};
 use crate::util::read_screen_property;
 
 const ORPHANED_SPACES_TIMEOUT_SEC: u64 = 30;
@@ -108,6 +109,7 @@ pub(crate) fn reconcile_displays(
     mut displays: Query<(&mut Display, Entity)>,
     active_strips: Query<Entity, (With<LayoutStrip>, With<ActiveWorkspaceMarker>)>,
     window_manager: Res<WindowManager>,
+    _main_thread: NonSend<AxMainThread>,
     mut retries: Local<u8>,
     mut commands: Commands,
 ) {
@@ -141,11 +143,14 @@ pub(crate) fn reconcile_displays(
         warn!("No present displays found... retrying again in {DISPLAY_RETRY_TIMEOUT} seconds.");
         *retries = retries.saturating_sub(1);
         if *retries > 0 {
-            let retry_displays = move |mut messages: MessageWriter<Event>| {
-                messages.write(Event::SystemWoke {
-                    msg: "Retrying display scan".to_string(),
-                });
-            };
+            let retry_displays =
+                move |mut messages: MessageWriter<Event>,
+                      mut synthetic_events: ResMut<SyntheticEventPending>| {
+                    messages.write(Event::SystemWoke {
+                        msg: "Retrying display scan".to_string(),
+                    });
+                    synthetic_events.mark();
+                };
             let system_id = commands.register_system(retry_displays);
             Timeout::callback(
                 Duration::from_secs(DISPLAY_RETRY_TIMEOUT),
@@ -263,7 +268,9 @@ fn remove_display(
             commands,
         );
         if let Ok(mut commands) = commands.get_entity(entity) {
-            commands.try_insert(timeout);
+            commands
+                .try_remove::<Scrolling>()
+                .try_insert((timeout, OrphanReconcileDeadline::default()));
         }
         if let Ok(mut commands) = commands.get_entity(display_entity) {
             commands.detach_child(entity);

--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::time::Duration;
 
 use bevy::app::{App, Plugin, PostUpdate};
 use bevy::ecs::entity::Entity;
@@ -9,23 +8,21 @@ use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With};
 use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
-use bevy::ecs::system::{Commands, Populated, Query, Res, Single};
+use bevy::ecs::system::{Commands, NonSend, Populated, Query, Res, ResMut, Single};
 use bevy::prelude::Event as BevyEvent;
-use bevy::time::common_conditions::on_timer;
 use tracing::{Level, debug, error, instrument, trace, warn};
 
 use super::{FocusedMarker, MouseHeldMarker, SystemTheme, Unmanaged};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
+use crate::ecs::runtime::FocusRecoveryDeadline;
 use crate::ecs::{
     ActiveWorkspaceMarker, Scrolling, SendMessageTrigger, SpawnCommandsExt, StrayFocusEvent,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, Window, WindowManager};
-use crate::platform::WorkspaceId;
-
-const REFRESH_WINDOW_CHECK_FREQ_MS: u64 = 1000;
+use crate::platform::{AxMainThread, WorkspaceId};
 
 #[derive(Default)]
 pub struct TierMemory {
@@ -90,14 +87,13 @@ pub struct FocusEventsPlugin;
 impl Plugin for FocusEventsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<FocusHistory>();
+        app.init_resource::<FocusRecoveryDeadline>();
         app.add_systems(
             PostUpdate,
             (
                 autocenter_window_on_focus.after(super::systems::animate_resize_entities),
                 mouse_follows_focus.after(super::systems::animate_resize_entities),
-                recover_lost_focus.run_if(on_timer(Duration::from_millis(
-                    REFRESH_WINDOW_CHECK_FREQ_MS,
-                ))),
+                recover_lost_focus,
             ),
         );
         app.add_observer(dim_remove_window_trigger)
@@ -293,7 +289,12 @@ fn virtual_strip_activated(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn focus_window_trigger(trigger: On<FocusWindow>, windows: Windows, apps: Query<&Application>) {
+fn focus_window_trigger(
+    trigger: On<FocusWindow>,
+    _main_thread: NonSend<AxMainThread>,
+    windows: Windows,
+    apps: Query<&Application>,
+) {
     let FocusWindow { entity, raise } = *trigger.event();
     let Some(window) = windows.get(entity) else {
         return;
@@ -316,11 +317,17 @@ fn focus_window_trigger(trigger: On<FocusWindow>, windows: Windows, apps: Query<
 fn recover_lost_focus(
     windows: Windows,
     active_workspace: Query<&LayoutStrip, With<ActiveWorkspaceMarker>>,
+    mut deadline: ResMut<FocusRecoveryDeadline>,
     mut commands: Commands,
 ) {
     if windows.focused().is_some() {
         return;
     }
+    let now = std::time::Instant::now();
+    if !deadline.due(now) {
+        return;
+    }
+    deadline.schedule_next(now);
     error!("Lost focus marker, recovering!");
     if let Ok(strip) = active_workspace
         .single()

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -19,10 +19,20 @@ use crate::ecs::{
     Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, SpawnCommandsExt,
 };
 use crate::errors::{Error, Result};
-use crate::manager::{Display, Origin, Window};
+use crate::manager::{Display, Origin, Size, Window};
 use crate::platform::WorkspaceId;
 
 pub struct LayoutEventsPlugin;
+
+/// Clamp a window origin to the range where it still touches both viewport
+/// edges. For an oversized window this range is reversed: from right-aligned
+/// to left-aligned, which lets the strip pan across the hidden content.
+pub(crate) fn clamp_origin_to_viewport(origin: Origin, size: Size, viewport: IRect) -> Origin {
+    let far_edge = viewport.max - size;
+    let minimum = viewport.min.min(far_edge);
+    let maximum = viewport.min.max(far_edge);
+    origin.clamp(minimum, maximum)
+}
 
 impl Plugin for LayoutEventsPlugin {
     fn build(&self, app: &mut App) {
@@ -1024,9 +1034,7 @@ fn reshuffle_layout_strip(
         let visible_width = display_bounds.intersect(frame).width();
 
         // Expose the window by clamping it into the viewport.
-        frame.min = frame
-            .min
-            .clamp(display_bounds.min, display_bounds.max - size);
+        frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
         frame.max = frame.min + size;
 
         let strip_position = (frame.min - layout_position.0).with_y(display_bounds.min.y);
@@ -1101,9 +1109,7 @@ fn ensure_visible_in_strip(
         let candidate_min = layout_position.0 + strip_position.0;
         // Clamp into the viewport. If already on-screen, this is a no-op and
         // the strip target equals its current position — no movement.
-        //let clamped_min = candidate_min.clamp(viewport.min, viewport.max - size);
-        let clamped_min =
-            candidate_min.clamp(viewport.min, (viewport.max - size).max(viewport.min));
+        let clamped_min = clamp_origin_to_viewport(candidate_min, size, viewport);
         if clamped_min == candidate_min {
             return;
         }
@@ -1356,6 +1362,36 @@ fn position_layout_windows(
 mod tests {
     use super::*;
     use bevy::prelude::*;
+
+    #[test]
+    fn clamp_origin_supports_oversized_windows() {
+        let viewport = IRect::new(0, 20, 1024, 768);
+        let size = Size::new(2048, 748);
+
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(300, 20), size, viewport),
+            Origin::new(0, 20)
+        );
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-1600, 20), size, viewport),
+            Origin::new(-1024, 20)
+        );
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-600, 20), size, viewport),
+            Origin::new(-600, 20)
+        );
+    }
+
+    #[test]
+    fn clamp_origin_keeps_regular_windows_inside_viewport() {
+        let viewport = IRect::new(0, 20, 1024, 768);
+        let size = Size::new(400, 300);
+
+        assert_eq!(
+            clamp_origin_to_viewport(Origin::new(-100, 900), size, viewport),
+            Origin::new(0, 468)
+        );
+    }
 
     fn setup_world_and_strip() -> (World, LayoutStrip, Vec<Entity>) {
         let mut world = World::new();

--- a/src/ecs/runtime.rs
+++ b/src/ecs/runtime.rs
@@ -1,0 +1,574 @@
+use std::pin::Pin;
+use std::sync::mpsc::TryRecvError;
+use std::time::{Duration, Instant};
+
+use bevy::app::AppExit;
+use bevy::ecs::component::Component;
+use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::message::MessageWriter;
+use bevy::ecs::query::{With, Without};
+use bevy::ecs::resource::Resource;
+use bevy::ecs::system::{NonSend, NonSendMut, Query, Res, ResMut, SystemParam};
+use bevy::time::{Real, Time};
+
+use super::{
+    ActiveWorkspaceMarker, FlashMessage, FocusedMarker, FreshMarker, Initializing,
+    RefreshWindowSizes, RepositionMarker, ResizeMarker, RetryFrontSwitch, Scrolling, Timeout,
+    VerifyWindowPosition,
+};
+use crate::events::{Event, EventReceiver};
+use crate::manager::Window;
+use crate::platform::PlatformCallbacks;
+
+pub(crate) const ACTIVE_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+// Keep the pre-existing low-power and state-save timers alive until the
+// persistence PR replaces them with explicit deadlines. This preserves their
+// behavior without returning to a 60 Hz idle loop.
+const LEGACY_TIMER_FALLBACK_INTERVAL: Duration = Duration::from_secs(60);
+const FRESH_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const ORPHAN_RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+const FOCUS_RECOVERY_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Component, Debug)]
+pub(crate) struct FreshPollDeadline(Instant);
+
+impl Default for FreshPollDeadline {
+    fn default() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl FreshPollDeadline {
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn schedule_next(&mut self, now: Instant) {
+        self.0 = now + FRESH_POLL_INTERVAL;
+    }
+
+    fn next_deadline(&self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Component, Debug)]
+pub(crate) struct OrphanReconcileDeadline(Instant);
+
+impl Default for OrphanReconcileDeadline {
+    fn default() -> Self {
+        Self(Instant::now() + ORPHAN_RECONCILE_INTERVAL)
+    }
+}
+
+impl OrphanReconcileDeadline {
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn schedule_next(&mut self, now: Instant) {
+        self.0 = now + ORPHAN_RECONCILE_INTERVAL;
+    }
+
+    fn next_deadline(&self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Resource, Debug)]
+pub(crate) struct FocusRecoveryDeadline(Instant);
+
+impl Default for FocusRecoveryDeadline {
+    fn default() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl FocusRecoveryDeadline {
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        now >= self.0
+    }
+
+    pub(crate) fn schedule_next(&mut self, now: Instant) {
+        self.0 = now + FOCUS_RECOVERY_INTERVAL;
+    }
+
+    fn next_deadline(&self) -> Instant {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RuntimeActivity {
+    pub frame_work: bool,
+    pub nearest_deadline: Option<Instant>,
+}
+
+/// Latches synthetic Bevy messages produced after the `First`-stage native
+/// event pump. The next pump consumes the latch and skips its blocking wait so
+/// those already-published messages reach their readers without requiring an
+/// unrelated native wake.
+#[derive(Resource, Debug, Default)]
+pub(super) struct SyntheticEventPending(bool);
+
+impl SyntheticEventPending {
+    pub(super) fn mark(&mut self) {
+        self.0 = true;
+    }
+
+    fn take(&mut self) -> bool {
+        std::mem::take(&mut self.0)
+    }
+}
+
+impl RuntimeActivity {
+    pub(crate) fn wait(self, now: Instant) -> Option<Duration> {
+        if self.frame_work {
+            Some(ACTIVE_FRAME_INTERVAL)
+        } else {
+            self.nearest_deadline
+                .map(|deadline| deadline.saturating_duration_since(now))
+                .or(Some(LEGACY_TIMER_FALLBACK_INTERVAL))
+        }
+    }
+
+    pub(crate) fn nearest(deadlines: impl IntoIterator<Item = Option<Instant>>) -> Option<Instant> {
+        deadlines.into_iter().flatten().min()
+    }
+}
+
+#[derive(SystemParam)]
+pub(super) struct RuntimeWork<'w, 's> {
+    repositioning: Query<'w, 's, (), With<RepositionMarker>>,
+    resizing: Query<'w, 's, (), With<ResizeMarker>>,
+    scrolling: Query<'w, 's, (), With<Scrolling>>,
+    flash_messages: Query<'w, 's, (), With<FlashMessage>>,
+    timeouts: Query<'w, 's, &'static Timeout>,
+    fresh_polls: Query<'w, 's, &'static FreshPollDeadline, With<FreshMarker>>,
+    refreshes: Query<'w, 's, &'static RefreshWindowSizes, With<ActiveWorkspaceMarker>>,
+    orphan_checks: Query<'w, 's, &'static OrphanReconcileDeadline, Without<ChildOf>>,
+    windows: Query<'w, 's, (), With<Window>>,
+    focused_windows: Query<'w, 's, (), (With<Window>, With<FocusedMarker>)>,
+    focus_recovery: Option<Res<'w, FocusRecoveryDeadline>>,
+    retries: Query<'w, 's, &'static RetryFrontSwitch>,
+    verifications: Query<'w, 's, &'static VerifyWindowPosition>,
+    initializing: Option<Res<'w, Initializing>>,
+}
+
+fn runtime_activity(work: &RuntimeWork<'_, '_>, now: Instant) -> RuntimeActivity {
+    let timeout_deadline = work.timeouts.iter().map(Timeout::next_deadline).min();
+    let fresh_poll_deadline = work
+        .fresh_polls
+        .iter()
+        .map(FreshPollDeadline::next_deadline)
+        .min();
+    let refresh_deadline = work
+        .refreshes
+        .iter()
+        .map(RefreshWindowSizes::next_deadline)
+        .min();
+    let orphan_deadline = work
+        .orphan_checks
+        .iter()
+        .map(OrphanReconcileDeadline::next_deadline)
+        .min();
+    let focus_recovery_deadline = (!work.windows.is_empty() && work.focused_windows.is_empty())
+        .then(|| {
+            work.focus_recovery
+                .as_deref()
+                .map(FocusRecoveryDeadline::next_deadline)
+        })
+        .flatten();
+    let retry_deadline = work
+        .retries
+        .iter()
+        .map(RetryFrontSwitch::next_deadline)
+        .min();
+    let verification_deadline = work
+        .verifications
+        .iter()
+        .map(VerifyWindowPosition::next_deadline)
+        .min();
+    let immediate_deferred = work
+        .initializing
+        .is_some()
+        .then_some(now + ACTIVE_FRAME_INTERVAL);
+    RuntimeActivity {
+        frame_work: !work.repositioning.is_empty()
+            || !work.resizing.is_empty()
+            || !work.scrolling.is_empty()
+            || !work.flash_messages.is_empty(),
+        nearest_deadline: RuntimeActivity::nearest([
+            timeout_deadline,
+            fresh_poll_deadline,
+            refresh_deadline,
+            orphan_deadline,
+            focus_recovery_deadline,
+            retry_deadline,
+            verification_deadline,
+            immediate_deferred,
+        ]),
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn pump_events(
+    mut exit: MessageWriter<AppExit>,
+    mut messages: MessageWriter<Event>,
+    incoming_events: Option<NonSend<EventReceiver>>,
+    platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
+    mut real_time: Option<ResMut<Time<Real>>>,
+    mut synthetic_events: ResMut<SyntheticEventPending>,
+    work: RuntimeWork,
+) {
+    let Some((ref mut platform, incoming_events)) = platform.zip(incoming_events) else {
+        // No platform interface or incoming event pipe - probably executing in a unit test.
+        return;
+    };
+
+    let now = Instant::now();
+    let activity = runtime_activity(&work, now);
+    let synthetic_pending = synthetic_events.take();
+    let (received_events, should_exit, did_wait) =
+        pump_receiver(&incoming_events, activity, now, synthetic_pending, |wait| {
+            platform.pump_cocoa_event_loop(wait);
+        });
+    if did_wait && let Some(real_time) = real_time.as_mut() {
+        real_time.update_with_instant(Instant::now());
+    }
+    if should_exit {
+        exit.write(AppExit::Success);
+    }
+    messages.write_batch(received_events);
+}
+
+fn pump_receiver(
+    receiver: &EventReceiver,
+    activity: RuntimeActivity,
+    now: Instant,
+    synthetic_pending: bool,
+    mut pump: impl FnMut(Option<Duration>),
+) -> (Vec<Event>, bool, bool) {
+    let generation_before_drain = receiver.generation();
+    let (mut received_events, mut should_exit) = drain_event_channel(receiver);
+    let should_wait = !synthetic_pending
+        && received_events.is_empty()
+        && !should_exit
+        && receiver.generation() == generation_before_drain;
+    if should_wait {
+        pump(activity.wait(now));
+        let (after_wait, exit_after_wait) = drain_event_channel(receiver);
+        received_events = after_wait;
+        should_exit = exit_after_wait;
+    }
+    (received_events, should_exit, should_wait)
+}
+
+fn drain_event_channel(receiver: &EventReceiver) -> (Vec<Event>, bool) {
+    let mut received_events = Vec::new();
+    let mut pending_mouse = None;
+    let mut should_exit = false;
+    loop {
+        match receiver.try_recv() {
+            Ok(Event::Exit) | Err(TryRecvError::Disconnected) => {
+                should_exit = true;
+                break;
+            }
+            Ok(event) if matches!(event, Event::MouseMoved { .. }) => {
+                pending_mouse = Some(event);
+            }
+            Ok(event) => {
+                received_events.extend(pending_mouse.take());
+                received_events.push(event);
+            }
+            Err(TryRecvError::Empty) => break,
+        }
+    }
+    received_events.extend(pending_mouse);
+    (received_events, should_exit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ACTIVE_FRAME_INTERVAL, FreshPollDeadline, LEGACY_TIMER_FALLBACK_INTERVAL, RuntimeActivity,
+        RuntimeWork, SyntheticEventPending, pump_receiver, runtime_activity,
+    };
+    use crate::ecs::{ActiveWorkspaceMarker, RefreshWindowSizes, Scrolling, SendMessageTrigger};
+    use crate::events::{Event, EventReceiver, EventSender};
+    use bevy::app::{App, First, PostUpdate, PreUpdate, Update};
+    use bevy::ecs::message::{MessageReader, MessageWriter, Messages};
+    use bevy::ecs::resource::Resource;
+    use bevy::ecs::schedule::IntoScheduleConfigs;
+    use bevy::ecs::system::{Commands, Local, NonSend, Res, ResMut};
+    use bevy::time::{Real, Time, TimeSystems, Virtual};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn idle_runtime_keeps_only_the_legacy_minute_wake() {
+        let now = Instant::now();
+        assert_eq!(
+            RuntimeActivity {
+                frame_work: false,
+                nearest_deadline: None,
+            }
+            .wait(now),
+            Some(LEGACY_TIMER_FALLBACK_INTERVAL)
+        );
+    }
+
+    #[test]
+    fn frame_work_and_real_deadlines_have_distinct_waits() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(3);
+        assert_eq!(
+            RuntimeActivity {
+                frame_work: true,
+                nearest_deadline: Some(deadline),
+            }
+            .wait(now),
+            Some(ACTIVE_FRAME_INTERVAL)
+        );
+        assert_eq!(
+            RuntimeActivity {
+                frame_work: false,
+                nearest_deadline: Some(deadline),
+            }
+            .wait(now),
+            Some(Duration::from_secs(3))
+        );
+    }
+
+    #[test]
+    fn absolute_deadline_is_charged_once_after_sleep() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_millis(50);
+        let activity = RuntimeActivity {
+            frame_work: false,
+            nearest_deadline: Some(deadline),
+        };
+        assert_eq!(activity.wait(now), Some(Duration::from_millis(50)));
+        assert_eq!(activity.wait(deadline), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn deferred_deadline_wakes_real_pump_core_and_delivers_event() {
+        let (sender, receiver) = EventSender::new();
+        let now = Instant::now();
+        let activity = RuntimeActivity {
+            frame_work: false,
+            nearest_deadline: Some(now + Duration::from_millis(25)),
+        };
+        let mut observed_wait = None;
+
+        let (events, should_exit, did_wait) =
+            pump_receiver(&receiver, activity, now, false, |wait| {
+                observed_wait = wait;
+                sender
+                    .send(Event::ApplicationActivated)
+                    .expect("deadline wake event should send");
+            });
+
+        assert_eq!(observed_wait, Some(Duration::from_millis(25)));
+        assert!(!should_exit);
+        assert!(did_wait);
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, Event::ApplicationActivated))
+        );
+    }
+
+    #[test]
+    fn fresh_poll_exposes_monotonic_retry_deadline() {
+        let mut poll = FreshPollDeadline(Instant::now());
+        let now = poll.next_deadline();
+        assert!(poll.due(now));
+        poll.schedule_next(now);
+        assert_eq!(poll.next_deadline(), now + Duration::from_millis(50));
+        assert!(!poll.due(now));
+    }
+
+    #[derive(Resource, Default)]
+    struct CapturedActivity(Option<RuntimeActivity>);
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn capture_activity(work: RuntimeWork, mut captured: ResMut<CapturedActivity>) {
+        captured.0 = Some(runtime_activity(&work, Instant::now()));
+    }
+
+    #[test]
+    fn inactive_past_due_refresh_does_not_force_zero_wait() {
+        let now = Instant::now();
+        let active_deadline = now + Duration::from_secs(2);
+        let mut app = App::new();
+        app.init_resource::<CapturedActivity>()
+            .add_systems(Update, capture_activity);
+        app.world_mut().spawn(RefreshWindowSizes(now));
+        app.world_mut()
+            .spawn((RefreshWindowSizes(active_deadline), ActiveWorkspaceMarker));
+
+        app.update();
+
+        let activity = app.world().resource::<CapturedActivity>().0.unwrap();
+        assert_eq!(activity.nearest_deadline, Some(active_deadline));
+        assert!(activity.wait(now).is_some_and(|wait| wait > Duration::ZERO));
+    }
+
+    #[derive(Resource, Default)]
+    struct ScrollProbe(f64);
+
+    fn simulate_idle_wait_once(mut once: Local<bool>, mut real_time: ResMut<Time<Real>>) {
+        if *once {
+            return;
+        }
+        *once = true;
+        std::thread::sleep(Duration::from_millis(40));
+        real_time.update_with_instant(Instant::now());
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn advance_scroll_probe(time: Res<Time<Virtual>>, mut probe: ResMut<ScrollProbe>) {
+        probe.0 += time.delta_secs_f64() * 1_000.0;
+    }
+
+    #[test]
+    fn long_idle_wait_is_not_charged_to_next_scroll_frame() {
+        let mut app = App::new();
+        app.add_plugins(bevy::MinimalPlugins)
+            .init_resource::<ScrollProbe>()
+            .add_systems(PreUpdate, simulate_idle_wait_once)
+            .add_systems(Update, advance_scroll_probe);
+        app.world_mut().spawn(Scrolling::default());
+
+        app.update();
+        app.update();
+
+        assert!(
+            app.world().resource::<ScrollProbe>().0 < 20.0,
+            "40ms idle wait leaked into the next animation delta"
+        );
+    }
+
+    #[derive(Resource, Default)]
+    struct EventPipelineProbe {
+        waits: usize,
+        first_reader: usize,
+        second_reader: usize,
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn publish_native_events(
+        receiver: NonSend<EventReceiver>,
+        mut messages: MessageWriter<Event>,
+        mut synthetic_events: ResMut<SyntheticEventPending>,
+        mut probe: ResMut<EventPipelineProbe>,
+    ) {
+        let activity = RuntimeActivity {
+            frame_work: false,
+            nearest_deadline: None,
+        };
+        let synthetic_pending = synthetic_events.take();
+        let (events, _, _) = pump_receiver(
+            &receiver,
+            activity,
+            Instant::now(),
+            synthetic_pending,
+            |_| {
+                probe.waits += 1;
+            },
+        );
+        messages.write_batch(events);
+    }
+
+    fn write_synthetic_after_pump(mut written: Local<bool>, mut commands: Commands) {
+        if *written {
+            return;
+        }
+        *written = true;
+        commands.trigger(SendMessageTrigger(Event::ApplicationActivated));
+    }
+
+    fn first_native_reader(
+        mut messages: MessageReader<Event>,
+        mut probe: ResMut<EventPipelineProbe>,
+    ) {
+        probe.first_reader += messages
+            .read()
+            .filter(|event| matches!(event, Event::ApplicationActivated))
+            .count();
+    }
+
+    fn second_native_reader(
+        mut messages: MessageReader<Event>,
+        mut probe: ResMut<EventPipelineProbe>,
+    ) {
+        probe.second_reader += messages
+            .read()
+            .filter(|event| matches!(event, Event::ApplicationActivated))
+            .count();
+    }
+
+    #[test]
+    fn first_stage_pump_publishes_before_every_preupdate_reader() {
+        let (sender, receiver) = EventSender::new();
+        sender.send(Event::ApplicationActivated).unwrap();
+        let mut app = App::new();
+        app.add_plugins(bevy::MinimalPlugins)
+            .init_resource::<Messages<Event>>()
+            .init_resource::<EventPipelineProbe>()
+            .init_resource::<SyntheticEventPending>()
+            .insert_non_send_resource(receiver)
+            .add_systems(
+                First,
+                publish_native_events
+                    .after(TimeSystems)
+                    .after(bevy::ecs::message::message_update_system),
+            )
+            .add_systems(PreUpdate, (first_native_reader, second_native_reader));
+
+        app.update();
+
+        let probe = app.world().resource::<EventPipelineProbe>();
+        assert_eq!(probe.waits, 0, "queued native work must prevent sleeping");
+        assert_eq!(probe.first_reader, 1);
+        assert_eq!(probe.second_reader, 1);
+    }
+
+    #[test]
+    fn synthetic_event_after_pump_prevents_next_frame_wait() {
+        let (_sender, receiver) = EventSender::new();
+        let mut app = App::new();
+        app.add_plugins(bevy::MinimalPlugins)
+            .init_resource::<Messages<Event>>()
+            .init_resource::<EventPipelineProbe>()
+            .init_resource::<SyntheticEventPending>()
+            .insert_non_send_resource(receiver)
+            .add_observer(crate::ecs::triggers::send_message_trigger)
+            .add_systems(
+                First,
+                publish_native_events
+                    .after(TimeSystems)
+                    .after(bevy::ecs::message::message_update_system),
+            )
+            .add_systems(PreUpdate, first_native_reader)
+            .add_systems(PostUpdate, write_synthetic_after_pump);
+
+        app.update();
+        let waits_after_first_pump = app.world().resource::<EventPipelineProbe>().waits;
+        assert_eq!(
+            app.world().resource::<EventPipelineProbe>().first_reader,
+            0,
+            "synthetic event is intentionally produced after the first pump"
+        );
+
+        app.update();
+
+        let probe = app.world().resource::<EventPipelineProbe>();
+        assert_eq!(
+            probe.waits, waits_after_first_pump,
+            "latched synthetic work must prevent the next pump from waiting"
+        );
+        assert_eq!(probe.first_reader, 1);
+    }
+}

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -63,8 +63,10 @@ fn swipe_gesture(
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
     let mut total_delta = 0.0;
+    let mut gesture_delta = 0.0;
     let mut touchpad_down = false;
     let mut has_scroll_event = false;
+    let mut has_gesture_event = false;
 
     // Normalization: Touchpad deltas are typically small fractions.
     // Scroll wheel deltas can be larger. We scale it down slightly
@@ -88,10 +90,12 @@ fn swipe_gesture(
             Event::Swipe { delta, fingers }
                 if config
                     .swipe_gesture_fingers()
-                    .is_none_or(|fingers_configured| fingers_configured == *fingers) =>
+                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 total_delta += delta;
+                gesture_delta += delta;
                 has_scroll_event = true;
+                has_gesture_event = true;
             }
             _ => (),
         }
@@ -117,15 +121,21 @@ fn swipe_gesture(
         };
 
         let dt = time.delta_secs_f64();
-        let new_velocity = if dt > 0.0 {
-            total_delta * swipe_sensitivity / dt
+        let new_velocity = if has_gesture_event && dt > 0.0 {
+            gesture_delta * swipe_sensitivity / dt
         } else {
             0.0
         };
 
         if let Some(scrolling) = scrolling.as_mut() {
-            // Smoothen velocity changes using EMA.
-            scrolling.velocity = 0.3 * new_velocity + 0.7 * scrolling.velocity;
+            // Native modifier-scroll events already include macOS momentum.
+            // Add synthetic inertia only for raw multi-finger gestures.
+            scrolling.velocity = if has_gesture_event {
+                // Smoothen gesture velocity changes using EMA.
+                0.3 * new_velocity + 0.7 * scrolling.velocity
+            } else {
+                0.0
+            };
             scrolling.is_user_swiping = true;
             scrolling.last_event = Instant::now();
             scrolling.position +=
@@ -135,7 +145,7 @@ fn swipe_gesture(
                 velocity: new_velocity,
                 position: f64::from(position.0.x)
                     + total_delta * viewport_width * direction_modifier * swipe_sensitivity,
-                is_user_swiping: touchpad_down,
+                is_user_swiping: true,
                 last_event: Instant::now(),
             });
         }
@@ -386,7 +396,7 @@ fn vertical_swipe_gesture(
             Event::VerticalSwipe { delta, fingers }
                 if config
                     .swipe_gesture_fingers()
-                    .is_none_or(|fingers_configured| fingers_configured == *fingers) =>
+                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
                 state.last_event = Some(Instant::now());
 

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -156,7 +156,7 @@ fn swipe_gesture(
     // AppKit can report physical Ended and momentum Began together. Apply the
     // physical end first so the momentum phase remains the final state.
     mark_physical_touch_end(touchpad_physical_up, scrolling.as_deref_mut());
-    resume_touchpad_gesture(resumes_gesture, scrolling.as_deref_mut());
+    resume_touchpad_gesture(resumes_gesture, touchpad_down, scrolling.as_deref_mut());
 
     if touchpad_down && !has_scroll_event && scrolling.is_none() {
         insert_touchpad_begin_state(
@@ -326,9 +326,15 @@ fn begin_touchpad_gesture(
     }
 }
 
-fn resume_touchpad_gesture(resumes_gesture: bool, scrolling: Option<&mut Scrolling>) {
+fn resume_touchpad_gesture(
+    resumes_gesture: bool,
+    interrupts_target: bool,
+    scrolling: Option<&mut Scrolling>,
+) {
     if resumes_gesture && let Some(scrolling) = scrolling {
-        scrolling.target_position = None;
+        if interrupts_target {
+            scrolling.target_position = None;
+        }
         scrolling.snap_pending = true;
         scrolling.is_user_swiping = true;
         scrolling.gesture_active = true;

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -15,20 +15,39 @@ use crate::config::swipe::SwipeGestureDirection;
 use crate::ecs::layout::{Column, LayoutStrip};
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, MissionControlActive, Position, Scrolling, SendMessageTrigger,
+    ActiveWorkspaceMarker, MissionControlActive, PagingGesture, Position, Scrolling,
+    SendMessageTrigger,
 };
 use crate::errors::Result;
 use crate::events::Event;
 use crate::manager::{Window, WindowManager};
 use crate::platform::Modifiers;
 
+mod paging;
+use paging::{
+    capture_gesture as capture_paging_gesture, constrain_motion as constrain_paging_motion,
+    ready_to_snap as scrolling_ready_to_snap, snap_target as paging_snap_target,
+};
+
 pub struct ScrollEventsPlugin;
 
 const NATIVE_SCROLL_RESPONSE_SECONDS: f64 = 0.04;
 const NATIVE_SCROLL_SETTLE_PX: f64 = 0.25;
-/// Distance from a window edge at which sticky scrolling engages. This is a
-/// hit zone, not a visual gap: the resulting snap lands exactly on the edge.
-const STICKY_EDGE_THRESHOLD_PX: i32 = 12;
+/// Logical-point distance inside a window edge at which sticky scrolling
+/// engages. This is a hit zone, not a visual gap: the snap lands on the edge.
+const STICKY_EDGE_THRESHOLD_POINTS: i32 = 32;
+
+#[derive(Default)]
+struct GestureInput {
+    scroll_delta: Option<f64>,
+    gesture_delta: Option<f64>,
+    lifecycle: u8,
+}
+
+const TOUCHPAD_DOWN: u8 = 1 << 0;
+const TOUCHPAD_PHYSICAL_UP: u8 = 1 << 1;
+const TOUCHPAD_MOMENTUM_START: u8 = 1 << 2;
+const TOUCHPAD_UP: u8 = 1 << 3;
 
 impl Plugin for ScrollEventsPlugin {
     fn build(&self, app: &mut App) {
@@ -54,27 +73,24 @@ impl Plugin for ScrollEventsPlugin {
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+// This ECS system intentionally keeps event aggregation and component updates
+// in one schedule boundary; pure paging math lives in `scroll::paging`.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn swipe_gesture(
     mut messages: MessageReader<Event>,
     active_display: ActiveDisplay,
     mut active_workspace: Single<
-        (Entity, &Position, Option<&mut Scrolling>),
+        (Entity, &LayoutStrip, &Position, Option<&mut Scrolling>),
         With<ActiveWorkspaceMarker>,
     >,
+    windows: Windows,
     time: Res<Time>,
     config: Res<Config>,
     mut commands: Commands,
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
-    let snap_enabled = config.sticky_scroll() || config.auto_center();
-    let mut scroll_delta = 0.0;
-    let mut gesture_delta = 0.0;
-    let mut touchpad_down = false;
-    let mut has_scroll_event = false;
-    let mut has_gesture_event = false;
-
+    let snap_enabled = config.swipe_paging() || config.sticky_scroll() || config.auto_center();
     // Normalization: Touchpad deltas are typically small fractions.
     // Scroll wheel deltas can be larger. We scale it down slightly
     // to match the "feel" of a finger swipe.
@@ -83,49 +99,80 @@ fn swipe_gesture(
     const SCROLL_FULL_RANGE: f64 = 2.0;
     let scroll_scale = SCROLL_SCALE_LOWER
         + ((SCROLL_SCALE_UPPER - SCROLL_SCALE_LOWER) / SCROLL_FULL_RANGE) * swipe_sensitivity;
+    let input = read_gesture_input(&mut messages, &config, scroll_scale);
+    let GestureInput {
+        scroll_delta,
+        gesture_delta,
+        lifecycle,
+    } = input;
+    let touchpad_down = lifecycle & TOUCHPAD_DOWN != 0;
+    let touchpad_physical_up = lifecycle & TOUCHPAD_PHYSICAL_UP != 0;
+    let touchpad_momentum_start = lifecycle & TOUCHPAD_MOMENTUM_START != 0;
+    let touchpad_up = lifecycle & TOUCHPAD_UP != 0;
+    let has_gesture_event = gesture_delta.is_some();
+    let has_scroll_event = scroll_delta.is_some() || has_gesture_event;
+    let scroll_delta = scroll_delta.unwrap_or_default();
+    let gesture_delta = gesture_delta.unwrap_or_default();
 
-    for event in messages.read() {
-        match event {
-            Event::TouchpadDown => {
-                touchpad_down = true;
-            }
-            Event::Scroll { delta } => {
-                scroll_delta += *delta * scroll_scale;
-                has_scroll_event = true;
-            }
-            Event::Swipe { delta, fingers }
-                if config
-                    .swipe_gesture_fingers()
-                    .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
-            {
-                gesture_delta += *delta;
-                has_scroll_event = true;
-                has_gesture_event = true;
-            }
-            _ => (),
-        }
-    }
-
-    if !touchpad_down && !has_scroll_event {
+    if lifecycle == 0 && !has_scroll_event {
         return;
     }
 
-    let (entity, position, scrolling) = &mut *active_workspace;
+    let (entity, layout_strip, position, scrolling) = &mut *active_workspace;
+    let has_active_session = scrolling.as_ref().is_some_and(|scrolling| {
+        scrolling.gesture_active
+            || scrolling.is_user_swiping
+            || scrolling.snap_pending
+            || scrolling.paging_gesture.is_some()
+    });
+    let resumes_gesture = has_active_session && (touchpad_down || touchpad_momentum_start);
+    let starts_new_gesture = (touchpad_down && !has_active_session)
+        || (!has_active_session
+            && has_scroll_event
+            && !touchpad_momentum_start
+            && scrolling
+                .as_ref()
+                .is_none_or(|scrolling| !scrolling.is_user_swiping));
+    let viewport = active_display.actual_bounds(&config);
+    let paging_gesture = (config.swipe_paging() && starts_new_gesture)
+        .then(|| {
+            current_paging_gesture(
+                layout_strip,
+                position,
+                scrolling.as_deref(),
+                &windows,
+                &viewport,
+            )
+        })
+        .flatten();
 
-    if touchpad_down && let Some(scrolling) = scrolling.as_mut() {
-        scrolling.velocity = 0.0;
-        scrolling.target_position = None;
-        scrolling.snap_pending = snap_enabled;
-        scrolling.is_user_swiping = true;
-        scrolling.last_event = Instant::now();
+    begin_touchpad_gesture(
+        starts_new_gesture,
+        touchpad_down,
+        snap_enabled,
+        paging_gesture,
+        scrolling.as_deref_mut(),
+    );
+    // AppKit can report physical Ended and momentum Began together. Apply the
+    // physical end first so the momentum phase remains the final state.
+    mark_physical_touch_end(touchpad_physical_up, scrolling.as_deref_mut());
+    resume_touchpad_gesture(resumes_gesture, scrolling.as_deref_mut());
+
+    if touchpad_down && !has_scroll_event && scrolling.is_none() {
+        insert_touchpad_begin_state(
+            *entity,
+            position.x,
+            snap_enabled,
+            paging_gesture,
+            &mut commands,
+        );
     }
 
     if has_scroll_event {
+        // Preserve the established gesture-distance normalization. Paging
+        // anchors themselves use the usable viewport below.
         let viewport_width = f64::from(active_display.bounds().width());
-        let direction_modifier = match config.swipe_gesture_direction() {
-            SwipeGestureDirection::Natural => -1.0,
-            SwipeGestureDirection::Reversed => 1.0,
-        };
+        let direction_modifier = horizontal_direction_modifier(&config);
 
         let dt = time.delta_secs_f64();
         let new_velocity = if has_gesture_event && dt > 0.0 {
@@ -140,8 +187,7 @@ fn swipe_gesture(
 
         if let Some(scrolling) = scrolling.as_mut() {
             let was_user_swiping = scrolling.is_user_swiping;
-            // Native modifier-scroll events already include macOS momentum.
-            // Add synthetic inertia only for raw multi-finger gestures.
+            // Native modifier-scroll has momentum; synthesize inertia only for raw gestures.
             scrolling.velocity = if has_gesture_event {
                 // Smoothen gesture velocity changes using EMA.
                 0.3 * new_velocity + 0.7 * scrolling.velocity
@@ -166,18 +212,153 @@ fn swipe_gesture(
                 let target = scrolling.target_position.unwrap_or(scrolling.position);
                 scrolling.target_position = Some(target + scroll_distance);
             }
+            constrain_paging_motion(scrolling, direction_modifier);
         } else if let Ok(mut entity_commands) = commands.get_entity(*entity) {
             let initial_position = f64::from(position.0.x) + gesture_distance;
-            entity_commands.try_insert(Scrolling {
+            let mut scrolling = Scrolling {
                 velocity: new_velocity,
                 position: initial_position,
                 target_position: (scroll_delta != 0.0)
                     .then_some(initial_position + scroll_distance),
                 snap_pending: snap_enabled,
-                is_user_swiping: touchpad_down || has_scroll_event,
+                is_user_swiping: !touchpad_up && (touchpad_down || has_scroll_event),
+                gesture_active: touchpad_down && !touchpad_up,
+                paging_gesture,
                 last_event: Instant::now(),
-            });
+            };
+            constrain_paging_motion(&mut scrolling, direction_modifier);
+            entity_commands.try_insert(scrolling);
         }
+    }
+
+    let direction_modifier = horizontal_direction_modifier(&config);
+    finish_touchpad_gesture(touchpad_up, direction_modifier, scrolling.as_deref_mut());
+}
+
+fn read_gesture_input(
+    messages: &mut MessageReader<Event>,
+    config: &Config,
+    scroll_scale: f64,
+) -> GestureInput {
+    let mut input = GestureInput::default();
+    for event in messages.read() {
+        match event {
+            Event::TouchpadDown => input.lifecycle |= TOUCHPAD_DOWN,
+            Event::TouchpadPhysicalUp => input.lifecycle |= TOUCHPAD_PHYSICAL_UP,
+            Event::TouchpadMomentumStart => input.lifecycle |= TOUCHPAD_MOMENTUM_START,
+            Event::TouchpadUp => input.lifecycle |= TOUCHPAD_UP,
+            Event::Scroll { delta } => {
+                *input.scroll_delta.get_or_insert(0.0) += *delta * scroll_scale;
+            }
+            Event::Swipe { delta, fingers }
+                if config
+                    .swipe_gesture_fingers()
+                    .is_some_and(|configured| configured == *fingers) =>
+            {
+                *input.gesture_delta.get_or_insert(0.0) += *delta;
+            }
+            _ => {}
+        }
+    }
+    input
+}
+
+fn insert_touchpad_begin_state(
+    entity: Entity,
+    position: i32,
+    snap_enabled: bool,
+    paging_gesture: Option<PagingGesture>,
+    commands: &mut Commands,
+) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+        entity_commands.try_insert(Scrolling {
+            position: f64::from(position),
+            snap_pending: snap_enabled,
+            is_user_swiping: true,
+            gesture_active: true,
+            paging_gesture,
+            ..Default::default()
+        });
+    }
+}
+
+fn horizontal_direction_modifier(config: &Config) -> f64 {
+    match config.swipe_gesture_direction() {
+        SwipeGestureDirection::Natural => -1.0,
+        SwipeGestureDirection::Reversed => 1.0,
+    }
+}
+
+fn current_paging_gesture(
+    layout_strip: &LayoutStrip,
+    position: &Position,
+    scrolling: Option<&Scrolling>,
+    windows: &Windows<'_, '_>,
+    viewport: &IRect,
+) -> Option<PagingGesture> {
+    let get_window_frame = |entity| windows.moving_frame(entity);
+    let columns = layout_strip.columns().filter_map(|column| {
+        let entity = column.top()?;
+        Some((
+            windows.layout_position(entity)?.0.x,
+            column.width(&get_window_frame)?,
+        ))
+    });
+    let current_position = scrolling.map_or(f64::from(position.x), |scrolling| scrolling.position);
+    capture_paging_gesture(current_position, viewport, columns)
+}
+
+fn begin_touchpad_gesture(
+    starts_new_gesture: bool,
+    touchpad_down: bool,
+    snap_enabled: bool,
+    paging_gesture: Option<PagingGesture>,
+    scrolling: Option<&mut Scrolling>,
+) {
+    if starts_new_gesture && let Some(scrolling) = scrolling {
+        scrolling.velocity = 0.0;
+        scrolling.target_position = None;
+        scrolling.snap_pending = snap_enabled;
+        scrolling.is_user_swiping = true;
+        scrolling.gesture_active = touchpad_down;
+        scrolling.paging_gesture = paging_gesture;
+        scrolling.last_event = Instant::now();
+    }
+}
+
+fn resume_touchpad_gesture(resumes_gesture: bool, scrolling: Option<&mut Scrolling>) {
+    if resumes_gesture && let Some(scrolling) = scrolling {
+        scrolling.target_position = None;
+        scrolling.snap_pending = true;
+        scrolling.is_user_swiping = true;
+        scrolling.gesture_active = true;
+        scrolling.last_event = Instant::now();
+    }
+}
+
+fn mark_physical_touch_end(physical_up: bool, scrolling: Option<&mut Scrolling>) {
+    if physical_up && let Some(scrolling) = scrolling {
+        scrolling.gesture_active = false;
+        // Keep user-swiping true until either momentum starts or the inactivity
+        // fallback proves there will be no native momentum phase.
+        scrolling.is_user_swiping = true;
+        scrolling.last_event = Instant::now();
+    }
+}
+
+fn finish_touchpad_gesture(
+    touchpad_up: bool,
+    direction_modifier: f64,
+    scrolling: Option<&mut Scrolling>,
+) {
+    // Momentum can keep moving afterwards, but sticky selection starts only
+    // after both the gesture and any remaining target/velocity have settled.
+    if touchpad_up && let Some(scrolling) = scrolling {
+        if let Some(paging) = scrolling.paging_gesture.as_mut() {
+            paging.release_velocity = scrolling.velocity * direction_modifier;
+        }
+        scrolling.gesture_active = false;
+        scrolling.is_user_swiping = false;
     }
 }
 
@@ -196,7 +377,7 @@ pub(super) fn swiping_timeout(
     let viewport_width = f64::from(active_display.bounds().width());
 
     for (entity, mut scroll) in strips {
-        if scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD {
+        if !scroll.gesture_active && scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD {
             scroll.is_user_swiping = false;
 
             if scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
@@ -249,8 +430,9 @@ fn apply_snap_force(
     const SNAP_DISPLAY_RATIO: f64 = 0.45;
 
     let (layout_strip, position, ref mut scroll) = *strip;
+    let paging = config.swipe_paging();
     let sticky = config.sticky_scroll();
-    if !sticky && !config.auto_center() {
+    if !paging && !sticky && !config.auto_center() {
         scroll.snap_pending = false;
         return;
     }
@@ -258,12 +440,18 @@ fn apply_snap_force(
     let viewport = active_display.actual_bounds(&config);
     let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
 
-    if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 || scroll.target_position.is_some() {
+    if !scrolling_ready_to_snap(scroll) {
         return;
     }
 
     let get_window_frame = |entity| windows.moving_frame(entity);
-    let target_offset = if sticky {
+    let target_offset = if paging {
+        let Some(paging_gesture) = scroll.paging_gesture else {
+            scroll.snap_pending = false;
+            return;
+        };
+        paging_snap_target(scroll.position, f64::from(viewport.width()), paging_gesture) as i32
+    } else if sticky {
         let Some(target_offset) = sticky_edge_snap_target(
             position.x,
             &viewport,
@@ -299,7 +487,7 @@ fn apply_snap_force(
 
     let dist_to_snap = f64::from(position.x - target_offset);
     scroll.snap_pending = false;
-    if sticky || dist_to_snap.abs() < snap_threshold {
+    if paging || sticky || dist_to_snap.abs() < snap_threshold {
         // Keep Scrolling alive until the shared target integrator reaches the
         // anchor. This works for native modifier-scroll and raw gestures.
         scroll.velocity = 0.0;
@@ -313,7 +501,7 @@ fn sticky_edge_snap_target(
     columns: impl IntoIterator<Item = (i32, i32)>,
 ) -> Option<i32> {
     let current_offset = i64::from(current_offset);
-    let threshold = i64::from(STICKY_EDGE_THRESHOLD_PX);
+    let threshold = i64::from(STICKY_EDGE_THRESHOLD_POINTS);
 
     columns
         .into_iter()
@@ -352,10 +540,7 @@ fn scrolling_integrator(
     let viewport_width = f64::from(viewport.width());
 
     // Direction modifier: Natural moves strip left (negative offset) for positive delta (finger left)
-    let direction_modifier = match config.swipe_gesture_direction() {
-        SwipeGestureDirection::Natural => -1.0,
-        SwipeGestureDirection::Reversed => 1.0,
-    };
+    let direction_modifier = horizontal_direction_modifier(&config);
 
     let scroll = &mut *strip;
     if let Some(target) = scroll.target_position {
@@ -363,12 +548,16 @@ fn scrolling_integrator(
         scroll.position = position;
         if settled {
             scroll.target_position = None;
+            if !scroll.snap_pending {
+                scroll.paging_gesture = None;
+            }
         }
         return;
     }
 
     if scroll.velocity.abs() > 0.0001 {
         scroll.position += scroll.velocity * dt * viewport_width * direction_modifier;
+        constrain_paging_motion(scroll, direction_modifier);
     }
 }
 
@@ -470,6 +659,18 @@ where
         })
         .map(|(position, frame)| position.x + frame.width())?;
 
+    if config.swipe_paging() {
+        let content_min = layout_strip
+            .columns()
+            .filter_map(Column::top)
+            .filter_map(|entity| windows.layout_position(entity))
+            .map(|position| position.0.x)
+            .min()?;
+        let first_edge = viewport.min.x - content_min;
+        let last_edge = viewport.max.x - total_strip_width;
+        return Some(current_offset.clamp(first_edge.min(last_edge), first_edge.max(last_edge)));
+    }
+
     let continuous_swipe = config.continuous_swipe();
     let has_oversized_column = layout_strip.columns().any(|column| {
         column
@@ -492,7 +693,7 @@ where
         && let Some((left_snap, right_snap)) = left_snap.zip(right_snap)
     {
         // Allow scrolling until the last or first window reaches the viewport
-        // edge exactly. Sticky's 12px value is only an activation threshold.
+        // edge exactly. Sticky's 32pt value is only an activation threshold.
         (viewport.min.x - left_snap, viewport.max.x - right_snap)
     } else {
         // Pan between the leading and trailing strip edges. The min/max form
@@ -580,132 +781,4 @@ fn switch_virtual_workspace(delta: f64, config: &Config, commands: &mut Commands
 }
 
 #[cfg(test)]
-mod tests {
-    use std::time::{Duration, Instant};
-
-    use bevy::ecs::query::With;
-    use bevy::prelude::Entity;
-    use bevy::time::TimeUpdateStrategy;
-
-    use bevy::math::IRect;
-
-    use super::{Scrolling, smooth_native_scroll, sticky_edge_snap_target};
-    use crate::commands::Command;
-    use crate::ecs::{ActiveWorkspaceMarker, Position};
-    use crate::events::Event;
-    use crate::tests::TestHarness;
-
-    #[test]
-    fn native_scroll_smoothing_converges_without_overshoot() {
-        let mut position = 0.0;
-        let mut settled = false;
-
-        for _ in 0..120 {
-            let previous = position;
-            (position, settled) = smooth_native_scroll(position, 100.0, 1.0 / 60.0);
-            assert!(position >= previous);
-            assert!(position <= 100.0);
-
-            if settled {
-                break;
-            }
-        }
-
-        assert!((position - 100.0).abs() < f64::EPSILON);
-        assert!(settled);
-    }
-
-    #[test]
-    fn sticky_scroll_snaps_only_inside_the_edge_hit_zone() {
-        let viewport = IRect::new(0, 0, 1000, 800);
-        let columns = [(0, 600), (600, 600)];
-
-        assert_eq!(
-            sticky_edge_snap_target(-609, &viewport, columns),
-            Some(-600),
-            "a column edge inside the 12px hit zone should snap exactly to the viewport edge"
-        );
-        assert_eq!(
-            sticky_edge_snap_target(-191, &viewport, columns),
-            Some(-200),
-            "the right edge should also snap exactly when it is inside the hit zone"
-        );
-        assert_eq!(
-            sticky_edge_snap_target(-591, &viewport, columns),
-            None,
-            "the hit zone must be inside the window, not outside its edge"
-        );
-        assert_eq!(
-            sticky_edge_snap_target(-187, &viewport, columns),
-            None,
-            "sticky scroll must not pull an edge from farther than 12px"
-        );
-    }
-
-    #[test]
-    fn sticky_scroll_exposes_both_edges_of_an_oversized_column() {
-        let viewport = IRect::new(0, 0, 1000, 800);
-        let oversized_column = [(0, 1500)];
-
-        assert_eq!(
-            sticky_edge_snap_target(-9, &viewport, oversized_column),
-            Some(0)
-        );
-        assert_eq!(
-            sticky_edge_snap_target(-491, &viewport, oversized_column),
-            Some(-500)
-        );
-        assert_eq!(
-            sticky_edge_snap_target(-250, &viewport, oversized_column),
-            None,
-            "an oversized window must remain freely pannable between its edge zones"
-        );
-    }
-
-    #[test]
-    fn scrolling_component_is_removed_after_integer_effective_dead_zone() {
-        let commands = vec![
-            Event::MenuOpened { window_id: 0 },
-            Event::Command {
-                command: Command::PrintState,
-            },
-        ];
-
-        TestHarness::new()
-            .with_windows(3)
-            .on_iteration(0, |world, _state| {
-                world.insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
-                    16,
-                )));
-                let entity = {
-                    let mut query = world.query_filtered::<Entity, With<ActiveWorkspaceMarker>>();
-                    query.single(world).expect("one active workspace")
-                };
-                world.entity_mut(entity).insert(Scrolling {
-                    velocity: 0.0,
-                    position: 0.0,
-                    target_position: Some(-1.0),
-                    snap_pending: false,
-                    is_user_swiping: false,
-                    last_event: Instant::now()
-                        .checked_sub(Duration::from_millis(100))
-                        .expect("100ms must fit before the current instant"),
-                });
-            })
-            .on_iteration(1, |world, _state| {
-                let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
-                assert!(
-                    query.single(world).is_err(),
-                    "settled integer-effective motion must remove Scrolling"
-                );
-                let mut positions =
-                    world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
-                assert_eq!(
-                    positions.single(world).expect("one active workspace").x,
-                    -1,
-                    "the final effective pixel must be applied before settlement"
-                );
-            })
-            .run(commands);
-    }
-}
+mod tests;

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -26,7 +26,9 @@ pub struct ScrollEventsPlugin;
 
 const NATIVE_SCROLL_RESPONSE_SECONDS: f64 = 0.04;
 const NATIVE_SCROLL_SETTLE_PX: f64 = 0.25;
-const STICKY_EDGE_GAP_PX: i32 = 12;
+/// Distance from a window edge at which sticky scrolling engages. This is a
+/// hit zone, not a visual gap: the resulting snap lands exactly on the edge.
+const STICKY_EDGE_THRESHOLD_PX: i32 = 12;
 
 impl Plugin for ScrollEventsPlugin {
     fn build(&self, app: &mut App) {
@@ -262,7 +264,7 @@ fn apply_snap_force(
 
     let get_window_frame = |entity| windows.moving_frame(entity);
     let target_offset = if sticky {
-        sticky_edge_snap_target(
+        let Some(target_offset) = sticky_edge_snap_target(
             position.x,
             &viewport,
             layout_strip.columns().filter_map(|column| {
@@ -271,8 +273,11 @@ fn apply_snap_force(
                 let column_width = column.width(&get_window_frame)?;
                 Some((column_position, column_width))
             }),
-        )
-        .unwrap_or(position.x)
+        ) else {
+            scroll.snap_pending = false;
+            return;
+        };
+        target_offset
     } else {
         let viewport_center = viewport.center().x;
         layout_strip
@@ -307,19 +312,31 @@ fn sticky_edge_snap_target(
     viewport: &IRect,
     columns: impl IntoIterator<Item = (i32, i32)>,
 ) -> Option<i32> {
-    let edge_gap = STICKY_EDGE_GAP_PX.min(viewport.width().saturating_sub(1) / 2);
-    let left_anchor = viewport.min.x + edge_gap;
-    let right_anchor = viewport.max.x - edge_gap;
+    let current_offset = i64::from(current_offset);
+    let threshold = i64::from(STICKY_EDGE_THRESHOLD_PX);
 
     columns
         .into_iter()
         .flat_map(|(column_position, column_width)| {
             [
-                left_anchor - column_position,
-                right_anchor - (column_position + column_width),
+                (
+                    viewport.min.x - column_position,
+                    // The viewport's left edge is inside the window.
+                    -threshold..=0,
+                ),
+                (
+                    viewport.max.x - (column_position + column_width),
+                    // The viewport's right edge is inside the window.
+                    0..=threshold,
+                ),
             ]
         })
-        .min_by_key(|target| (i64::from(current_offset) - i64::from(*target)).abs())
+        .filter_map(|(target, hit_zone)| {
+            hit_zone
+                .contains(&(current_offset - i64::from(target)))
+                .then_some(target)
+        })
+        .min_by_key(|target| (current_offset - i64::from(*target)).abs())
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -470,30 +487,18 @@ where
     let left_snap = strip_position(layout_strip.last());
     let right_snap = strip_position(layout_strip.get(1));
 
-    let edge_gap = if config.sticky_scroll() {
-        STICKY_EDGE_GAP_PX.min(viewport.width().saturating_sub(1) / 2)
-    } else {
-        0
-    };
-
     let (first_edge, last_edge) = if continuous_swipe
         && !has_oversized_column
         && let Some((left_snap, right_snap)) = left_snap.zip(right_snap)
     {
-        // Allow to scroll away until the last or first window reaches the
-        // viewport edge, preserving the sticky outer gap.
-        (
-            viewport.min.x + edge_gap - left_snap,
-            viewport.max.x - edge_gap - right_snap,
-        )
+        // Allow scrolling until the last or first window reaches the viewport
+        // edge exactly. Sticky's 12px value is only an activation threshold.
+        (viewport.min.x - left_snap, viewport.max.x - right_snap)
     } else {
         // Pan between the leading and trailing strip edges. The min/max form
         // also handles strips narrower than the viewport without an inverted
         // clamp range.
-        (
-            viewport.min.x + edge_gap,
-            viewport.max.x - edge_gap - total_strip_width,
-        )
+        (viewport.min.x, viewport.max.x - total_strip_width)
     };
 
     Some(current_offset.clamp(first_edge.min(last_edge), first_edge.max(last_edge)))
@@ -611,19 +616,29 @@ mod tests {
     }
 
     #[test]
-    fn sticky_scroll_snaps_column_edges_instead_of_centers() {
+    fn sticky_scroll_snaps_only_inside_the_edge_hit_zone() {
         let viewport = IRect::new(0, 0, 1000, 800);
         let columns = [(0, 600), (600, 600)];
 
         assert_eq!(
-            sticky_edge_snap_target(-520, &viewport, columns),
-            Some(-588),
-            "the next column's left edge should land 12px from the viewport edge"
+            sticky_edge_snap_target(-609, &viewport, columns),
+            Some(-600),
+            "a column edge inside the 12px hit zone should snap exactly to the viewport edge"
         );
         assert_eq!(
-            sticky_edge_snap_target(-260, &viewport, columns),
-            Some(-212),
-            "the current column's right edge should land 12px from the viewport edge"
+            sticky_edge_snap_target(-191, &viewport, columns),
+            Some(-200),
+            "the right edge should also snap exactly when it is inside the hit zone"
+        );
+        assert_eq!(
+            sticky_edge_snap_target(-591, &viewport, columns),
+            None,
+            "the hit zone must be inside the window, not outside its edge"
+        );
+        assert_eq!(
+            sticky_edge_snap_target(-187, &viewport, columns),
+            None,
+            "sticky scroll must not pull an edge from farther than 12px"
         );
     }
 
@@ -633,12 +648,17 @@ mod tests {
         let oversized_column = [(0, 1500)];
 
         assert_eq!(
-            sticky_edge_snap_target(-100, &viewport, oversized_column),
-            Some(12)
+            sticky_edge_snap_target(-9, &viewport, oversized_column),
+            Some(0)
         );
         assert_eq!(
-            sticky_edge_snap_target(-450, &viewport, oversized_column),
-            Some(-512)
+            sticky_edge_snap_target(-491, &viewport, oversized_column),
+            Some(-500)
+        );
+        assert_eq!(
+            sticky_edge_snap_target(-250, &viewport, oversized_column),
+            None,
+            "an oversized window must remain freely pannable between its edge zones"
         );
     }
 

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -26,6 +26,7 @@ pub struct ScrollEventsPlugin;
 
 const NATIVE_SCROLL_RESPONSE_SECONDS: f64 = 0.04;
 const NATIVE_SCROLL_SETTLE_PX: f64 = 0.25;
+const STICKY_EDGE_GAP_PX: i32 = 12;
 
 impl Plugin for ScrollEventsPlugin {
     fn build(&self, app: &mut App) {
@@ -253,28 +254,43 @@ fn apply_snap_force(
     }
 
     let viewport = active_display.actual_bounds(&config);
-    let viewport_center = viewport.center().x;
     let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
 
     if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 || scroll.target_position.is_some() {
         return;
     }
 
-    let target_offset = layout_strip
-        .all_columns()
-        .into_iter()
-        .filter_map(|entity| {
-            windows
-                .layout_position(entity)
-                .map(|p| p.0.x)
-                .zip(Some(entity))
-        })
-        .map(|(position, entity)| {
-            let col_width = windows.moving_frame(entity).map_or(0, |f| f.width());
-            viewport_center - (position + col_width / 2)
-        })
-        .min_by_key(|target| (position.x - target).abs())
-        .unwrap_or(position.x);
+    let get_window_frame = |entity| windows.moving_frame(entity);
+    let target_offset = if sticky {
+        sticky_edge_snap_target(
+            position.x,
+            &viewport,
+            layout_strip.columns().filter_map(|column| {
+                let entity = column.top()?;
+                let column_position = windows.layout_position(entity)?.0.x;
+                let column_width = column.width(&get_window_frame)?;
+                Some((column_position, column_width))
+            }),
+        )
+        .unwrap_or(position.x)
+    } else {
+        let viewport_center = viewport.center().x;
+        layout_strip
+            .all_columns()
+            .into_iter()
+            .filter_map(|entity| {
+                windows
+                    .layout_position(entity)
+                    .map(|p| p.0.x)
+                    .zip(Some(entity))
+            })
+            .map(|(column_position, entity)| {
+                let column_width = windows.moving_frame(entity).map_or(0, |f| f.width());
+                viewport_center - (column_position + column_width / 2)
+            })
+            .min_by_key(|target| (position.x - target).abs())
+            .unwrap_or(position.x)
+    };
 
     let dist_to_snap = f64::from(position.x - target_offset);
     scroll.snap_pending = false;
@@ -284,6 +300,26 @@ fn apply_snap_force(
         scroll.velocity = 0.0;
         scroll.target_position = Some(f64::from(target_offset));
     }
+}
+
+fn sticky_edge_snap_target(
+    current_offset: i32,
+    viewport: &IRect,
+    columns: impl IntoIterator<Item = (i32, i32)>,
+) -> Option<i32> {
+    let edge_gap = STICKY_EDGE_GAP_PX.min(viewport.width().saturating_sub(1) / 2);
+    let left_anchor = viewport.min.x + edge_gap;
+    let right_anchor = viewport.max.x - edge_gap;
+
+    columns
+        .into_iter()
+        .flat_map(|(column_position, column_width)| {
+            [
+                left_anchor - column_position,
+                right_anchor - (column_position + column_width),
+            ]
+        })
+        .min_by_key(|target| (i64::from(current_offset) - i64::from(*target)).abs())
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -330,6 +366,20 @@ fn smooth_native_scroll(position: f64, target: f64, dt: f64) -> (f64, bool) {
     }
 }
 
+/// Preserve the integrator's subpixel remainder unless viewport constraints
+/// actually changed the integer position that macOS can apply.
+fn reconcile_integrated_position(
+    integrated_position: f64,
+    effective_position: i32,
+    clamped_position: i32,
+) -> f64 {
+    if effective_position == clamped_position {
+        integrated_position
+    } else {
+        f64::from(clamped_position)
+    }
+}
+
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn apply_scrolling_constraints(
@@ -345,8 +395,9 @@ fn apply_scrolling_constraints(
     let (strip, ref mut position, ref mut scroll) = *strip;
 
     let get_window_frame = |entity| windows.moving_frame(entity);
+    let effective_offset = scroll.position as i32;
     if let Some(clamped_offset) = clamp_viewport_offset(
-        scroll.position as i32,
+        effective_offset,
         strip,
         &windows,
         &get_window_frame,
@@ -354,10 +405,12 @@ fn apply_scrolling_constraints(
         &config,
     ) {
         position.x = clamped_offset;
-        scroll.position = f64::from(clamped_offset);
+        scroll.position =
+            reconcile_integrated_position(scroll.position, effective_offset, clamped_offset);
         if let Some(target) = scroll.target_position
+            && let effective_target = target as i32
             && let Some(clamped_target) = clamp_viewport_offset(
-                target as i32,
+                effective_target,
                 strip,
                 &windows,
                 &get_window_frame,
@@ -365,7 +418,11 @@ fn apply_scrolling_constraints(
                 &config,
             )
         {
-            scroll.target_position = Some(f64::from(clamped_target));
+            scroll.target_position = Some(reconcile_integrated_position(
+                target,
+                effective_target,
+                clamped_target,
+            ));
         }
     } else {
         scroll.velocity = 0.0;
@@ -413,21 +470,33 @@ where
     let left_snap = strip_position(layout_strip.last());
     let right_snap = strip_position(layout_strip.get(1));
 
-    Some(
-        if continuous_swipe
-            && !has_oversized_column
-            && let Some((left_snap, right_snap)) = left_snap.zip(right_snap)
-        {
-            // Allow to scroll away until the last or first window snaps.
-            current_offset.clamp(viewport.min.x - left_snap, viewport.max.x - right_snap)
-        } else if viewport.width() < total_strip_width {
-            // Snap the strip directly to the edges.
-            current_offset.clamp(viewport.max.x - total_strip_width, viewport.min.x)
-        } else {
-            // Snap the strip directly to the edges.
-            current_offset.clamp(viewport.min.x, viewport.max.x - total_strip_width)
-        },
-    )
+    let edge_gap = if config.sticky_scroll() {
+        STICKY_EDGE_GAP_PX.min(viewport.width().saturating_sub(1) / 2)
+    } else {
+        0
+    };
+
+    let (first_edge, last_edge) = if continuous_swipe
+        && !has_oversized_column
+        && let Some((left_snap, right_snap)) = left_snap.zip(right_snap)
+    {
+        // Allow to scroll away until the last or first window reaches the
+        // viewport edge, preserving the sticky outer gap.
+        (
+            viewport.min.x + edge_gap - left_snap,
+            viewport.max.x - edge_gap - right_snap,
+        )
+    } else {
+        // Pan between the leading and trailing strip edges. The min/max form
+        // also handles strips narrower than the viewport without an inverted
+        // clamp range.
+        (
+            viewport.min.x + edge_gap,
+            viewport.max.x - edge_gap - total_strip_width,
+        )
+    };
+
+    Some(current_offset.clamp(first_edge.min(last_edge), first_edge.max(last_edge)))
 }
 
 #[derive(Default)]
@@ -507,7 +576,19 @@ fn switch_virtual_workspace(delta: f64, config: &Config, commands: &mut Commands
 
 #[cfg(test)]
 mod tests {
-    use super::smooth_native_scroll;
+    use std::time::{Duration, Instant};
+
+    use bevy::ecs::query::With;
+    use bevy::prelude::Entity;
+    use bevy::time::TimeUpdateStrategy;
+
+    use bevy::math::IRect;
+
+    use super::{Scrolling, smooth_native_scroll, sticky_edge_snap_target};
+    use crate::commands::Command;
+    use crate::ecs::{ActiveWorkspaceMarker, Position};
+    use crate::events::Event;
+    use crate::tests::TestHarness;
 
     #[test]
     fn native_scroll_smoothing_converges_without_overshoot() {
@@ -527,5 +608,84 @@ mod tests {
 
         assert!((position - 100.0).abs() < f64::EPSILON);
         assert!(settled);
+    }
+
+    #[test]
+    fn sticky_scroll_snaps_column_edges_instead_of_centers() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let columns = [(0, 600), (600, 600)];
+
+        assert_eq!(
+            sticky_edge_snap_target(-520, &viewport, columns),
+            Some(-588),
+            "the next column's left edge should land 12px from the viewport edge"
+        );
+        assert_eq!(
+            sticky_edge_snap_target(-260, &viewport, columns),
+            Some(-212),
+            "the current column's right edge should land 12px from the viewport edge"
+        );
+    }
+
+    #[test]
+    fn sticky_scroll_exposes_both_edges_of_an_oversized_column() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let oversized_column = [(0, 1500)];
+
+        assert_eq!(
+            sticky_edge_snap_target(-100, &viewport, oversized_column),
+            Some(12)
+        );
+        assert_eq!(
+            sticky_edge_snap_target(-450, &viewport, oversized_column),
+            Some(-512)
+        );
+    }
+
+    #[test]
+    fn scrolling_component_is_removed_after_integer_effective_dead_zone() {
+        let commands = vec![
+            Event::MenuOpened { window_id: 0 },
+            Event::Command {
+                command: Command::PrintState,
+            },
+        ];
+
+        TestHarness::new()
+            .with_windows(3)
+            .on_iteration(0, |world, _state| {
+                world.insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
+                    16,
+                )));
+                let entity = {
+                    let mut query = world.query_filtered::<Entity, With<ActiveWorkspaceMarker>>();
+                    query.single(world).expect("one active workspace")
+                };
+                world.entity_mut(entity).insert(Scrolling {
+                    velocity: 0.0,
+                    position: 0.0,
+                    target_position: Some(-1.0),
+                    snap_pending: false,
+                    is_user_swiping: false,
+                    last_event: Instant::now()
+                        .checked_sub(Duration::from_millis(100))
+                        .expect("100ms must fit before the current instant"),
+                });
+            })
+            .on_iteration(1, |world, _state| {
+                let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+                assert!(
+                    query.single(world).is_err(),
+                    "settled integer-effective motion must remove Scrolling"
+                );
+                let mut positions =
+                    world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+                assert_eq!(
+                    positions.single(world).expect("one active workspace").x,
+                    -1,
+                    "the final effective pixel must be applied before settlement"
+                );
+            })
+            .run(commands);
     }
 }

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -20,7 +20,7 @@ use crate::ecs::{
 };
 use crate::errors::Result;
 use crate::events::Event;
-use crate::manager::{Window, WindowManager};
+use crate::manager::{Window, WindowManager, origin_from};
 use crate::platform::Modifiers;
 
 mod paging;
@@ -33,9 +33,9 @@ pub struct ScrollEventsPlugin;
 
 const NATIVE_SCROLL_RESPONSE_SECONDS: f64 = 0.04;
 const NATIVE_SCROLL_SETTLE_PX: f64 = 0.25;
-/// Logical-point distance inside a window edge at which sticky scrolling
+/// Fraction of the usable viewport inside a window edge at which snapping
 /// engages. This is a hit zone, not a visual gap: the snap lands on the edge.
-const STICKY_EDGE_THRESHOLD_POINTS: i32 = 32;
+const STICKY_EDGE_THRESHOLD_RATIO: f64 = 0.1;
 
 #[derive(Default)]
 struct GestureInput {
@@ -75,7 +75,11 @@ impl Plugin for ScrollEventsPlugin {
 
 // This ECS system intentionally keeps event aggregation and component updates
 // in one schedule boundary; pure paging math lives in `scroll::paging`.
-#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+#[allow(
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments,
+    clippy::too_many_lines
+)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn swipe_gesture(
     mut messages: MessageReader<Event>,
@@ -87,6 +91,7 @@ fn swipe_gesture(
     windows: Windows,
     time: Res<Time>,
     config: Res<Config>,
+    window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
@@ -110,6 +115,7 @@ fn swipe_gesture(
     let touchpad_momentum_start = lifecycle & TOUCHPAD_MOMENTUM_START != 0;
     let touchpad_up = lifecycle & TOUCHPAD_UP != 0;
     let has_gesture_event = gesture_delta.is_some();
+    let has_native_scroll_event = scroll_delta.is_some();
     let has_scroll_event = scroll_delta.is_some() || has_gesture_event;
     let scroll_delta = scroll_delta.unwrap_or_default();
     let gesture_delta = gesture_delta.unwrap_or_default();
@@ -142,6 +148,8 @@ fn swipe_gesture(
                 scrolling.as_deref(),
                 &windows,
                 &viewport,
+                &window_manager,
+                has_native_scroll_event,
             )
         })
         .flatten();
@@ -156,7 +164,12 @@ fn swipe_gesture(
     // AppKit can report physical Ended and momentum Began together. Apply the
     // physical end first so the momentum phase remains the final state.
     mark_physical_touch_end(touchpad_physical_up, scrolling.as_deref_mut());
-    resume_touchpad_gesture(resumes_gesture, touchpad_down, scrolling.as_deref_mut());
+    resume_touchpad_gesture(
+        resumes_gesture,
+        touchpad_down,
+        touchpad_momentum_start,
+        scrolling.as_deref_mut(),
+    );
 
     if touchpad_down && !has_scroll_event && scrolling.is_none() {
         insert_touchpad_begin_state(
@@ -295,17 +308,48 @@ fn current_paging_gesture(
     scrolling: Option<&Scrolling>,
     windows: &Windows<'_, '_>,
     viewport: &IRect,
+    window_manager: &WindowManager,
+    prefer_pointer_window: bool,
 ) -> Option<PagingGesture> {
     let get_window_frame = |entity| windows.moving_frame(entity);
-    let columns = layout_strip.columns().filter_map(|column| {
-        let entity = column.top()?;
-        Some((
-            windows.layout_position(entity)?.0.x,
-            column.width(&get_window_frame)?,
-        ))
-    });
+    let columns = layout_strip
+        .columns()
+        .filter_map(|column| {
+            let entity = column.top()?;
+            Some((
+                entity,
+                windows.layout_position(entity)?.0.x,
+                column.width(&get_window_frame)?,
+            ))
+        })
+        .collect::<Vec<_>>();
+    let preferred_column = prefer_pointer_window
+        .then(|| window_manager.cursor_position())
+        .flatten()
+        .and_then(|point| {
+            let cursor = origin_from(point);
+            let window_id = window_manager.find_window_at_point(&point).ok()?;
+            let (_, entity) = windows.find_managed(window_id)?;
+            windows
+                .moving_frame(entity)
+                .is_some_and(|frame| frame.contains(cursor))
+                .then_some(entity)
+        })
+        .and_then(|entity| {
+            columns
+                .iter()
+                .find(|(candidate, _, _)| *candidate == entity)
+                .map(|(_, position, width)| (*position, *width))
+        });
     let current_position = scrolling.map_or(f64::from(position.x), |scrolling| scrolling.position);
-    capture_paging_gesture(current_position, viewport, columns)
+    capture_paging_gesture(
+        current_position,
+        viewport,
+        columns
+            .into_iter()
+            .map(|(_, column_position, column_width)| (column_position, column_width)),
+        preferred_column,
+    )
 }
 
 fn begin_touchpad_gesture(
@@ -329,11 +373,18 @@ fn begin_touchpad_gesture(
 fn resume_touchpad_gesture(
     resumes_gesture: bool,
     interrupts_target: bool,
+    momentum_started: bool,
     scrolling: Option<&mut Scrolling>,
 ) {
     if resumes_gesture && let Some(scrolling) = scrolling {
         if interrupts_target {
             scrolling.target_position = None;
+        } else if momentum_started && let Some(target) = scrolling.target_position.take() {
+            // Native momentum already carries its own decaying deltas. Do not
+            // carry an interpolation backlog from the physical phase into it,
+            // otherwise the strip keeps gliding after macOS momentum has
+            // visibly slowed down.
+            scrolling.position = target;
         }
         scrolling.snap_pending = true;
         scrolling.is_user_swiping = true;
@@ -360,6 +411,12 @@ fn finish_touchpad_gesture(
     // Momentum can keep moving afterwards, but sticky selection starts only
     // after both the gesture and any remaining target/velocity have settled.
     if touchpad_up && let Some(scrolling) = scrolling {
+        if let Some(target) = scrolling.target_position.take() {
+            // The native momentum stream has ended, so its final target is the
+            // authoritative position. Settling an old interpolation target
+            // after this point creates a non-native extra tail.
+            scrolling.position = target;
+        }
         if let Some(paging) = scrolling.paging_gesture.as_mut() {
             paging.release_velocity = scrolling.velocity * direction_modifier;
         }
@@ -507,7 +564,7 @@ fn sticky_edge_snap_target(
     columns: impl IntoIterator<Item = (i32, i32)>,
 ) -> Option<i32> {
     let current_offset = i64::from(current_offset);
-    let threshold = i64::from(STICKY_EDGE_THRESHOLD_POINTS);
+    let threshold = (f64::from(viewport.width()) * STICKY_EDGE_THRESHOLD_RATIO) as i64;
 
     columns
         .into_iter()

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -1,9 +1,10 @@
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::{With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
-use bevy::ecs::system::{Commands, Local, Populated, Res, Single};
+use bevy::ecs::system::{Commands, Local, Populated, Query, Res, Single};
 use bevy::math::IRect;
 use bevy::time::Time;
 use std::time::{Duration, Instant};
@@ -15,12 +16,12 @@ use crate::config::swipe::SwipeGestureDirection;
 use crate::ecs::layout::{Column, LayoutStrip};
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, MissionControlActive, PagingGesture, Position, Scrolling,
+    ActiveWorkspaceMarker, DockPosition, MissionControlActive, PagingGesture, Position, Scrolling,
     SendMessageTrigger,
 };
 use crate::errors::Result;
 use crate::events::Event;
-use crate::manager::{Window, WindowManager, origin_from};
+use crate::manager::{Display, Window, WindowManager, origin_from};
 use crate::platform::Modifiers;
 
 mod paging;
@@ -58,6 +59,7 @@ impl Plugin for ScrollEventsPlugin {
         app.add_systems(
             Update,
             (
+                cleanup_detached_scrolling,
                 vertical_swipe_gesture.run_if(mission_control_inactive),
                 (
                     swipe_gesture.run_if(mission_control_inactive),
@@ -67,9 +69,22 @@ impl Plugin for ScrollEventsPlugin {
                     apply_scrolling_constraints,
                     swiping_timeout,
                 )
-                    .chain(),
+                    .chain()
+                    .after(crate::ecs::workspace::show_active_workspace),
             ),
         );
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn cleanup_detached_scrolling(
+    detached: Query<Entity, (With<Scrolling>, Without<ChildOf>)>,
+    mut commands: Commands,
+) {
+    for entity in detached {
+        if let Ok(mut entity_commands) = commands.get_entity(entity) {
+            entity_commands.try_remove::<Scrolling>();
+        }
     }
 }
 
@@ -428,35 +443,63 @@ fn finish_touchpad_gesture(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 pub(super) fn swiping_timeout(
-    strips: Populated<(Entity, &mut Scrolling), With<LayoutStrip>>,
-    active_display: ActiveDisplay,
+    strips: Populated<(Entity, &mut Scrolling, &ChildOf), With<LayoutStrip>>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     time: Res<Time>,
+    config: Res<Config>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     const FINGER_LIFT_THRESHOLD: Duration = Duration::from_millis(50);
-    const MIN_VELOCITY_PX: f64 = 5.0;
     let dt = time.delta_secs_f64();
-    let viewport_width = f64::from(active_display.bounds().width());
 
-    for (entity, mut scroll) in strips {
-        if !scroll.gesture_active && scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD {
-            scroll.is_user_swiping = false;
-
-            if scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
-                && scroll.target_position.is_none()
-                && !scroll.snap_pending
-                && let Ok(mut entity_commands) = commands.get_entity(entity)
-            {
-                entity_commands.try_remove::<Scrolling>();
-            }
-            if let Some(point) = window_manager.cursor_position() {
-                commands.trigger(SendMessageTrigger(Event::MouseMoved {
-                    point,
-                    modifiers: Modifiers::empty(),
-                }));
-            }
+    for (entity, mut scroll, parent) in strips {
+        let Ok((display, dock)) = displays.get(parent.parent()) else {
+            continue;
+        };
+        let viewport_width = f64::from(display.actual_display_bounds(dock, &config).width());
+        let timed_out =
+            !scroll.gesture_active && scroll.last_event.elapsed() > FINGER_LIFT_THRESHOLD;
+        let outcome = update_swipe_timeout(&mut scroll, timed_out, dt, viewport_width);
+        if outcome.remove
+            && let Ok(mut entity_commands) = commands.get_entity(entity)
+        {
+            entity_commands.try_remove::<Scrolling>();
         }
+        if outcome.emit_mouse_moved
+            && let Some(point) = window_manager.cursor_position()
+        {
+            commands.trigger(SendMessageTrigger(Event::MouseMoved {
+                point,
+                modifiers: Modifiers::empty(),
+            }));
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SwipeTimeoutOutcome {
+    emit_mouse_moved: bool,
+    remove: bool,
+}
+
+fn update_swipe_timeout(
+    scroll: &mut Scrolling,
+    timed_out: bool,
+    dt: f64,
+    viewport_width: f64,
+) -> SwipeTimeoutOutcome {
+    const MIN_VELOCITY_PX: f64 = 5.0;
+    let emit_mouse_moved = timed_out && scroll.is_user_swiping;
+    if emit_mouse_moved {
+        scroll.is_user_swiping = false;
+    }
+    SwipeTimeoutOutcome {
+        emit_mouse_moved,
+        remove: timed_out
+            && scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
+            && scroll.target_position.is_none()
+            && !scroll.snap_pending,
     }
 }
 
@@ -485,76 +528,80 @@ fn apply_inertia(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn apply_snap_force(
-    mut strip: Single<(&LayoutStrip, &Position, &mut Scrolling)>,
-    active_display: ActiveDisplay,
+    mut strips: Populated<(&LayoutStrip, &Position, &mut Scrolling, &ChildOf)>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     windows: Windows,
     config: Res<Config>,
 ) {
     const SNAP_DISPLAY_RATIO: f64 = 0.45;
 
-    let (layout_strip, position, ref mut scroll) = *strip;
     let paging = config.swipe_paging();
     let sticky = config.sticky_scroll();
-    if !paging && !sticky && !config.auto_center() {
+    for (layout_strip, position, mut scroll, parent) in &mut strips {
+        if !paging && !sticky && !config.auto_center() {
+            scroll.snap_pending = false;
+            continue;
+        }
+        let Ok((display, dock)) = displays.get(parent.parent()) else {
+            scroll.snap_pending = false;
+            continue;
+        };
+        let viewport = display.actual_display_bounds(dock, &config);
+        let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
+
+        if !scrolling_ready_to_snap(&scroll) {
+            continue;
+        }
+
+        let get_window_frame = |entity| windows.moving_frame(entity);
+        let target_offset = if paging {
+            let Some(paging_gesture) = scroll.paging_gesture else {
+                scroll.snap_pending = false;
+                continue;
+            };
+            paging_snap_target(scroll.position, f64::from(viewport.width()), paging_gesture) as i32
+        } else if sticky {
+            let Some(target_offset) = sticky_edge_snap_target(
+                position.x,
+                &viewport,
+                layout_strip.columns().filter_map(|column| {
+                    let entity = column.top()?;
+                    let column_position = windows.layout_position(entity)?.0.x;
+                    let column_width = column.width(&get_window_frame)?;
+                    Some((column_position, column_width))
+                }),
+            ) else {
+                scroll.snap_pending = false;
+                continue;
+            };
+            target_offset
+        } else {
+            let viewport_center = viewport.center().x;
+            layout_strip
+                .all_columns()
+                .into_iter()
+                .filter_map(|entity| {
+                    windows
+                        .layout_position(entity)
+                        .map(|p| p.0.x)
+                        .zip(Some(entity))
+                })
+                .map(|(column_position, entity)| {
+                    let column_width = windows.moving_frame(entity).map_or(0, |f| f.width());
+                    viewport_center - (column_position + column_width / 2)
+                })
+                .min_by_key(|target| (position.x - target).abs())
+                .unwrap_or(position.x)
+        };
+
+        let dist_to_snap = f64::from(position.x - target_offset);
         scroll.snap_pending = false;
-        return;
-    }
-
-    let viewport = active_display.actual_bounds(&config);
-    let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
-
-    if !scrolling_ready_to_snap(scroll) {
-        return;
-    }
-
-    let get_window_frame = |entity| windows.moving_frame(entity);
-    let target_offset = if paging {
-        let Some(paging_gesture) = scroll.paging_gesture else {
-            scroll.snap_pending = false;
-            return;
-        };
-        paging_snap_target(scroll.position, f64::from(viewport.width()), paging_gesture) as i32
-    } else if sticky {
-        let Some(target_offset) = sticky_edge_snap_target(
-            position.x,
-            &viewport,
-            layout_strip.columns().filter_map(|column| {
-                let entity = column.top()?;
-                let column_position = windows.layout_position(entity)?.0.x;
-                let column_width = column.width(&get_window_frame)?;
-                Some((column_position, column_width))
-            }),
-        ) else {
-            scroll.snap_pending = false;
-            return;
-        };
-        target_offset
-    } else {
-        let viewport_center = viewport.center().x;
-        layout_strip
-            .all_columns()
-            .into_iter()
-            .filter_map(|entity| {
-                windows
-                    .layout_position(entity)
-                    .map(|p| p.0.x)
-                    .zip(Some(entity))
-            })
-            .map(|(column_position, entity)| {
-                let column_width = windows.moving_frame(entity).map_or(0, |f| f.width());
-                viewport_center - (column_position + column_width / 2)
-            })
-            .min_by_key(|target| (position.x - target).abs())
-            .unwrap_or(position.x)
-    };
-
-    let dist_to_snap = f64::from(position.x - target_offset);
-    scroll.snap_pending = false;
-    if paging || sticky || dist_to_snap.abs() < snap_threshold {
-        // Keep Scrolling alive until the shared target integrator reaches the
-        // anchor. This works for native modifier-scroll and raw gestures.
-        scroll.velocity = 0.0;
-        scroll.target_position = Some(f64::from(target_offset));
+        if paging || sticky || dist_to_snap.abs() < snap_threshold {
+            // Keep Scrolling alive until the shared target integrator reaches
+            // the anchor for native modifier-scroll and raw gestures alike.
+            scroll.velocity = 0.0;
+            scroll.target_position = Some(f64::from(target_offset));
+        }
     }
 }
 
@@ -593,19 +640,32 @@ fn sticky_edge_snap_target(
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn scrolling_integrator(
-    mut strip: Single<&mut Scrolling, With<LayoutStrip>>,
+    mut strips: Populated<(&mut Scrolling, &ChildOf), With<LayoutStrip>>,
     time: Res<Time>,
-    active_display: ActiveDisplay,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     config: Res<Config>,
 ) {
     let dt = time.delta_secs_f64();
-    let viewport = active_display.actual_bounds(&config);
-    let viewport_width = f64::from(viewport.width());
 
     // Direction modifier: Natural moves strip left (negative offset) for positive delta (finger left)
     let direction_modifier = horizontal_direction_modifier(&config);
 
-    let scroll = &mut *strip;
+    for (mut scroll, parent) in &mut strips {
+        let viewport_width = displays
+            .get(parent.parent())
+            .map_or(0.0, |(display, dock)| {
+                f64::from(display.actual_display_bounds(dock, &config).width())
+            });
+        integrate_scrolling(&mut scroll, dt, viewport_width, direction_modifier);
+    }
+}
+
+fn integrate_scrolling(
+    scroll: &mut Scrolling,
+    dt: f64,
+    viewport_width: f64,
+    direction_modifier: f64,
+) {
     if let Some(target) = scroll.target_position {
         let (position, settled) = smooth_native_scroll(scroll.position, target, dt);
         scroll.position = position;
@@ -615,10 +675,7 @@ fn scrolling_integrator(
                 scroll.paging_gesture = None;
             }
         }
-        return;
-    }
-
-    if scroll.velocity.abs() > 0.0001 {
+    } else if scroll.velocity.abs() > 0.0001 {
         scroll.position += scroll.velocity * dt * viewport_width * direction_modifier;
         constrain_paging_motion(scroll, direction_modifier);
     }
@@ -652,50 +709,50 @@ fn reconcile_integrated_position(
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::TRACE, skip_all)]
 fn apply_scrolling_constraints(
-    mut strip: Single<
-        (&LayoutStrip, &mut Position, &mut Scrolling),
-        (With<ActiveWorkspaceMarker>, Without<Window>),
-    >,
-    active_display: ActiveDisplay,
+    mut strips: Populated<(&LayoutStrip, &mut Position, &mut Scrolling, &ChildOf), Without<Window>>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
     windows: Windows,
     config: Res<Config>,
 ) {
-    let viewport = active_display.actual_bounds(&config);
-    let (strip, ref mut position, ref mut scroll) = *strip;
-
-    let get_window_frame = |entity| windows.moving_frame(entity);
-    let effective_offset = scroll.position as i32;
-    if let Some(clamped_offset) = clamp_viewport_offset(
-        effective_offset,
-        strip,
-        &windows,
-        &get_window_frame,
-        &viewport,
-        &config,
-    ) {
-        position.x = clamped_offset;
-        scroll.position =
-            reconcile_integrated_position(scroll.position, effective_offset, clamped_offset);
-        if let Some(target) = scroll.target_position
-            && let effective_target = target as i32
-            && let Some(clamped_target) = clamp_viewport_offset(
-                effective_target,
-                strip,
-                &windows,
-                &get_window_frame,
-                &viewport,
-                &config,
-            )
-        {
-            scroll.target_position = Some(reconcile_integrated_position(
-                target,
-                effective_target,
-                clamped_target,
-            ));
+    for (strip, mut position, mut scroll, parent) in &mut strips {
+        let Ok((display, dock)) = displays.get(parent.parent()) else {
+            continue;
+        };
+        let viewport = display.actual_display_bounds(dock, &config);
+        let get_window_frame = |entity| windows.moving_frame(entity);
+        let effective_offset = scroll.position as i32;
+        if let Some(clamped_offset) = clamp_viewport_offset(
+            effective_offset,
+            strip,
+            &windows,
+            &get_window_frame,
+            &viewport,
+            &config,
+        ) {
+            position.x = clamped_offset;
+            scroll.position =
+                reconcile_integrated_position(scroll.position, effective_offset, clamped_offset);
+            if let Some(target) = scroll.target_position
+                && let effective_target = target as i32
+                && let Some(clamped_target) = clamp_viewport_offset(
+                    effective_target,
+                    strip,
+                    &windows,
+                    &get_window_frame,
+                    &viewport,
+                    &config,
+                )
+            {
+                scroll.target_position = Some(reconcile_integrated_position(
+                    target,
+                    effective_target,
+                    clamped_target,
+                ));
+            }
+        } else {
+            scroll.velocity = 0.0;
+            scroll.target_position = None;
         }
-    } else {
-        scroll.velocity = 0.0;
-        scroll.target_position = None;
     }
 }
 
@@ -845,3 +902,85 @@ fn switch_virtual_workspace(delta: f64, config: &Config, commands: &mut Commands
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod performance_tests {
+    use std::time::Instant;
+
+    use bevy::prelude::{App, ChildOf, Update};
+
+    use super::{
+        Scrolling, cleanup_detached_scrolling, integrate_scrolling, reconcile_integrated_position,
+        update_swipe_timeout,
+    };
+
+    #[test]
+    fn detached_strip_cancels_scrolling_on_next_ecs_update() {
+        let mut app = App::new();
+        app.add_systems(Update, cleanup_detached_scrolling);
+        let parent = app.world_mut().spawn_empty().id();
+        let strip = app
+            .world_mut()
+            .spawn((Scrolling::default(), ChildOf(parent)))
+            .id();
+        app.world_mut().entity_mut(strip).remove::<ChildOf>();
+
+        app.update();
+
+        assert!(!app.world().entity(strip).contains::<Scrolling>());
+    }
+
+    #[test]
+    fn two_scrolling_strips_integrate_independently() {
+        let now = Instant::now();
+        let mut first = Scrolling {
+            velocity: 1.0,
+            position: 10.0,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        let mut second = Scrolling {
+            velocity: -2.0,
+            position: -30.0,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        integrate_scrolling(&mut first, 0.1, 1000.0, 1.0);
+        integrate_scrolling(&mut second, 0.1, 500.0, 1.0);
+        assert!((first.position - 110.0).abs() < f64::EPSILON);
+        assert!((second.position + 130.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn timeout_uses_each_parent_display_width_and_emits_lift_once() {
+        let now = Instant::now();
+        let mut narrow = Scrolling {
+            velocity: 1.0,
+            is_user_swiping: true,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        let mut wide = Scrolling {
+            velocity: 1.0,
+            is_user_swiping: true,
+            last_event: now,
+            ..Scrolling::default()
+        };
+        let narrow_result = update_swipe_timeout(&mut narrow, true, 0.016, 100.0);
+        let wide_result = update_swipe_timeout(&mut wide, true, 0.016, 1000.0);
+        assert!(narrow_result.remove);
+        assert!(!wide_result.remove);
+        assert!(narrow_result.emit_mouse_moved);
+        assert!(wide_result.emit_mouse_moved);
+        assert!(
+            !update_swipe_timeout(&mut narrow, true, 0.016, 100.0).emit_mouse_moved,
+            "synthetic mouse move is emitted only on the swiping transition"
+        );
+    }
+
+    #[test]
+    fn clamp_reconciliation_preserves_remainder_only_inside_boundary() {
+        assert!((reconcile_integrated_position(-0.75, 0, 0) + 0.75).abs() < f64::EPSILON);
+        assert!((reconcile_integrated_position(2.25, 2, 1) - 1.0).abs() < f64::EPSILON);
+    }
+}

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -24,6 +24,9 @@ use crate::platform::Modifiers;
 
 pub struct ScrollEventsPlugin;
 
+const NATIVE_SCROLL_RESPONSE_SECONDS: f64 = 0.04;
+const NATIVE_SCROLL_SETTLE_PX: f64 = 0.25;
+
 impl Plugin for ScrollEventsPlugin {
     fn build(&self, app: &mut App) {
         let mission_control_inactive = |mission_control: Option<Res<MissionControlActive>>| {
@@ -62,7 +65,8 @@ fn swipe_gesture(
     mut commands: Commands,
 ) {
     let swipe_sensitivity = config.swipe_sensitivity();
-    let mut total_delta = 0.0;
+    let snap_enabled = config.sticky_scroll() || config.auto_center();
+    let mut scroll_delta = 0.0;
     let mut gesture_delta = 0.0;
     let mut touchpad_down = false;
     let mut has_scroll_event = false;
@@ -81,10 +85,9 @@ fn swipe_gesture(
         match event {
             Event::TouchpadDown => {
                 touchpad_down = true;
-                total_delta = 0.0;
             }
             Event::Scroll { delta } => {
-                total_delta += *delta * scroll_scale;
+                scroll_delta += *delta * scroll_scale;
                 has_scroll_event = true;
             }
             Event::Swipe { delta, fingers }
@@ -92,8 +95,7 @@ fn swipe_gesture(
                     .swipe_gesture_fingers()
                     .is_some_and(|fingers_configured| fingers_configured == *fingers) =>
             {
-                total_delta += delta;
-                gesture_delta += delta;
+                gesture_delta += *delta;
                 has_scroll_event = true;
                 has_gesture_event = true;
             }
@@ -109,6 +111,8 @@ fn swipe_gesture(
 
     if touchpad_down && let Some(scrolling) = scrolling.as_mut() {
         scrolling.velocity = 0.0;
+        scrolling.target_position = None;
+        scrolling.snap_pending = snap_enabled;
         scrolling.is_user_swiping = true;
         scrolling.last_event = Instant::now();
     }
@@ -126,8 +130,13 @@ fn swipe_gesture(
         } else {
             0.0
         };
+        let gesture_distance =
+            gesture_delta * viewport_width * direction_modifier * swipe_sensitivity;
+        let scroll_distance =
+            scroll_delta * viewport_width * direction_modifier * swipe_sensitivity;
 
         if let Some(scrolling) = scrolling.as_mut() {
+            let was_user_swiping = scrolling.is_user_swiping;
             // Native modifier-scroll events already include macOS momentum.
             // Add synthetic inertia only for raw multi-finger gestures.
             scrolling.velocity = if has_gesture_event {
@@ -137,15 +146,32 @@ fn swipe_gesture(
                 0.0
             };
             scrolling.is_user_swiping = true;
+            scrolling.snap_pending = snap_enabled;
             scrolling.last_event = Instant::now();
-            scrolling.position +=
-                total_delta * viewport_width * direction_modifier * swipe_sensitivity;
+
+            if has_gesture_event {
+                scrolling.target_position = None;
+                scrolling.position += gesture_distance;
+            }
+
+            if scroll_delta != 0.0 {
+                // A new physical gesture interrupts an in-flight sticky snap.
+                // Native momentum events keep extending the same target.
+                if !was_user_swiping {
+                    scrolling.target_position = None;
+                }
+                let target = scrolling.target_position.unwrap_or(scrolling.position);
+                scrolling.target_position = Some(target + scroll_distance);
+            }
         } else if let Ok(mut entity_commands) = commands.get_entity(*entity) {
+            let initial_position = f64::from(position.0.x) + gesture_distance;
             entity_commands.try_insert(Scrolling {
                 velocity: new_velocity,
-                position: f64::from(position.0.x)
-                    + total_delta * viewport_width * direction_modifier * swipe_sensitivity,
-                is_user_swiping: true,
+                position: initial_position,
+                target_position: (scroll_delta != 0.0)
+                    .then_some(initial_position + scroll_distance),
+                snap_pending: snap_enabled,
+                is_user_swiping: touchpad_down || has_scroll_event,
                 last_event: Instant::now(),
             });
         }
@@ -171,6 +197,8 @@ pub(super) fn swiping_timeout(
             scroll.is_user_swiping = false;
 
             if scroll.velocity.abs() * dt * viewport_width < MIN_VELOCITY_PX
+                && scroll.target_position.is_none()
+                && !scroll.snap_pending
                 && let Ok(mut entity_commands) = commands.get_entity(entity)
             {
                 entity_commands.try_remove::<Scrolling>();
@@ -214,12 +242,13 @@ fn apply_snap_force(
     active_display: ActiveDisplay,
     windows: Windows,
     config: Res<Config>,
-    time: Res<Time>,
 ) {
-    const CENTER_MAGNETIC_FORCE: f64 = 10.0;
     const SNAP_DISPLAY_RATIO: f64 = 0.45;
 
-    if !config.auto_center() {
+    let (layout_strip, position, ref mut scroll) = *strip;
+    let sticky = config.sticky_scroll();
+    if !sticky && !config.auto_center() {
+        scroll.snap_pending = false;
         return;
     }
 
@@ -227,12 +256,11 @@ fn apply_snap_force(
     let viewport_center = viewport.center().x;
     let snap_threshold = SNAP_DISPLAY_RATIO * f64::from(viewport.width());
 
-    let (strip, position, ref mut scroll) = *strip;
-    if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 {
+    if scroll.is_user_swiping || scroll.velocity.abs() > 0.5 || scroll.target_position.is_some() {
         return;
     }
 
-    let target_offset = strip
+    let target_offset = layout_strip
         .all_columns()
         .into_iter()
         .filter_map(|entity| {
@@ -249,9 +277,12 @@ fn apply_snap_force(
         .unwrap_or(position.x);
 
     let dist_to_snap = f64::from(position.x - target_offset);
-    if dist_to_snap.abs() < snap_threshold {
-        let dt = time.delta_secs_f64();
-        scroll.position -= dist_to_snap * dt * CENTER_MAGNETIC_FORCE;
+    scroll.snap_pending = false;
+    if sticky || dist_to_snap.abs() < snap_threshold {
+        // Keep Scrolling alive until the shared target integrator reaches the
+        // anchor. This works for native modifier-scroll and raw gestures.
+        scroll.velocity = 0.0;
+        scroll.target_position = Some(f64::from(target_offset));
     }
 }
 
@@ -274,8 +305,28 @@ fn scrolling_integrator(
     };
 
     let scroll = &mut *strip;
+    if let Some(target) = scroll.target_position {
+        let (position, settled) = smooth_native_scroll(scroll.position, target, dt);
+        scroll.position = position;
+        if settled {
+            scroll.target_position = None;
+        }
+        return;
+    }
+
     if scroll.velocity.abs() > 0.0001 {
         scroll.position += scroll.velocity * dt * viewport_width * direction_modifier;
+    }
+}
+
+fn smooth_native_scroll(position: f64, target: f64, dt: f64) -> (f64, bool) {
+    let blend = 1.0 - (-dt / NATIVE_SCROLL_RESPONSE_SECONDS).exp();
+    let position = position + (target - position) * blend;
+
+    if (target - position).abs() <= NATIVE_SCROLL_SETTLE_PX {
+        (target, true)
+    } else {
+        (position, false)
     }
 }
 
@@ -304,8 +355,21 @@ fn apply_scrolling_constraints(
     ) {
         position.x = clamped_offset;
         scroll.position = f64::from(clamped_offset);
+        if let Some(target) = scroll.target_position
+            && let Some(clamped_target) = clamp_viewport_offset(
+                target as i32,
+                strip,
+                &windows,
+                &get_window_frame,
+                &viewport,
+                &config,
+            )
+        {
+            scroll.target_position = Some(f64::from(clamped_target));
+        }
     } else {
         scroll.velocity = 0.0;
+        scroll.target_position = None;
     }
 }
 
@@ -333,6 +397,11 @@ where
         .map(|(position, frame)| position.x + frame.width())?;
 
     let continuous_swipe = config.continuous_swipe();
+    let has_oversized_column = layout_strip.columns().any(|column| {
+        column
+            .width(get_window_frame)
+            .is_some_and(|width| width > viewport.width())
+    });
     let strip_position = |column: Result<Column>| {
         column
             .ok()
@@ -345,7 +414,10 @@ where
     let right_snap = strip_position(layout_strip.get(1));
 
     Some(
-        if continuous_swipe && let Some((left_snap, right_snap)) = left_snap.zip(right_snap) {
+        if continuous_swipe
+            && !has_oversized_column
+            && let Some((left_snap, right_snap)) = left_snap.zip(right_snap)
+        {
             // Allow to scroll away until the last or first window snaps.
             current_offset.clamp(viewport.min.x - left_snap, viewport.max.x - right_snap)
         } else if viewport.width() < total_strip_width {
@@ -431,4 +503,29 @@ fn switch_virtual_workspace(delta: f64, config: &Config, commands: &mut Commands
     commands.trigger(SendMessageTrigger(Event::Command {
         command: Command::Window(Operation::Virtual(direction)),
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::smooth_native_scroll;
+
+    #[test]
+    fn native_scroll_smoothing_converges_without_overshoot() {
+        let mut position = 0.0;
+        let mut settled = false;
+
+        for _ in 0..120 {
+            let previous = position;
+            (position, settled) = smooth_native_scroll(position, 100.0, 1.0 / 60.0);
+            assert!(position >= previous);
+            assert!(position <= 100.0);
+
+            if settled {
+                break;
+            }
+        }
+
+        assert!((position - 100.0).abs() < f64::EPSILON);
+        assert!(settled);
+    }
 }

--- a/src/ecs/scroll/paging.rs
+++ b/src/ecs/scroll/paging.rs
@@ -1,0 +1,295 @@
+//! Pure one-hop paging math for horizontal strip gestures.
+
+use bevy::math::IRect;
+
+use crate::ecs::{PagingGesture, Scrolling};
+
+use super::STICKY_EDGE_THRESHOLD_POINTS;
+
+pub(super) const FLING_VELOCITY_THRESHOLD: f64 = 0.5;
+const ADVANCE_RATIO: f64 = 0.25;
+
+pub(super) fn capture_gesture(
+    current_position: f64,
+    viewport: &IRect,
+    columns: impl IntoIterator<Item = (i32, i32)>,
+) -> Option<PagingGesture> {
+    let stops = snap_stops(viewport, columns);
+    let start_index = stops
+        .iter()
+        .enumerate()
+        .min_by(|(_, left), (_, right)| {
+            (current_position - **left)
+                .abs()
+                .total_cmp(&(current_position - **right).abs())
+        })?
+        .0;
+
+    Some(PagingGesture {
+        start_stop: stops[start_index],
+        previous_stop: start_index.checked_sub(1).map(|index| stops[index]),
+        next_stop: stops.get(start_index + 1).copied(),
+        release_velocity: 0.0,
+    })
+}
+
+pub(super) fn constrain_motion(scrolling: &mut Scrolling, direction_modifier: f64) {
+    let Some(paging) = scrolling.paging_gesture else {
+        return;
+    };
+    let lower = paging.next_stop.unwrap_or(paging.start_stop);
+    let upper = paging.previous_stop.unwrap_or(paging.start_stop);
+    let previous_position = scrolling.position;
+    scrolling.position = scrolling.position.clamp(lower, upper);
+    if let Some(target) = scrolling.target_position.as_mut() {
+        *target = target.clamp(lower, upper);
+    }
+
+    let coordinate_velocity = scrolling.velocity * direction_modifier;
+    if (previous_position < lower && coordinate_velocity < 0.0)
+        || (previous_position > upper && coordinate_velocity > 0.0)
+    {
+        scrolling.velocity = 0.0;
+    }
+}
+
+/// Return reading-order paging stops. Numeric offsets decrease as the strip
+/// advances to the right, so the result is sorted from greatest to smallest.
+fn snap_stops(viewport: &IRect, columns: impl IntoIterator<Item = (i32, i32)>) -> Vec<f64> {
+    let columns = columns
+        .into_iter()
+        .filter(|(_, width)| *width > 0)
+        .collect::<Vec<_>>();
+    let Some(content_min) = columns.iter().map(|(position, _)| *position).min() else {
+        return Vec::new();
+    };
+    let content_max = columns
+        .iter()
+        .map(|(position, width)| position.saturating_add(*width))
+        .max()
+        .unwrap_or(content_min);
+    let first_bound = viewport.min.x - content_min;
+    let last_bound = viewport.max.x - content_max;
+    let lower_bound = f64::from(first_bound.min(last_bound));
+    let upper_bound = f64::from(first_bound.max(last_bound));
+
+    let mut stops = columns
+        .into_iter()
+        .flat_map(|(position, width)| {
+            let left_aligned = f64::from(viewport.min.x - position).clamp(lower_bound, upper_bound);
+            let right_aligned =
+                f64::from(viewport.max.x - position - width).clamp(lower_bound, upper_bound);
+            if width > viewport.width() {
+                [Some(left_aligned), Some(right_aligned)]
+            } else {
+                [Some(left_aligned), None]
+            }
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+    stops.sort_by(|left, right| right.total_cmp(left));
+    stops.dedup();
+    stops
+}
+
+pub(super) fn snap_target(
+    current_position: f64,
+    viewport_width: f64,
+    paging: PagingGesture,
+) -> f64 {
+    let edge_target = [
+        Some(paging.start_stop),
+        paging.previous_stop,
+        paging.next_stop,
+    ]
+    .into_iter()
+    .flatten()
+    .filter(|stop| (current_position - *stop).abs() <= f64::from(STICKY_EDGE_THRESHOLD_POINTS))
+    .min_by(|left, right| {
+        (current_position - *left)
+            .abs()
+            .total_cmp(&(current_position - *right).abs())
+    });
+    if let Some(target) = edge_target {
+        return target;
+    }
+
+    let displacement = current_position - paging.start_stop;
+    let displacement_neighbor = if displacement > 0.0 {
+        paging.previous_stop
+    } else if displacement < 0.0 {
+        paging.next_stop
+    } else {
+        None
+    };
+    if let Some(neighbor) = displacement_neighbor {
+        let threshold = ((paging.start_stop - neighbor).abs() * ADVANCE_RATIO)
+            .min(viewport_width * ADVANCE_RATIO);
+        if displacement.abs() >= threshold {
+            return neighbor;
+        }
+    }
+
+    let fling_neighbor = if paging.release_velocity > 0.0 {
+        paging.previous_stop
+    } else if paging.release_velocity < 0.0 {
+        paging.next_stop
+    } else {
+        None
+    };
+    if paging.release_velocity.abs() >= FLING_VELOCITY_THRESHOLD
+        && let Some(neighbor) = fling_neighbor
+    {
+        return neighbor;
+    }
+
+    paging.start_stop
+}
+
+pub(super) fn ready_to_snap(scrolling: &Scrolling) -> bool {
+    !scrolling.gesture_active
+        && !scrolling.is_user_swiping
+        && scrolling.velocity.abs() <= FLING_VELOCITY_THRESHOLD
+        && scrolling.target_position.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::math::IRect;
+
+    use super::{capture_gesture, constrain_motion, ready_to_snap, snap_stops, snap_target};
+    use crate::ecs::{PagingGesture, Scrolling};
+
+    #[test]
+    fn normal_has_one_stop_and_oversized_has_two() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        assert_eq!(
+            snap_stops(&viewport, [(0, 600), (600, 1500), (2100, 600)]),
+            vec![0.0, -600.0, -1100.0, -1700.0]
+        );
+    }
+
+    #[test]
+    fn arbitrarily_wide_column_still_has_exactly_two_stops() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let stops = snap_stops(&viewport, [(0, 600), (600, 3500), (4100, 600)]);
+        assert_eq!(stops, vec![0.0, -600.0, -3100.0, -3700.0]);
+        assert_eq!(
+            stops
+                .iter()
+                .filter(|stop| **stop <= -600.0 && **stop >= -3100.0)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn neighborhood_is_ordered_and_reverse_symmetric() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let columns = [(0, 600), (600, 1500), (2100, 600)];
+        let left = capture_gesture(-600.0, &viewport, columns).unwrap();
+        assert_eq!(
+            (left.previous_stop, left.next_stop),
+            (Some(0.0), Some(-1100.0))
+        );
+        let right = capture_gesture(-1100.0, &viewport, columns).unwrap();
+        assert_eq!(
+            (right.previous_stop, right.next_stop),
+            (Some(-600.0), Some(-1700.0))
+        );
+    }
+
+    #[test]
+    fn motion_is_capped_at_adjacent_stops() {
+        let mut scrolling = Scrolling {
+            position: -5000.0,
+            target_position: Some(-4000.0),
+            velocity: -2.0,
+            paging_gesture: Some(gesture()),
+            ..Default::default()
+        };
+        constrain_motion(&mut scrolling, 1.0);
+        assert_eq!(
+            (
+                scrolling.position,
+                scrolling.target_position,
+                scrolling.velocity
+            ),
+            (-1100.0, Some(-1100.0), 0.0)
+        );
+
+        scrolling.position = 5000.0;
+        scrolling.target_position = Some(4000.0);
+        scrolling.velocity = 2.0;
+        constrain_motion(&mut scrolling, 1.0);
+        assert_eq!(
+            (
+                scrolling.position,
+                scrolling.target_position,
+                scrolling.velocity
+            ),
+            (0.0, Some(0.0), 0.0)
+        );
+    }
+
+    #[test]
+    fn release_returns_or_advances_exactly_one_stop() {
+        let paging = gesture();
+        assert_eq!(snap_target(-700.0, 1000.0, paging), -600.0);
+        assert_eq!(snap_target(-730.0, 1000.0, paging), -1100.0);
+        assert_eq!(snap_target(-1080.0, 1000.0, paging), -1100.0);
+        assert_eq!(
+            snap_target(
+                -650.0,
+                1000.0,
+                PagingGesture {
+                    release_velocity: -0.5,
+                    ..paging
+                }
+            ),
+            -1100.0
+        );
+        assert_eq!(
+            snap_target(
+                -970.0,
+                1000.0,
+                PagingGesture {
+                    start_stop: -1100.0,
+                    previous_stop: Some(-600.0),
+                    next_stop: Some(-1700.0),
+                    release_velocity: 0.0
+                }
+            ),
+            -600.0
+        );
+    }
+
+    #[test]
+    fn snap_waits_for_end_and_momentum_settlement() {
+        let mut scrolling = Scrolling {
+            gesture_active: true,
+            is_user_swiping: true,
+            ..Default::default()
+        };
+        assert!(!ready_to_snap(&scrolling));
+        scrolling.gesture_active = false;
+        assert!(!ready_to_snap(&scrolling));
+        scrolling.is_user_swiping = false;
+        scrolling.target_position = Some(-600.0);
+        assert!(!ready_to_snap(&scrolling));
+        scrolling.target_position = None;
+        scrolling.velocity = 0.51;
+        assert!(!ready_to_snap(&scrolling));
+        scrolling.velocity = 0.5;
+        assert!(ready_to_snap(&scrolling));
+    }
+
+    fn gesture() -> PagingGesture {
+        PagingGesture {
+            start_stop: -600.0,
+            previous_stop: Some(0.0),
+            next_stop: Some(-1100.0),
+            release_velocity: 0.0,
+        }
+    }
+}

--- a/src/ecs/scroll/paging.rs
+++ b/src/ecs/scroll/paging.rs
@@ -4,31 +4,90 @@ use bevy::math::IRect;
 
 use crate::ecs::{PagingGesture, Scrolling};
 
-use super::STICKY_EDGE_THRESHOLD_POINTS;
+use super::STICKY_EDGE_THRESHOLD_RATIO;
 
 pub(super) const FLING_VELOCITY_THRESHOLD: f64 = 0.5;
 const ADVANCE_RATIO: f64 = 0.25;
+// Window positions are integrated as floats but ultimately applied in integer
+// logical points. Treat sub-point drift as exact stop alignment so an already
+// consumed stop is not reintroduced as a movement boundary.
+const STOP_ALIGNMENT_EPSILON: f64 = 0.5;
 
 pub(super) fn capture_gesture(
     current_position: f64,
     viewport: &IRect,
     columns: impl IntoIterator<Item = (i32, i32)>,
+    preferred_column: Option<(i32, i32)>,
 ) -> Option<PagingGesture> {
-    let stops = snap_stops(viewport, columns);
-    let start_index = stops
-        .iter()
-        .enumerate()
-        .min_by(|(_, left), (_, right)| {
-            (current_position - **left)
+    let columns = columns.into_iter().collect::<Vec<_>>();
+    let (lower_bound, upper_bound) = content_bounds(viewport, &columns)?;
+    let stops = snap_stops(viewport, columns.iter().copied());
+    let preferred_stop = preferred_column
+        .into_iter()
+        .flat_map(|column| column_stops(viewport, column, lower_bound, upper_bound))
+        .min_by(|left, right| {
+            (current_position - *left)
                 .abs()
-                .total_cmp(&(current_position - **right).abs())
-        })?
-        .0;
+                .total_cmp(&(current_position - *right).abs())
+        });
+    let start_index = preferred_stop
+        .and_then(|preferred| {
+            stops
+                .iter()
+                .position(|stop| (*stop - preferred).abs() <= f64::EPSILON)
+        })
+        .or_else(|| {
+            stops
+                .iter()
+                .enumerate()
+                .min_by(|(_, left), (_, right)| {
+                    (current_position - **left)
+                        .abs()
+                        .total_cmp(&(current_position - **right).abs())
+                })
+                .map(|(index, _)| index)
+        })?;
+
+    let start_stop = stops[start_index];
+    let (previous_stop, next_stop) =
+        if (current_position - start_stop).abs() <= STOP_ALIGNMENT_EPSILON {
+            (
+                start_index.checked_sub(1).map(|index| stops[index]),
+                stops.get(start_index + 1).copied(),
+            )
+        } else {
+            // Motion bounds must come from the real gesture origin. If the
+            // strip starts between stops, deriving both neighbors from the
+            // selected snap target marks one edge as already consumed and lets
+            // a gesture skip it. A pointer-selected window remains the first
+            // boundary in its direction even when another global stop lies
+            // between the current offset and that window's anchor.
+            (
+                (start_stop > current_position)
+                    .then_some(start_stop)
+                    .or_else(|| {
+                        stops
+                            .iter()
+                            .copied()
+                            .filter(|stop| *stop > current_position)
+                            .min_by(f64::total_cmp)
+                    }),
+                (start_stop < current_position)
+                    .then_some(start_stop)
+                    .or_else(|| {
+                        stops
+                            .iter()
+                            .copied()
+                            .filter(|stop| *stop < current_position)
+                            .max_by(f64::total_cmp)
+                    }),
+            )
+        };
 
     Some(PagingGesture {
-        start_stop: stops[start_index],
-        previous_stop: start_index.checked_sub(1).map(|index| stops[index]),
-        next_stop: stops.get(start_index + 1).copied(),
+        start_stop,
+        previous_stop,
+        next_stop,
         release_velocity: 0.0,
     })
 }
@@ -60,9 +119,21 @@ fn snap_stops(viewport: &IRect, columns: impl IntoIterator<Item = (i32, i32)>) -
         .into_iter()
         .filter(|(_, width)| *width > 0)
         .collect::<Vec<_>>();
-    let Some(content_min) = columns.iter().map(|(position, _)| *position).min() else {
+    let Some((lower_bound, upper_bound)) = content_bounds(viewport, &columns) else {
         return Vec::new();
     };
+
+    let mut stops = columns
+        .into_iter()
+        .flat_map(|column| column_stops(viewport, column, lower_bound, upper_bound))
+        .collect::<Vec<_>>();
+    stops.sort_by(|left, right| right.total_cmp(left));
+    stops.dedup();
+    stops
+}
+
+fn content_bounds(viewport: &IRect, columns: &[(i32, i32)]) -> Option<(f64, f64)> {
+    let content_min = columns.iter().map(|(position, _)| *position).min()?;
     let content_max = columns
         .iter()
         .map(|(position, width)| position.saturating_add(*width))
@@ -70,26 +141,27 @@ fn snap_stops(viewport: &IRect, columns: impl IntoIterator<Item = (i32, i32)>) -
         .unwrap_or(content_min);
     let first_bound = viewport.min.x - content_min;
     let last_bound = viewport.max.x - content_max;
-    let lower_bound = f64::from(first_bound.min(last_bound));
-    let upper_bound = f64::from(first_bound.max(last_bound));
+    Some((
+        f64::from(first_bound.min(last_bound)),
+        f64::from(first_bound.max(last_bound)),
+    ))
+}
 
-    let mut stops = columns
-        .into_iter()
-        .flat_map(|(position, width)| {
-            let left_aligned = f64::from(viewport.min.x - position).clamp(lower_bound, upper_bound);
-            let right_aligned =
-                f64::from(viewport.max.x - position - width).clamp(lower_bound, upper_bound);
-            if width > viewport.width() {
-                [Some(left_aligned), Some(right_aligned)]
-            } else {
-                [Some(left_aligned), None]
-            }
-        })
-        .flatten()
-        .collect::<Vec<_>>();
-    stops.sort_by(|left, right| right.total_cmp(left));
-    stops.dedup();
-    stops
+fn column_stops(
+    viewport: &IRect,
+    (position, width): (i32, i32),
+    lower_bound: f64,
+    upper_bound: f64,
+) -> impl Iterator<Item = f64> {
+    let left_aligned = f64::from(viewport.min.x - position).clamp(lower_bound, upper_bound);
+    let right_aligned =
+        f64::from(viewport.max.x - position - width).clamp(lower_bound, upper_bound);
+    [
+        Some(left_aligned),
+        (width > viewport.width()).then_some(right_aligned),
+    ]
+    .into_iter()
+    .flatten()
 }
 
 pub(super) fn snap_target(
@@ -104,7 +176,7 @@ pub(super) fn snap_target(
     ]
     .into_iter()
     .flatten()
-    .filter(|stop| (current_position - *stop).abs() <= f64::from(STICKY_EDGE_THRESHOLD_POINTS))
+    .filter(|stop| (current_position - *stop).abs() <= viewport_width * STICKY_EDGE_THRESHOLD_RATIO)
     .min_by(|left, right| {
         (current_position - *left)
             .abs()
@@ -154,6 +226,7 @@ pub(super) fn ready_to_snap(scrolling: &Scrolling) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use bevy::math::IRect;
 
@@ -187,16 +260,65 @@ mod tests {
     fn neighborhood_is_ordered_and_reverse_symmetric() {
         let viewport = IRect::new(0, 0, 1000, 800);
         let columns = [(0, 600), (600, 1500), (2100, 600)];
-        let left = capture_gesture(-600.0, &viewport, columns).unwrap();
+        let left = capture_gesture(-600.0, &viewport, columns, None).unwrap();
         assert_eq!(
             (left.previous_stop, left.next_stop),
             (Some(0.0), Some(-1100.0))
         );
-        let right = capture_gesture(-1100.0, &viewport, columns).unwrap();
+        let right = capture_gesture(-1100.0, &viewport, columns, None).unwrap();
         assert_eq!(
             (right.previous_stop, right.next_stop),
             (Some(-600.0), Some(-1700.0))
         );
+    }
+
+    #[test]
+    fn window_under_pointer_selects_the_paging_neighborhood() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let columns = [(0, 600), (600, 600), (1200, 600)];
+
+        let gesture = capture_gesture(-300.0, &viewport, columns, Some((600, 600))).unwrap();
+
+        assert_eq!(gesture.start_stop, -600.0);
+        assert_eq!(gesture.previous_stop, Some(0.0));
+        assert_eq!(gesture.next_stop, Some(-600.0));
+
+        let last_window = capture_gesture(-300.0, &viewport, columns, Some((1200, 600))).unwrap();
+        assert_eq!(last_window.start_stop, -800.0);
+        assert_eq!(last_window.previous_stop, Some(0.0));
+        assert_eq!(last_window.next_stop, Some(-800.0));
+    }
+
+    #[test]
+    fn unsnapped_origin_cannot_skip_the_first_stop_in_either_direction() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let columns = [(0, 600), (600, 1500), (2100, 600)];
+        let paging = capture_gesture(-700.0, &viewport, columns, None).unwrap();
+        assert_eq!(paging.start_stop, -600.0);
+        assert_eq!(paging.previous_stop, Some(-600.0));
+        assert_eq!(paging.next_stop, Some(-1100.0));
+
+        let mut towards_previous = Scrolling {
+            position: 500.0,
+            target_position: Some(500.0),
+            velocity: 2.0,
+            paging_gesture: Some(paging),
+            ..Default::default()
+        };
+        constrain_motion(&mut towards_previous, 1.0);
+        assert_eq!(towards_previous.position, -600.0);
+        assert_eq!(towards_previous.target_position, Some(-600.0));
+
+        let mut towards_next = Scrolling {
+            position: -5000.0,
+            target_position: Some(-5000.0),
+            velocity: -2.0,
+            paging_gesture: Some(paging),
+            ..Default::default()
+        };
+        constrain_motion(&mut towards_next, 1.0);
+        assert_eq!(towards_next.position, -1100.0);
+        assert_eq!(towards_next.target_position, Some(-1100.0));
     }
 
     #[test]
@@ -240,7 +362,7 @@ mod tests {
         assert_eq!(snap_target(-1080.0, 1000.0, paging), -1100.0);
         assert_eq!(
             snap_target(
-                -650.0,
+                -701.0,
                 1000.0,
                 PagingGesture {
                     release_velocity: -0.5,

--- a/src/ecs/scroll/tests.rs
+++ b/src/ecs/scroll/tests.rs
@@ -5,7 +5,7 @@ use bevy::math::IRect;
 use bevy::prelude::Entity;
 use bevy::time::TimeUpdateStrategy;
 
-use super::{Scrolling, smooth_native_scroll, sticky_edge_snap_target};
+use super::{Scrolling, resume_touchpad_gesture, smooth_native_scroll, sticky_edge_snap_target};
 use crate::commands::Command;
 use crate::ecs::{ActiveWorkspaceMarker, Position};
 use crate::events::Event;
@@ -26,6 +26,27 @@ fn native_scroll_smoothing_converges_without_overshoot() {
     }
     assert!((position - 100.0).abs() < f64::EPSILON);
     assert!(settled);
+}
+
+#[test]
+fn momentum_resume_preserves_target_but_new_touch_interrupts_it() {
+    let mut scrolling = Scrolling {
+        target_position: Some(-320.0),
+        ..Default::default()
+    };
+
+    resume_touchpad_gesture(true, false, Some(&mut scrolling));
+    assert_eq!(
+        scrolling.target_position,
+        Some(-320.0),
+        "momentum must continue extending the in-flight native-scroll target"
+    );
+
+    resume_touchpad_gesture(true, true, Some(&mut scrolling));
+    assert_eq!(
+        scrolling.target_position, None,
+        "a new physical touch must interrupt the previous target"
+    );
 }
 
 #[test]
@@ -173,17 +194,31 @@ fn later_native_momentum_keeps_original_one_hop_paging_session() {
     TestHarness::new()
         .with_windows(1)
         .on_iteration(2, |world, _state| {
+            // Keep the physical-scroll target in flight across the lifecycle
+            // events below. The harness otherwise advances 500ms per event,
+            // enough for the native-scroll integrator to settle completely.
+            world.insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(1)));
             assert_original_oversized_paging_session(world);
         })
         .on_iteration(4, |world, _state| {
-            let (_, _, _, gesture_active, is_user_swiping) = paging_snapshot(world);
+            let (_, _, target_position, gesture_active, is_user_swiping) = paging_snapshot(world);
             assert_original_oversized_paging_session(world);
+            assert_eq!(
+                target_position,
+                Some(0.0),
+                "physical touch end must retain the unfinished native-scroll target"
+            );
             assert!(!gesture_active);
             assert!(is_user_swiping);
         })
         .on_iteration(5, |world, _state| {
-            let (_, _, _, gesture_active, _) = paging_snapshot(world);
+            let (_, _, target_position, gesture_active, _) = paging_snapshot(world);
             assert_original_oversized_paging_session(world);
+            assert_eq!(
+                target_position,
+                Some(0.0),
+                "momentum start must continue the unfinished physical-scroll target"
+            );
             assert!(gesture_active);
         })
         .on_iteration(6, |world, _state| {

--- a/src/ecs/scroll/tests.rs
+++ b/src/ecs/scroll/tests.rs
@@ -1,0 +1,284 @@
+use std::time::{Duration, Instant};
+
+use bevy::ecs::query::With;
+use bevy::math::IRect;
+use bevy::prelude::Entity;
+use bevy::time::TimeUpdateStrategy;
+
+use super::{Scrolling, smooth_native_scroll, sticky_edge_snap_target};
+use crate::commands::Command;
+use crate::ecs::{ActiveWorkspaceMarker, Position};
+use crate::events::Event;
+use crate::tests::TestHarness;
+
+#[test]
+fn native_scroll_smoothing_converges_without_overshoot() {
+    let mut position = 0.0;
+    let mut settled = false;
+    for _ in 0..120 {
+        let previous = position;
+        (position, settled) = smooth_native_scroll(position, 100.0, 1.0 / 60.0);
+        assert!(position >= previous);
+        assert!(position <= 100.0);
+        if settled {
+            break;
+        }
+    }
+    assert!((position - 100.0).abs() < f64::EPSILON);
+    assert!(settled);
+}
+
+#[test]
+fn sticky_scroll_snaps_only_inside_the_edge_hit_zone() {
+    let viewport = IRect::new(0, 0, 1000, 800);
+    let columns = [(0, 600), (600, 600)];
+    assert_eq!(
+        sticky_edge_snap_target(-631, &viewport, columns),
+        Some(-600)
+    );
+    assert_eq!(
+        sticky_edge_snap_target(-169, &viewport, columns),
+        Some(-200)
+    );
+    assert_eq!(sticky_edge_snap_target(-591, &viewport, columns), None);
+    assert_eq!(sticky_edge_snap_target(-167, &viewport, columns), None);
+}
+
+#[test]
+fn sticky_scroll_exposes_both_edges_of_an_oversized_column() {
+    let viewport = IRect::new(0, 0, 1000, 800);
+    let column = [(0, 1500)];
+    assert_eq!(sticky_edge_snap_target(-9, &viewport, column), Some(0));
+    assert_eq!(sticky_edge_snap_target(-491, &viewport, column), Some(-500));
+    assert_eq!(sticky_edge_snap_target(-250, &viewport, column), None);
+}
+
+#[test]
+fn scrolling_component_is_removed_after_integer_effective_dead_zone() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(0, |world, _state| {
+            world.insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
+                16,
+            )));
+            let entity = {
+                let mut query = world.query_filtered::<Entity, With<ActiveWorkspaceMarker>>();
+                query.single(world).expect("one active workspace")
+            };
+            world.entity_mut(entity).insert(Scrolling {
+                position: 0.0,
+                target_position: Some(-1.0),
+                last_event: Instant::now()
+                    .checked_sub(Duration::from_millis(100))
+                    .expect("100ms must fit before now"),
+                ..Default::default()
+            });
+        })
+        .on_iteration(1, |world, _state| {
+            let mut scrolling = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            assert!(scrolling.single(world).is_err());
+            let mut positions = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+            assert_eq!(positions.single(world).expect("one active workspace").x, -1);
+        })
+        .run(commands);
+}
+
+#[test]
+fn explicit_touchpad_contact_is_not_ended_by_inactivity_fallback() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::TouchpadUp,
+    ];
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(0, |world, _state| {
+            let entity = {
+                let mut query = world.query_filtered::<Entity, With<ActiveWorkspaceMarker>>();
+                query.single(world).expect("one active workspace")
+            };
+            world.entity_mut(entity).insert(Scrolling {
+                is_user_swiping: true,
+                gesture_active: true,
+                last_event: Instant::now()
+                    .checked_sub(Duration::from_millis(100))
+                    .expect("100ms must fit before now"),
+                ..Default::default()
+            });
+        })
+        .on_iteration(1, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query
+                .single(world)
+                .expect("active contact keeps scrolling alive");
+            assert!(scrolling.is_user_swiping);
+            assert!(scrolling.gesture_active);
+        })
+        .on_iteration(2, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            assert!(query.single(world).is_err());
+        })
+        .run(commands);
+}
+
+#[test]
+fn explicit_touchpad_begin_creates_lifecycle_state_before_first_delta() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::TouchpadDown,
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::TouchpadUp,
+    ];
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query
+                .single(world)
+                .expect("touch begin must create scrolling lifecycle state");
+            assert!(scrolling.is_user_swiping);
+            assert!(scrolling.gesture_active);
+            assert!(scrolling.paging_gesture.is_some());
+        })
+        .run(commands);
+}
+
+#[test]
+fn later_native_momentum_keeps_original_one_hop_paging_session() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(crate::commands::Operation::SetWidth(2.0)),
+        },
+        Event::TouchpadDown,
+        Event::Scroll { delta: -100.0 },
+        Event::TouchpadPhysicalUp,
+        Event::TouchpadMomentumStart,
+        Event::Scroll { delta: -100.0 },
+        Event::TouchpadUp,
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            assert_original_oversized_paging_session(world);
+        })
+        .on_iteration(4, |world, _state| {
+            let (_, _, _, gesture_active, is_user_swiping) = paging_snapshot(world);
+            assert_original_oversized_paging_session(world);
+            assert!(!gesture_active);
+            assert!(is_user_swiping);
+        })
+        .on_iteration(5, |world, _state| {
+            let (_, _, _, gesture_active, _) = paging_snapshot(world);
+            assert_original_oversized_paging_session(world);
+            assert!(gesture_active);
+        })
+        .on_iteration(6, |world, _state| {
+            let (_, position, target_position, _, _) = paging_snapshot(world);
+            assert_original_oversized_paging_session(world);
+            assert!((-1024.0..=0.0).contains(&position));
+            assert!(target_position.is_none_or(|target| (-1024.0..=0.0).contains(&target)));
+        })
+        .on_iteration(8, |world, _state| {
+            let mut query = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+            let position = query.single(world).expect("active workspace").x;
+            assert!(
+                (-1024..=0).contains(&position),
+                "native momentum must settle within the original one-hop bounds"
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn touchpad_down_during_pending_settlement_does_not_recapture_stop() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(crate::commands::Operation::SetWidth(2.0)),
+        },
+        Event::TouchpadDown,
+        Event::Scroll { delta: -100.0 },
+        Event::TouchpadPhysicalUp,
+        Event::TouchpadDown,
+    ];
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            assert_original_oversized_paging_session(world);
+        })
+        .on_iteration(5, |world, _state| {
+            assert_original_oversized_paging_session(world);
+            let (_, _, _, gesture_active, is_user_swiping) = paging_snapshot(world);
+            assert!(gesture_active);
+            assert!(is_user_swiping);
+        })
+        .run(commands);
+}
+
+#[test]
+fn physical_up_and_momentum_start_in_same_update_leave_momentum_active() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(crate::commands::Operation::SetWidth(2.0)),
+        },
+        Event::TouchpadDown,
+        Event::Scroll { delta: -100.0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(3, |world, _state| {
+            assert_original_oversized_paging_session(world);
+            world.write_message(Event::TouchpadPhysicalUp);
+            world.write_message(Event::TouchpadMomentumStart);
+        })
+        .on_iteration(4, |world, _state| {
+            assert_original_oversized_paging_session(world);
+            let (_, _, _, gesture_active, is_user_swiping) = paging_snapshot(world);
+            assert!(gesture_active, "momentum start must win over physical end");
+            assert!(is_user_swiping);
+        })
+        .run(commands);
+}
+
+fn assert_original_oversized_paging_session(world: &mut bevy::prelude::World) {
+    let (paging, _, _, _, _) = paging_snapshot(world);
+    assert_eq!(paging.start_stop, -1024.0);
+    assert_eq!(paging.previous_stop, Some(0.0));
+    assert_eq!(paging.next_stop, None);
+}
+
+fn paging_snapshot(
+    world: &mut bevy::prelude::World,
+) -> (crate::ecs::PagingGesture, f64, Option<f64>, bool, bool) {
+    let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+    let scrolling = query
+        .single(world)
+        .expect("active workspace should be scrolling");
+    (
+        scrolling
+            .paging_gesture
+            .expect("paging session should remain captured"),
+        scrolling.position,
+        scrolling.target_position,
+        scrolling.gesture_active,
+        scrolling.is_user_swiping,
+    )
+}

--- a/src/ecs/scroll/tests.rs
+++ b/src/ecs/scroll/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::float_cmp)]
+
 use std::time::{Duration, Instant};
 
 use bevy::ecs::query::With;
@@ -5,7 +7,10 @@ use bevy::math::IRect;
 use bevy::prelude::Entity;
 use bevy::time::TimeUpdateStrategy;
 
-use super::{Scrolling, resume_touchpad_gesture, smooth_native_scroll, sticky_edge_snap_target};
+use super::{
+    Scrolling, finish_touchpad_gesture, resume_touchpad_gesture, smooth_native_scroll,
+    sticky_edge_snap_target,
+};
 use crate::commands::Command;
 use crate::ecs::{ActiveWorkspaceMarker, Position};
 use crate::events::Event;
@@ -29,24 +34,41 @@ fn native_scroll_smoothing_converges_without_overshoot() {
 }
 
 #[test]
-fn momentum_resume_preserves_target_but_new_touch_interrupts_it() {
+fn momentum_resume_discards_physical_interpolation_backlog() {
     let mut scrolling = Scrolling {
+        position: -280.0,
         target_position: Some(-320.0),
         ..Default::default()
     };
 
-    resume_touchpad_gesture(true, false, Some(&mut scrolling));
-    assert_eq!(
-        scrolling.target_position,
-        Some(-320.0),
-        "momentum must continue extending the in-flight native-scroll target"
-    );
+    resume_touchpad_gesture(true, false, true, Some(&mut scrolling));
+    assert_eq!(scrolling.position, -320.0);
+    assert_eq!(scrolling.target_position, None);
 
-    resume_touchpad_gesture(true, true, Some(&mut scrolling));
+    scrolling.target_position = Some(-360.0);
+    resume_touchpad_gesture(true, true, false, Some(&mut scrolling));
     assert_eq!(
         scrolling.target_position, None,
         "a new physical touch must interrupt the previous target"
     );
+}
+
+#[test]
+fn native_momentum_end_commits_the_final_target_without_extra_tail() {
+    let mut scrolling = Scrolling {
+        position: -280.0,
+        target_position: Some(-320.0),
+        gesture_active: true,
+        is_user_swiping: true,
+        ..Default::default()
+    };
+
+    finish_touchpad_gesture(true, 1.0, Some(&mut scrolling));
+
+    assert_eq!(scrolling.position, -320.0);
+    assert_eq!(scrolling.target_position, None);
+    assert!(!scrolling.gesture_active);
+    assert!(!scrolling.is_user_swiping);
 }
 
 #[test]
@@ -61,8 +83,7 @@ fn sticky_scroll_snaps_only_inside_the_edge_hit_zone() {
         sticky_edge_snap_target(-169, &viewport, columns),
         Some(-200)
     );
-    assert_eq!(sticky_edge_snap_target(-591, &viewport, columns), None);
-    assert_eq!(sticky_edge_snap_target(-167, &viewport, columns), None);
+    assert_eq!(sticky_edge_snap_target(-301, &viewport, columns), None);
 }
 
 #[test]
@@ -212,13 +233,10 @@ fn later_native_momentum_keeps_original_one_hop_paging_session() {
             assert!(is_user_swiping);
         })
         .on_iteration(5, |world, _state| {
-            let (_, _, target_position, gesture_active, _) = paging_snapshot(world);
+            let (_, position, target_position, gesture_active, _) = paging_snapshot(world);
             assert_original_oversized_paging_session(world);
-            assert_eq!(
-                target_position,
-                Some(0.0),
-                "momentum start must continue the unfinished physical-scroll target"
-            );
+            assert_eq!(position, 0.0);
+            assert_eq!(target_position, None);
             assert!(gesture_active);
         })
         .on_iteration(6, |world, _state| {
@@ -294,10 +312,14 @@ fn physical_up_and_momentum_start_in_same_update_leave_momentum_active() {
 }
 
 fn assert_original_oversized_paging_session(world: &mut bevy::prelude::World) {
-    let (paging, _, _, _, _) = paging_snapshot(world);
+    let (paging, position, target_position, _, _) = paging_snapshot(world);
     assert_eq!(paging.start_stop, -1024.0);
     assert_eq!(paging.previous_stop, Some(0.0));
-    assert_eq!(paging.next_stop, None);
+    assert_eq!(
+        paging.next_stop,
+        Some(-1024.0),
+        "position={position}, target_position={target_position:?}"
+    );
 }
 
 fn paging_snapshot(

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -27,9 +27,9 @@ use crate::config::{Config, decorations::BorderRadiusOption};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, Initializing, LowPowerMode,
-    MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState, Scrolling,
-    SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
+    ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, FocusedMarker, Initializing,
+    LowPowerMode, MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState,
+    Scrolling, SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
 };
 use crate::events::Event;
 use crate::manager::{
@@ -174,6 +174,7 @@ pub(crate) fn add_existing_application(
 pub(crate) fn finish_setup(
     process_query: Query<Entity, With<ExistingMarker>>,
     windows: Windows,
+    applications: Query<&Application>,
     mut bruteforce_tasks: Query<(Entity, &mut BruteforceWindows)>,
     mut workspaces: Query<(&mut LayoutStrip, Has<ActiveWorkspaceMarker>, &ChildOf)>,
     window_manager: Res<WindowManager>,
@@ -203,6 +204,7 @@ pub(crate) fn finish_setup(
         windows.iter().size_hint()
     );
 
+    let mut focused_managed_window = false;
     for (mut strip, active_strip, _) in &mut workspaces {
         debug!("space {}: before refresh {strip:?}", strip.id());
         let workspace_windows = window_manager
@@ -246,7 +248,22 @@ pub(crate) fn finish_setup(
 
         if active_strip && let Some(entity) = strip.first().ok().and_then(|column| column.top()) {
             commands.focus_entity(entity, true);
+            focused_managed_window = true;
         }
+    }
+
+    // An all-floating workspace has no strip member to receive the initial
+    // focus marker. Mirror the frontmost app's AX focus so menu actions such as
+    // Toggle Managed work immediately after launch.
+    if !focused_managed_window
+        && let Some(focused_window_id) = applications
+            .iter()
+            .find(|app| app.is_frontmost())
+            .and_then(|app| app.focused_window_id().ok())
+        && let Some((_, entity)) = windows.find(focused_window_id)
+        && let Ok(mut entity_commands) = commands.get_entity(entity)
+    {
+        entity_commands.try_insert(FocusedMarker);
     }
 
     commands.remove_resource::<Initializing>();

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -2,7 +2,7 @@ use bevy::app::AppExit;
 use bevy::ecs::change_detection::{DetectChanges, DetectChangesMut};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::{ChildOf, Children};
-use bevy::ecs::message::{MessageReader, MessageWriter};
+use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::{Added, Changed, Has, Or, With, Without};
 use bevy::ecs::system::{
     Commands, Local, NonSend, NonSendMut, Populated, Query, Res, ResMut, Single,
@@ -13,8 +13,6 @@ use bevy::tasks::futures_lite::future;
 use bevy::time::Time;
 use objc2_foundation::NSPoint;
 use std::collections::HashSet;
-use std::pin::Pin;
-use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::time::Duration;
 use tracing::{Level, debug, error, info, instrument, trace, warn};
 
@@ -26,24 +24,20 @@ use super::{
 use crate::config::{Config, decorations::BorderRadiusOption};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
+use crate::ecs::runtime::FreshPollDeadline;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, BruteforceWindows, FlashMessage, FocusedMarker, Initializing,
     LowPowerMode, MissionControlActive, Position, ReadDisplayProperties, RestoreWindowState,
     Scrolling, SendMessageTrigger, SpawnCommandsExt, Unmanaged, WidthRatio, WindowProperties,
 };
-use crate::events::Event;
+use crate::events::{Event, EventReceiver};
 use crate::manager::{
     Application, Display, Process, Window, WindowManager, WindowOS, bruteforce_windows,
 };
 use crate::overlay::{FlashMessageManager, OverlayManager};
-use crate::platform::{PlatformCallbacks, WinID};
+use crate::platform::{AxMainThread, WinID};
 
 const ANIAMTE_SNAP_THRESHOLD: f32 = 5.0;
-const LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS: u32 = 16;
-const LOOP_MAX_TIMEOUT_LOWPOWER_MS: u32 = 500;
-const LOOP_MAX_TIMEOUT_MS: u32 = 50;
-const LOOP_TIMEOUT_STEP: u32 = 1;
-
 /// Gathers all present displays and spawns them as entities in the Bevy world.
 /// The currently active display (identified by `window_manager.active_display_id()`) is marked with `ActiveDisplayMarker`.
 ///
@@ -284,14 +278,22 @@ pub(crate) fn finish_setup(
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn add_launched_process(
     window_manager: Res<WindowManager>,
-    fresh_processes: Populated<(Entity, &mut BProcess, Has<Children>), With<FreshMarker>>,
+    fresh_processes: Populated<
+        (Entity, &mut BProcess, Has<Children>, &mut FreshPollDeadline),
+        With<FreshMarker>,
+    >,
     config: Res<Config>,
     mut commands: Commands,
 ) {
     const APP_OBSERVABLE_TIMEOUT_SEC: u64 = 5;
     let mut already_seen = HashSet::new();
 
-    for (entity, mut process, children) in fresh_processes {
+    let now = std::time::Instant::now();
+    for (entity, mut process, children, mut poll) in fresh_processes {
+        if !poll.due(now) {
+            continue;
+        }
+        poll.schedule_next(now);
         let process = &mut *process.0;
 
         if !already_seen.insert(process.psn()) {
@@ -313,7 +315,9 @@ pub(super) fn add_launched_process(
         if children {
             // Process already has an attached Application, so finish.
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_remove::<FreshMarker>();
+                entity_commands
+                    .try_remove::<FreshMarker>()
+                    .try_remove::<FreshPollDeadline>();
             }
             continue;
         }
@@ -331,7 +335,13 @@ pub(super) fn add_launched_process(
                 )),
                 &mut commands,
             );
-            commands.spawn((app, FreshMarker, timeout, ChildOf(entity)));
+            commands.spawn((
+                app,
+                FreshMarker,
+                FreshPollDeadline::default(),
+                timeout,
+                ChildOf(entity),
+            ));
         } else {
             debug!("failed to register some observers {}", process.name());
         }
@@ -350,7 +360,15 @@ pub(super) fn add_launched_process(
 /// * `commands` - Bevy commands to spawn entities and manage components.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn add_launched_application(
-    app_query: Populated<(&mut Application, Entity, Has<Children>), With<FreshMarker>>,
+    app_query: Populated<
+        (
+            &mut Application,
+            Entity,
+            Has<Children>,
+            &mut FreshPollDeadline,
+        ),
+        With<FreshMarker>,
+    >,
     windows: Windows,
     config: Res<Config>,
     mut commands: Commands,
@@ -358,14 +376,21 @@ pub(super) fn add_launched_application(
     // TODO: maybe refactor this with add_existing_application_windows()
     let find_window = |window_id| windows.find(window_id);
 
-    for (app, entity, has_children) in app_query {
+    let now = std::time::Instant::now();
+    for (app, entity, has_children, mut poll) in app_query {
+        if !poll.due(now) {
+            continue;
+        }
+        poll.schedule_next(now);
         let mut create_windows = app.window_list(&config);
         // Retain the non-existing windows, so they can be created.
         create_windows.retain(|window| find_window(window.id()).is_none());
 
         if !create_windows.is_empty() {
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_remove::<FreshMarker>();
+                entity_commands
+                    .try_remove::<FreshMarker>()
+                    .try_remove::<FreshPollDeadline>();
             }
             debug!(
                 "spawn! (polling path found {} new windows for {entity})",
@@ -377,7 +402,9 @@ pub(super) fn add_launched_application(
             // Remove FreshMarker so the Timeout gets cleaned up.
             debug!("removing FreshMarker from {entity}: windows already created via AXCreated");
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_remove::<FreshMarker>();
+                entity_commands
+                    .try_remove::<FreshMarker>()
+                    .try_remove::<FreshPollDeadline>();
             }
         }
     }
@@ -424,7 +451,8 @@ pub(super) fn timeout_ticker(
     mut commands: Commands,
 ) {
     for (entity, mut timeout) in timers {
-        if timeout.timer.is_finished() {
+        timeout.timer.tick(clock.delta());
+        if timeout.due(std::time::Instant::now()) {
             trace!("Despawning entity {entity} due to timeout.");
             if let Some(system_id) = timeout.system_id.take() {
                 commands.run_system(system_id);
@@ -434,8 +462,6 @@ pub(super) fn timeout_ticker(
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 entity_commands.try_despawn();
             }
-        } else {
-            timeout.timer.tick(clock.delta());
         }
     }
 }
@@ -444,12 +470,17 @@ pub(super) fn timeout_ticker(
 /// during `ApplicationFrontSwitched`. Runs each frame until success or timeout.
 #[allow(clippy::needless_pass_by_value)]
 pub(super) fn retry_front_switch(
-    retries: Populated<(Entity, &RetryFrontSwitch)>,
+    _main_thread: NonSend<AxMainThread>,
+    mut retries: Populated<(Entity, &mut RetryFrontSwitch)>,
     applications: Query<&Application>,
     mut commands: Commands,
 ) {
-    for (entity, retry) in retries.iter() {
-        let Ok(app) = applications.get(retry.0) else {
+    let now = std::time::Instant::now();
+    for (entity, mut retry) in &mut retries {
+        if !retry.due(now) {
+            continue;
+        }
+        let Ok(app) = applications.get(retry.application) else {
             // Application entity no longer exists, clean up.
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 entity_commands.try_despawn();
@@ -472,6 +503,8 @@ pub(super) fn retry_front_switch(
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 entity_commands.try_despawn();
             }
+        } else {
+            retry.schedule_retry(now);
         }
         // Otherwise, let timeout_ticker handle expiry.
     }
@@ -576,65 +609,6 @@ pub(super) fn animate_resize_entities(
                 entity_commands.try_remove::<ResizeMarker>();
             }
         });
-}
-
-#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
-pub(super) fn pump_events(
-    mut exit: MessageWriter<AppExit>,
-    mut messages: MessageWriter<Event>,
-    low_power_mode: Option<Res<LowPowerMode>>,
-    incoming_events: Option<NonSend<Receiver<Event>>>,
-    platform: Option<NonSendMut<Pin<Box<PlatformCallbacks>>>>,
-    repositioning: Query<(), With<RepositionMarker>>,
-    resizing: Query<(), With<ResizeMarker>>,
-    scrolling: Query<(), With<Scrolling>>,
-    flash_messages: Query<(), With<FlashMessage>>,
-    mut timeout: Local<u32>,
-) {
-    let Some((ref mut platform, incoming_events)) = platform.zip(incoming_events) else {
-        // No platform interface or incoming event pipe - probably executing in a unit test.
-        return;
-    };
-
-    platform.pump_cocoa_event_loop(f64::from(*timeout) / 1000.0);
-    let mut received_events = Vec::new();
-    let mut pending_mouse = None;
-    loop {
-        // Repeatedly drain the events until timeout.
-        match incoming_events.recv_timeout(Duration::from_millis(1)) {
-            Ok(Event::Exit) | Err(RecvTimeoutError::Disconnected) => {
-                exit.write(AppExit::Success);
-                break;
-            }
-            Ok(event) => {
-                if matches!(event, Event::MouseMoved { .. }) {
-                    pending_mouse = Some(event);
-                } else {
-                    received_events.extend(pending_mouse.take());
-                    received_events.push(event);
-                }
-                *timeout = LOOP_TIMEOUT_STEP;
-            }
-            Err(RecvTimeoutError::Timeout) => {
-                received_events.extend(pending_mouse.take());
-                messages.write_batch(received_events);
-                let frame_active = !repositioning.is_empty()
-                    || !resizing.is_empty()
-                    || !scrolling.is_empty()
-                    || !flash_messages.is_empty();
-                let low_power = low_power_mode.is_some_and(|low_power| low_power.0);
-                let timeout_limit = if frame_active {
-                    LOOP_MAX_TIMEOUT_FRAME_ACTIVE_MS
-                } else if low_power {
-                    LOOP_MAX_TIMEOUT_LOWPOWER_MS
-                } else {
-                    LOOP_MAX_TIMEOUT_MS
-                };
-                *timeout = timeout.min(timeout_limit) + LOOP_TIMEOUT_STEP;
-                break;
-            }
-        }
-    }
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
@@ -752,7 +726,7 @@ pub(super) fn window_moved_update_frame(
 
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn gather_initial_processes(
-    receiver: Option<NonSendMut<Receiver<Event>>>,
+    receiver: Option<NonSendMut<EventReceiver>>,
     mut displays: Query<&mut Display>,
     mut commands: Commands,
 ) {
@@ -941,7 +915,12 @@ pub(super) fn verify_window_position(
     mut windows: Populated<(Entity, &mut Window, &Position, &mut VerifyWindowPosition)>,
     mut commands: Commands,
 ) {
+    let now = std::time::Instant::now();
     for (entity, mut window, position, mut verification) in &mut windows {
+        if !verification.due(now) {
+            continue;
+        }
+
         if window
             .update_frame()
             .is_ok_and(|frame| frame.min == position.0)

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -4,10 +4,8 @@ use bevy::ecs::lifecycle::{Add, Remove, RemovedComponents};
 use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With};
-use bevy::ecs::system::{Commands, NonSendMut, Populated, Query, Res, ResMut, Single};
+use bevy::ecs::system::{Commands, Populated, Query, Res, ResMut, Single};
 use bevy::math::IRect;
-use notify::event::{DataChange, MetadataKind, ModifyKind};
-use notify::{EventKind, Watcher};
 use std::cmp::Ordering;
 use std::time::Duration;
 use tracing::{Level, debug, error, info, instrument, trace, warn};
@@ -21,6 +19,7 @@ use crate::config::Config;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
+use crate::ecs::runtime::{FreshPollDeadline, SyntheticEventPending};
 use crate::ecs::state::PaneruState;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, Position,
@@ -32,11 +31,10 @@ use crate::manager::{
     Application, Display, Origin, Process, Size, Window, WindowManager, WindowPadding,
 };
 use crate::platform::WinID;
-use crate::util::symlink_target;
 
 /// Computes the passthrough keybinding set for the given window/app and
 /// publishes it to the input thread. Called on focus change and config reload.
-fn update_passthrough(window: &Window, app: &Application, config: &Config) {
+pub(super) fn update_passthrough(window: &Window, app: &Application, config: &Config) {
     let properties = WindowProperties::new(app, window, config);
     crate::platform::input::set_focused_passthrough(properties.passthrough_keys());
 }
@@ -114,7 +112,7 @@ pub(super) fn front_switched_trigger(
                 )),
                 &mut commands,
             );
-            commands.spawn((timeout, RetryFrontSwitch(app_entity)));
+            commands.spawn((timeout, RetryFrontSwitch::new(app_entity)));
         }
     }
 }
@@ -398,7 +396,7 @@ pub(super) fn application_event_trigger(
                     )),
                     &mut commands,
                 );
-                commands.spawn((FreshMarker, timeout, process));
+                commands.spawn((FreshMarker, FreshPollDeadline::default(), timeout, process));
             }
 
             Event::ApplicationTerminated { psn } => {
@@ -1111,81 +1109,6 @@ pub(super) fn apply_window_positions(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-pub(super) fn refresh_configuration_trigger(
-    mut messages: MessageReader<Event>,
-    window_manager: Res<WindowManager>,
-    mut config: ResMut<Config>,
-    mut watcher: Option<NonSendMut<Box<dyn Watcher>>>,
-    windows: Windows,
-    mut displays: Query<&mut Display>,
-    applications: Query<&Application>,
-) {
-    for event in messages.read() {
-        let Event::ConfigRefresh(event) = event else {
-            continue;
-        };
-
-        let Some(ref mut watcher) = watcher else {
-            continue;
-        };
-
-        match &event.kind {
-            EventKind::Modify(
-                // When using the RecommendedWatcher, the event triggers on file data.
-                // When using PollWatcher, it triggers on modification time.
-                ModifyKind::Metadata(MetadataKind::WriteTime)
-                | ModifyKind::Data(DataChange::Content),
-            ) => (),
-            EventKind::Remove(_) => {
-                for path in &event.paths {
-                    _ = watcher.unwatch(path).inspect_err(|err| {
-                        error!("unwatching the config '{}': {err}", path.display());
-                    });
-                }
-                continue;
-            }
-            _ => continue,
-        }
-
-        for path in &event.paths {
-            if let Some(symlink) = symlink_target(path) {
-                debug!(
-                    "symlink '{}' changed, replacing the watcher.",
-                    symlink.display()
-                );
-                if let Ok(new_watcher) =
-                    window_manager
-                        .setup_config_watcher(path)
-                        .inspect_err(|err| {
-                            error!("watching the config '{}': {err}", path.display());
-                        })
-                {
-                    **watcher = new_watcher;
-                }
-            }
-            info!("Reloading configuration file; {}", path.display());
-            _ = config.reload_config(path.as_path()).inspect_err(|err| {
-                error!("loading config '{}': {err}", path.display());
-            });
-        }
-
-        let height = config.menubar_height();
-        for mut display in &mut displays {
-            display.set_menubar_height_override(height);
-        }
-
-        // Recompute passthrough keys for the currently focused window.
-        if let Some((window, _, parent)) = windows
-            .focused()
-            .and_then(|(w, e)| windows.find_parent(w.id()).map(|(w, _, p)| (w, e, p)))
-            && let Ok(app) = applications.get(parent)
-        {
-            update_passthrough(window, app, &config);
-        }
-    }
-}
-
-#[allow(clippy::needless_pass_by_value)]
 pub(super) fn window_removal_trigger(
     trigger: On<Remove, Window>,
     mut workspaces: Query<&mut LayoutStrip>,
@@ -1205,9 +1128,11 @@ pub(super) fn window_removal_trigger(
 pub(super) fn send_message_trigger(
     trigger: On<SendMessageTrigger>,
     mut messages: MessageWriter<Event>,
+    mut synthetic_events: ResMut<SyntheticEventPending>,
 ) {
     let event = &trigger.event().0;
     messages.write(event.clone());
+    synthetic_events.mark();
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -85,6 +85,36 @@ pub(crate) struct PreviousStripPosition {
     pub focus: Option<Entity>,
 }
 
+fn fullscreen_window_in_strip(
+    workspace_id: WorkspaceId,
+    strip: &LayoutStrip,
+    windows: &Windows,
+    window_manager: &WindowManager,
+) -> Option<Entity> {
+    window_manager
+        .windows_in_workspace(workspace_id)
+        .ok()
+        .and_then(|window_ids| {
+            window_ids.into_iter().find_map(|window_id| {
+                windows
+                    .find_managed(window_id)
+                    .map(|(_, entity)| entity)
+                    .filter(|entity| strip.contains(*entity))
+            })
+        })
+        .or_else(|| {
+            windows.managed_iter().find_map(|(window, entity, _)| {
+                (strip.contains(entity) && window.is_full_screen()).then_some(entity)
+            })
+        })
+        .or_else(|| {
+            windows
+                .focused()
+                .map(|(_, entity)| entity)
+                .filter(|entity| strip.contains(*entity))
+        })
+}
+
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 fn workspace_change_handler(
@@ -142,19 +172,21 @@ fn workspace_change_handler(
     if insert_into.is_none()
         && let Some(old_space) = remove_from
         && window_manager.is_fullscreen_space(active_display.id())
-        && let Some((_, focused)) = windows.focused()
         && let Ok((mut old_strip, old_strip_entity, _, _)) = workspaces.get_mut(old_space)
+        && let Some(fullscreen_window) =
+            fullscreen_window_in_strip(workspace_id, &old_strip, &windows, &window_manager)
+        && let Ok(original_index) = old_strip.index_of(fullscreen_window)
     {
         debug!("workspace_change: space={workspace_id} fullscreen");
 
         let fullscreen_marker = NativeFullscreenMarker {
             layout_strip: old_strip_entity,
             workspace_id: old_strip.id(),
-            index: old_strip.index_of(focused).unwrap_or(0),
+            index: original_index,
         };
-        old_strip.remove(focused);
+        old_strip.remove(fullscreen_window);
 
-        let fullscreen_strip = LayoutStrip::fullscreen(workspace_id, focused);
+        let fullscreen_strip = LayoutStrip::fullscreen(workspace_id, fullscreen_window);
         let entity = commands
             .spawn((
                 Position(active_display.bounds().min),

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -9,10 +9,10 @@ use bevy::ecs::observer::On;
 use bevy::ecs::query::{Added, Has, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
-use bevy::ecs::system::{Commands, Local, ParamSet, Populated, Query, Res, ResMut, Single};
-use bevy::time::common_conditions::on_timer;
+use bevy::ecs::system::{
+    Commands, Local, NonSend, ParamSet, Populated, Query, Res, ResMut, Single,
+};
 use std::collections::HashSet;
-use std::time::Duration;
 use tracing::{Level, debug, error, instrument, warn};
 
 use super::{ActiveDisplayMarker, SpawnWindowTrigger};
@@ -21,6 +21,7 @@ use crate::config::Config;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
+use crate::ecs::runtime::OrphanReconcileDeadline;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, NativeFullscreenMarker, Position,
     RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker, SpawnCommandsExt,
@@ -29,15 +30,12 @@ use crate::ecs::{
 use crate::errors::Result;
 use crate::events::Event;
 use crate::manager::{Application, Display, Origin, Window, WindowManager};
-use crate::platform::{WinID, WorkspaceId};
+use crate::platform::{AxMainThread, WinID, WorkspaceId};
 
 pub struct WorkspaceEventsPlugin;
 
 impl Plugin for WorkspaceEventsPlugin {
     fn build(&self, app: &mut App) {
-        const REFRESH_WINDOW_CHECK_FREQ_MS: u64 = 1000;
-        const DISPLAY_CHANGE_CHECK_FREQ_MS: u64 = 1000;
-
         let reap_workspaces = |config: Option<Res<Config>>| {
             config.is_some_and(|config| config.reap_empty_workspaces())
         };
@@ -56,14 +54,8 @@ impl Plugin for WorkspaceEventsPlugin {
                 show_active_workspace,
                 handle_virtual_window_moves,
                 detect_moved_windows.run_if(not(resource_exists::<Initializing>)),
-                refresh_workspace_window_sizes.run_if(on_timer(Duration::from_millis(
-                    REFRESH_WINDOW_CHECK_FREQ_MS,
-                ))),
-                find_orphaned_workspaces
-                    .after(crate::ecs::display::reconcile_displays)
-                    .run_if(on_timer(Duration::from_millis(
-                        DISPLAY_CHANGE_CHECK_FREQ_MS,
-                    ))),
+                refresh_workspace_window_sizes,
+                find_orphaned_workspaces.after(crate::ecs::display::reconcile_displays),
             ),
         );
         app.add_systems(PostUpdate, workspace_destroyed_handler);
@@ -208,6 +200,7 @@ fn workspace_change_handler(
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all, fields(trigger))]
 fn detect_moved_windows(
+    _main_thread: NonSend<AxMainThread>,
     activated_workspace: Single<Entity, Added<ActiveWorkspaceMarker>>,
     windows: Windows,
     mut workspaces: Query<(&mut LayoutStrip, Entity, Has<NativeFullscreenMarker>)>,
@@ -411,17 +404,28 @@ fn windows_not_in_strips<F: Fn(WinID) -> Option<Entity>>(
         })
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 #[instrument(level = Level::DEBUG, skip_all)]
 fn find_orphaned_workspaces(
-    orphans: Populated<(&LayoutStrip, Entity, &Timeout, Option<&ChildOf>), With<Timeout>>,
+    _main_thread: NonSend<AxMainThread>,
+    orphans: Populated<
+        (
+            &LayoutStrip,
+            Entity,
+            &Timeout,
+            &mut OrphanReconcileDeadline,
+            Option<&ChildOf>,
+        ),
+        With<Timeout>,
+    >,
     displays: Populated<(&Display, Entity)>,
     window_manager: Res<WindowManager>,
     mut commands: Commands,
 ) {
     let present = window_manager.present_displays();
 
-    for (orphan, orphan_entity, timeout, child) in orphans {
+    let now = std::time::Instant::now();
+    for (orphan, orphan_entity, timeout, mut reconcile, child) in orphans {
         if orphan.len() == 0 {
             if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
                 cmd.try_despawn();
@@ -433,6 +437,7 @@ fn find_orphaned_workspaces(
             // Was reparented, remove timer.
             if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
                 cmd.try_remove::<Timeout>();
+                cmd.try_remove::<OrphanReconcileDeadline>();
                 cmd.insert(RefreshWindowSizes::default());
             }
             debug!(
@@ -442,7 +447,7 @@ fn find_orphaned_workspaces(
             continue;
         }
 
-        if timeout.timer.is_finished() {
+        if timeout.due(now) {
             // Rescue windows from orphaned strips before despawning by floating them.
             debug!("Rescue windows from timed out orphan {}.", orphan.id());
             for lost_window in orphan.all_windows() {
@@ -452,6 +457,11 @@ fn find_orphaned_workspaces(
             }
             continue;
         }
+
+        if !reconcile.due(now) {
+            continue;
+        }
+        reconcile.schedule_next(now);
 
         // Find which display now owns this space ID.
         let target = present.iter().find_map(|(present_display, spaces)| {
@@ -475,6 +485,7 @@ fn find_orphaned_workspaces(
 
         if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
             cmd.try_remove::<Timeout>()
+                .try_remove::<OrphanReconcileDeadline>()
                 .insert(ChildOf(target_entity))
                 .insert(RefreshWindowSizes::default());
         }
@@ -483,6 +494,7 @@ fn find_orphaned_workspaces(
 
 #[allow(clippy::needless_pass_by_value)]
 fn refresh_workspace_window_sizes(
+    _main_thread: NonSend<AxMainThread>,
     layout_strip: Single<(&LayoutStrip, Entity, &RefreshWindowSizes), With<ActiveWorkspaceMarker>>,
     mut windows: Query<(Entity, &mut Window, &mut Bounds, Option<&Unmanaged>)>,
     active_display: ActiveDisplay,
@@ -490,7 +502,7 @@ fn refresh_workspace_window_sizes(
     mut commands: Commands,
 ) {
     let (strip, strip_entity, marker) = *layout_strip;
-    if !marker.ready() {
+    if !marker.ready(std::time::Instant::now()) {
         return;
     }
 
@@ -1171,5 +1183,100 @@ fn reap_empty_virtual_workspaces(
                 entity_commands.try_despawn();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod main_thread_tests {
+    use std::time::{Duration, Instant};
+
+    use bevy::prelude::*;
+
+    use super::{LayoutStrip, find_orphaned_workspaces, refresh_workspace_window_sizes};
+    use crate::ecs::runtime::OrphanReconcileDeadline;
+    use crate::ecs::{
+        ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, RefreshWindowSizes, Timeout,
+    };
+    use crate::manager::{
+        Display, MockWindowApi, MockWindowManagerApi, Size, Window, WindowManager,
+    };
+    use crate::platform::AxMainThread;
+
+    #[test]
+    fn refresh_window_sizes_runs_ax_on_main_thread() {
+        let expected_thread = std::thread::current().id();
+        let mut window = MockWindowApi::new();
+        window.expect_id().return_const(7);
+        window.expect_update_frame().times(1).returning(move || {
+            assert_eq!(std::thread::current().id(), expected_thread);
+            Ok(IRect::new(0, 0, 400, 300))
+        });
+        let mut manager = MockWindowManagerApi::new();
+        manager
+            .expect_windows_in_workspace()
+            .times(1)
+            .returning(|_| Ok(vec![7]));
+
+        let mut app = App::new();
+        app.insert_non_send_resource(AxMainThread::for_tests())
+            .insert_resource(WindowManager(Box::new(manager)))
+            .add_systems(Update, refresh_workspace_window_sizes);
+        let display = app
+            .world_mut()
+            .spawn((
+                Display::new(1, IRect::new(0, 0, 1_000, 800), 0),
+                ActiveDisplayMarker,
+            ))
+            .id();
+        let window = app
+            .world_mut()
+            .spawn((Window::new(Box::new(window)), Bounds(Size::new(1, 1))))
+            .id();
+        let mut strip = LayoutStrip::new(1, 0);
+        strip.append(window);
+        let strip = app
+            .world_mut()
+            .spawn((
+                strip,
+                ActiveWorkspaceMarker,
+                RefreshWindowSizes(Instant::now()),
+                ChildOf(display),
+            ))
+            .id();
+
+        app.update();
+
+        assert!(!app.world().entity(strip).contains::<RefreshWindowSizes>());
+    }
+
+    fn spawn_orphan(mut commands: Commands) {
+        let timeout = Timeout::new(Duration::from_secs(30), None, &mut commands);
+        commands.spawn((
+            LayoutStrip::new(99, 0),
+            timeout,
+            OrphanReconcileDeadline::default(),
+        ));
+    }
+
+    #[test]
+    fn orphan_reconciliation_runs_cg_query_on_main_thread() {
+        let expected_thread = std::thread::current().id();
+        let mut manager = MockWindowManagerApi::new();
+        manager
+            .expect_present_displays()
+            .times(1)
+            .returning(move || {
+                assert_eq!(std::thread::current().id(), expected_thread);
+                Vec::new()
+            });
+        let mut app = App::new();
+        app.insert_non_send_resource(AxMainThread::for_tests())
+            .insert_resource(WindowManager(Box::new(manager)))
+            .add_systems(Startup, spawn_orphan)
+            .add_systems(Update, find_orphaned_workspaces);
+        app.world_mut()
+            .spawn(Display::new(1, IRect::new(0, 0, 1_000, 800), 0));
+
+        app.update();
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -99,7 +99,11 @@ pub enum Event {
 
     /// Fingers have been placed on the touchpad.
     TouchpadDown,
-    /// All fingers are up from the touchpad.
+    /// Physical contact ended; a native momentum phase may still follow.
+    TouchpadPhysicalUp,
+    /// Native momentum began for the current physical gesture.
+    TouchpadMomentumStart,
+    /// The full touchpad gesture, including native momentum, has ended.
     TouchpadUp,
 
     /// A new space (virtual desktop) has been created.

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,9 +1,14 @@
 use bevy::ecs::message::Message;
 use objc2::rc::Retained;
-use objc2_core_foundation::{CFRetained, CGPoint};
+use objc2_core_foundation::{
+    CFRetained, CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext, CGPoint, kCFRunLoopDefaultMode,
+};
 use objc2_core_graphics::CGDirectDisplayID;
+use std::ffi::c_void;
 use std::os::unix::net::UnixStream;
-use std::sync::mpsc::{Receiver, Sender, channel};
+use std::ptr::{from_ref, null_mut};
+use std::sync::atomic::{AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, RecvError, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
 
 use crate::commands::Command;
@@ -170,7 +175,67 @@ pub enum Event {
 #[derive(Clone, Debug)]
 pub struct EventSender {
     tx: Sender<Event>,
+    wake: Arc<EventWake>,
 }
+
+#[derive(Debug)]
+struct EventWake {
+    generation: AtomicU64,
+    source: AtomicPtr<CFRunLoopSource>,
+    active_signals: AtomicUsize,
+}
+
+impl Default for EventWake {
+    fn default() -> Self {
+        Self {
+            generation: AtomicU64::new(0),
+            source: AtomicPtr::new(null_mut()),
+            active_signals: AtomicUsize::new(0),
+        }
+    }
+}
+
+/// Receiver paired with [`EventSender`]. The generation counter makes the
+/// queue-before-sleep protocol testable; the registered run-loop source closes
+/// the final check-to-sleep race because its signalled state is latched.
+pub struct EventReceiver {
+    rx: Receiver<Event>,
+    wake: Arc<EventWake>,
+}
+
+impl EventReceiver {
+    pub fn recv(&self) -> std::result::Result<Event, RecvError> {
+        self.rx.recv()
+    }
+
+    pub fn try_recv(&self) -> std::result::Result<Event, TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.wake.generation.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) struct EventWakeSource {
+    source: CFRetained<CFRunLoopSource>,
+    wake: Arc<EventWake>,
+}
+
+impl Drop for EventWakeSource {
+    fn drop(&mut self) {
+        self.wake.source.swap(null_mut(), Ordering::AcqRel);
+        while self.wake.active_signals.load(Ordering::Acquire) != 0 {
+            std::thread::yield_now();
+        }
+        if let Some(main_loop) = CFRunLoop::main() {
+            main_loop.remove_source(Some(&self.source), unsafe { kCFRunLoopDefaultMode });
+        }
+        self.source.invalidate();
+    }
+}
+
+unsafe extern "C-unwind" fn consume_event_wake(_: *mut c_void) {}
 
 impl EventSender {
     /// Creates a new `EventSender` and its corresponding `Receiver`.
@@ -179,9 +244,42 @@ impl EventSender {
     /// # Returns
     ///
     /// A tuple containing the `EventSender` and `Receiver` for the created channel.
-    pub fn new() -> (Self, Receiver<Event>) {
+    pub fn new() -> (Self, EventReceiver) {
         let (tx, rx) = channel::<Event>();
-        (Self { tx }, rx)
+        let wake = Arc::new(EventWake::default());
+        (
+            Self {
+                tx,
+                wake: Arc::clone(&wake),
+            },
+            EventReceiver { rx, wake },
+        )
+    }
+
+    pub(crate) fn install_main_run_loop_source(&self) -> Option<EventWakeSource> {
+        let mut context = CFRunLoopSourceContext {
+            version: 0,
+            info: null_mut(),
+            retain: None,
+            release: None,
+            copyDescription: None,
+            equal: None,
+            hash: None,
+            schedule: None,
+            cancel: None,
+            perform: Some(consume_event_wake),
+        };
+        let source = unsafe { CFRunLoopSource::new(None, 0, &raw mut context) }?;
+        let main_loop = CFRunLoop::main()?;
+        main_loop.add_source(Some(&source), unsafe { kCFRunLoopDefaultMode });
+        self.wake.source.store(
+            from_ref::<CFRunLoopSource>(&source).cast_mut(),
+            Ordering::Release,
+        );
+        Some(EventWakeSource {
+            source,
+            wake: Arc::clone(&self.wake),
+        })
     }
 
     /// Sends an `Event` through the internal channel.
@@ -194,6 +292,60 @@ impl EventSender {
     ///
     /// `Ok(())` if the event is sent successfully, otherwise `Err(Error)` if the receiver has disconnected.
     pub fn send(&self, event: Event) -> Result<()> {
-        Ok(self.tx.send(event)?)
+        self.tx.send(event)?;
+        self.wake.generation.fetch_add(1, Ordering::Release);
+        self.wake.active_signals.fetch_add(1, Ordering::AcqRel);
+        let source = self.wake.source.load(Ordering::Acquire);
+        if !source.is_null() {
+            // Main-thread sends must signal too: AppKit callbacks can run while
+            // PlatformCallbacks is draining queued NSEvents immediately before
+            // entering CFRunLoop::run_in_mode. Without a latched source, that
+            // subsequent run could sleep despite the newly queued ECS event.
+            // The source callback itself is empty and channel draining coalesces
+            // events, so it adds at most one wake turn, not persistent frame work.
+            // SAFETY: `EventWakeSource` owns the source until it first clears
+            // this pointer with Release ordering. Core Foundation permits
+            // signalling a run-loop source from arbitrary threads.
+            unsafe { &*source }.signal();
+        }
+        self.wake.active_signals.fetch_sub(1, Ordering::Release);
+        if let Some(main_loop) = CFRunLoop::main() {
+            main_loop.wake_up();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Event, EventSender};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn generation_latches_queued_before_sleep_and_during_ecs() {
+        let (sender, receiver) = EventSender::new();
+        let before = receiver.generation();
+        sender.send(Event::ApplicationActivated).unwrap();
+        assert!(receiver.generation() > before);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Event::ApplicationActivated)
+        ));
+
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = Arc::clone(&barrier);
+        let worker = thread::spawn(move || {
+            worker_barrier.wait();
+            sender.send(Event::ApplicationDeactivated).unwrap();
+        });
+        let before_ecs = receiver.generation();
+        barrier.wait();
+        worker.join().unwrap();
+        assert!(receiver.generation() > before_ecs);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Event::ApplicationDeactivated)
+        ));
     }
 }

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -38,6 +38,25 @@ use crate::util::{AXUIAttributes, AXUIWrapper, MacResult};
 static ENHANCED_UI_REFCOUNT: LazyLock<Mutex<HashMap<Pid, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// macOS may partially apply an AX width increase when the requested right edge
+/// would be far outside the display. Moving the partial result left by the
+/// missing width before retrying gives `WindowServer` enough offscreen room.
+///
+/// Only retry when the first attempt actually grew the window. Fixed-size apps
+/// otherwise look identical to this failure mode and must not be moved offscreen.
+fn resize_staging_origin(
+    previous_frame: IRect,
+    actual_frame: IRect,
+    target_width: i32,
+) -> Option<Origin> {
+    let actual_width = actual_frame.width();
+    (actual_width > previous_frame.width() && actual_width < target_width).then(|| {
+        actual_frame
+            .min
+            .with_x(actual_frame.min.x - (target_width - actual_width))
+    })
+}
+
 #[derive(Debug)]
 pub enum WindowPadding {
     Vertical(i32),
@@ -313,6 +332,56 @@ impl WindowOS {
         }
     }
 
+    fn set_ax_position(&mut self, origin: Origin) {
+        let mut point = CGPoint::new(
+            f64::from(origin.x + self.horizontal_padding),
+            f64::from(origin.y + self.vertical_padding),
+        );
+        let position_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGPoint,
+                NonNull::from(&mut point).as_ptr().cast(),
+            )
+        };
+        if let Ok(position) = AXUIWrapper::retain(position_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
+                    position.as_ref(),
+                )
+            };
+            let size = self.frame.size();
+            self.frame.min = origin;
+            self.frame.max = origin + size;
+        }
+    }
+
+    fn set_ax_size(&mut self, size: Size) {
+        let width_padding = 2 * self.horizontal_padding;
+        let height_padding = 2 * self.vertical_padding;
+        let mut cgsize = CGSize::new(
+            f64::from(size.x - width_padding),
+            f64::from(size.y - height_padding),
+        );
+        let size_ref = unsafe {
+            AXValueCreate(
+                kAXValueTypeCGSize,
+                NonNull::from(&mut cgsize).as_ptr().cast(),
+            )
+        };
+        if let Ok(size_value) = AXUIWrapper::retain(size_ref) {
+            unsafe {
+                AXUIElementSetAttributeValue(
+                    self.ax_element.as_ptr(),
+                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
+                    size_value.as_ref(),
+                )
+            };
+            self.frame.max = self.frame.min + size;
+        }
+    }
+
     /// Makes the window the key window for its application by sending synthesized events.
     ///
     /// # Arguments
@@ -424,28 +493,7 @@ impl WindowApi for WindowOS {
             return;
         }
         self.disable_enhanced_ui();
-        let mut point = CGPoint::new(
-            f64::from(origin.x + self.horizontal_padding),
-            f64::from(origin.y + self.vertical_padding),
-        );
-        let position_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGPoint,
-                NonNull::from(&mut point).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(position_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXPositionAttribute).as_ref(),
-                    position.as_ref(),
-                )
-            };
-            let size = self.frame.size();
-            self.frame.min = origin;
-            self.frame.max = origin + size;
-        }
+        self.set_ax_position(origin);
         self.reenable_enhanced_ui();
     }
 
@@ -455,28 +503,44 @@ impl WindowApi for WindowOS {
             trace!("already correct size.");
             return;
         }
+        let previous_frame = self.frame;
+        let target_origin = previous_frame.min;
         self.disable_enhanced_ui();
-        let width_padding = 2 * self.horizontal_padding;
-        let height_padding = 2 * self.vertical_padding;
-        let mut cgsize = CGSize::new(
-            f64::from(size.x - width_padding),
-            f64::from(size.y - height_padding),
-        );
-        let size_ref = unsafe {
-            AXValueCreate(
-                kAXValueTypeCGSize,
-                NonNull::from(&mut cgsize).as_ptr().cast(),
-            )
-        };
-        if let Ok(position) = AXUIWrapper::retain(size_ref) {
-            unsafe {
-                AXUIElementSetAttributeValue(
-                    self.ax_element.as_ptr(),
-                    CFString::from_static_str(kAXSizeAttribute).as_ref(),
-                    position.as_ref(),
-                )
+        self.set_ax_size(size);
+
+        let mut previous_observed_frame = previous_frame;
+        let mut staged = false;
+        for attempt in 1..=3 {
+            let Ok(actual_frame) = self.update_frame() else {
+                break;
             };
-            self.frame.max = self.frame.min + size;
+            let Some(staging_origin) =
+                resize_staging_origin(previous_observed_frame, actual_frame, size.x)
+            else {
+                break;
+            };
+            debug!(
+                attempt,
+                requested_width = size.x,
+                actual_width = actual_frame.width(),
+                staging_x = staging_origin.x,
+                "retrying partially constrained AX resize from an offscreen origin"
+            );
+            staged = true;
+            previous_observed_frame = actual_frame;
+            self.set_ax_position(staging_origin);
+            self.set_ax_size(size);
+        }
+
+        if staged {
+            if let Ok(final_frame) = self.update_frame() {
+                debug!(
+                    requested_width = size.x,
+                    actual_width = final_frame.width(),
+                    "completed staged AX resize"
+                );
+            }
+            self.set_ax_position(target_origin);
         }
         self.reenable_enhanced_ui();
     }
@@ -664,5 +728,37 @@ impl WindowApi for WindowOS {
             // Get first corner radius (usually all corners are the same)
             radii.get(0)?.as_i64().map(|v| v as f64)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stages_partially_applied_width_growth() {
+        let previous = IRect::new(-400, 40, 400, 640);
+        let actual = IRect::new(-400, 40, 2416, 640);
+
+        assert_eq!(
+            resize_staging_origin(previous, actual, 4112),
+            Some(Origin::new(-1696, 40))
+        );
+
+        let nearly_complete = IRect::new(-2056, 40, 2016, 640);
+        assert_eq!(
+            resize_staging_origin(actual, nearly_complete, 4112),
+            Some(Origin::new(-2096, 40))
+        );
+    }
+
+    #[test]
+    fn does_not_stage_fixed_size_or_completed_resizes() {
+        let fixed = IRect::new(0, 40, 230, 448);
+        assert_eq!(resize_staging_origin(fixed, fixed, 4112), None);
+
+        let previous = IRect::new(0, 40, 800, 640);
+        let completed = IRect::new(0, 40, 4112, 640);
+        assert_eq!(resize_staging_origin(previous, completed, 4112), None);
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -80,13 +80,30 @@ pub struct MenuBarManager {
     menu: Retained<NSMenu>,
     action_target: Retained<MenuActionTarget>,
     width_items: Vec<(i32, Retained<NSMenuItem>)>,
-    window_items: Vec<Retained<NSMenuItem>>,
+    managed_window_items: Vec<Retained<NSMenuItem>>,
+    manage_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
     current_label: Option<String>,
 }
 
 const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
 const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
+
+#[derive(Debug, Eq, PartialEq)]
+struct WindowMenuEnablement {
+    managed_actions: bool,
+    toggle_managed: bool,
+}
+
+fn window_menu_enablement(
+    has_focused_window: bool,
+    focused_width_ratio: Option<f64>,
+) -> WindowMenuEnablement {
+    WindowMenuEnablement {
+        managed_actions: focused_width_ratio.is_some(),
+        toggle_managed: has_focused_window,
+    }
+}
 
 impl MenuBarManager {
     pub fn new(mtm: MainThreadMarker, events: EventSender) -> Self {
@@ -106,7 +123,8 @@ impl MenuBarManager {
             menu,
             action_target,
             width_items: Vec::new(),
-            window_items: Vec::new(),
+            managed_window_items: Vec::new(),
+            manage_item: None,
             configured_widths: Vec::new(),
             current_label: None,
         }
@@ -117,6 +135,7 @@ impl MenuBarManager {
         virtual_index: u32,
         show_virtual_workspace: bool,
         preset_widths: &[f64],
+        has_focused_window: bool,
         focused_width_ratio: Option<f64>,
     ) {
         let widths = normalized_width_percentages(preset_widths);
@@ -124,9 +143,12 @@ impl MenuBarManager {
             self.rebuild_menu(&widths);
         }
 
-        let has_focused_window = focused_width_ratio.is_some();
-        for item in &self.window_items {
-            item.setEnabled(has_focused_window);
+        let enablement = window_menu_enablement(has_focused_window, focused_width_ratio);
+        for item in &self.managed_window_items {
+            item.setEnabled(enablement.managed_actions);
+        }
+        if let Some(manage_item) = &self.manage_item {
+            manage_item.setEnabled(enablement.toggle_managed);
         }
         for (percentage, item) in &self.width_items {
             let selected = focused_width_ratio
@@ -149,7 +171,8 @@ impl MenuBarManager {
     fn rebuild_menu(&mut self, widths: &[i32]) {
         self.menu.removeAllItems();
         self.width_items.clear();
-        self.window_items.clear();
+        self.managed_window_items.clear();
+        self.manage_item = None;
 
         let status = self.add_item("Paneru — Running", None);
         status.setEnabled(false);
@@ -160,14 +183,15 @@ impl MenuBarManager {
         for &percentage in widths {
             let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
             item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
-            self.window_items.push(item.clone());
+            self.managed_window_items.push(item.clone());
             self.width_items.push((percentage, item));
         }
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
         let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
-        self.window_items.extend([center, manage]);
+        self.managed_window_items.push(center);
+        self.manage_item = Some(manage);
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
@@ -236,21 +260,21 @@ pub fn update_menu_bar(
         return;
     };
 
-    let focused_width_ratio = active_display
-        .iter()
-        .next()
-        .zip(focused.iter().next())
-        .and_then(|((display, dock), (bounds, unmanaged))| {
+    let focused_window = focused.iter().next();
+    let focused_width_ratio = active_display.iter().next().zip(focused_window).and_then(
+        |((display, dock), (bounds, unmanaged))| {
             (!unmanaged).then(|| {
                 f64::from(bounds.0.x)
                     / f64::from(display.actual_display_bounds(dock, &config).width())
             })
-        });
+        },
+    );
 
     menu_bar.update(
         strip.virtual_index,
         config.workspace_menu_status(),
         &config.preset_column_widths(),
+        focused_window.is_some(),
         focused_width_ratio,
     );
 }
@@ -274,7 +298,10 @@ fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_virtual_workspace_label, normalized_width_percentages};
+    use super::{
+        WindowMenuEnablement, format_virtual_workspace_label, normalized_width_percentages,
+        window_menu_enablement,
+    };
 
     #[test]
     fn label_is_one_based() {
@@ -287,6 +314,31 @@ mod tests {
         assert_eq!(
             normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
             vec![50, 150, 200]
+        );
+    }
+
+    #[test]
+    fn unmanaged_focus_only_enables_toggle_managed() {
+        assert_eq!(
+            window_menu_enablement(true, None),
+            WindowMenuEnablement {
+                managed_actions: false,
+                toggle_managed: true,
+            }
+        );
+        assert_eq!(
+            window_menu_enablement(false, None),
+            WindowMenuEnablement {
+                managed_actions: false,
+                toggle_managed: false,
+            }
+        );
+        assert_eq!(
+            window_menu_enablement(true, Some(1.0)),
+            WindowMenuEnablement {
+                managed_actions: true,
+                toggle_managed: true,
+            }
         );
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,20 +1,87 @@
 use bevy::ecs::entity::Entity;
-use bevy::ecs::query::With;
-use bevy::ecs::system::{Local, NonSendMut, Query};
-use objc2::MainThreadMarker;
+use bevy::ecs::query::{Has, With};
+use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
-use objc2_app_kit::{NSColor, NSStatusBar, NSStatusItem, NSVariableStatusItemLength};
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+use objc2_app_kit::{
+    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSStatusBar,
+    NSStatusItem, NSVariableStatusItemLength,
+};
 use objc2_core_foundation::CGFloat;
-use objc2_foundation::NSString;
+use objc2_foundation::{NSObject, NSString};
 use tracing::warn;
 
-use crate::ecs::ActiveWorkspaceMarker;
+use crate::commands::{Command, Operation};
+use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
+use crate::ecs::{
+    ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Unmanaged,
+};
+use crate::events::{Event, EventSender};
+use crate::manager::Display;
+
+#[derive(Debug, Clone)]
+struct MenuActionTargetIvars {
+    events: EventSender,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "PaneruMenuActionTarget"]
+    #[ivars = MenuActionTargetIvars]
+    #[derive(Debug)]
+    struct MenuActionTarget;
+
+    impl MenuActionTarget {
+        #[unsafe(method(setWidth:))]
+        fn set_width(&self, item: &NSMenuItem) {
+            let Ok(percentage) = i32::try_from(item.tag()) else {
+                return;
+            };
+            let ratio = f64::from(percentage) / 100.0;
+            self.send_command(Command::Window(Operation::SetWidth(ratio)));
+        }
+
+        #[unsafe(method(centerWindow:))]
+        fn center_window(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::Center));
+        }
+
+        #[unsafe(method(toggleManaged:))]
+        fn toggle_managed(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::Manage));
+        }
+
+        #[unsafe(method(quitPaneru:))]
+        fn quit_paneru(&self, _: &NSMenuItem) {
+            self.send_command(Command::Quit);
+        }
+    }
+);
+
+impl MenuActionTarget {
+    fn new(mtm: MainThreadMarker, events: EventSender) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(MenuActionTargetIvars { events });
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn send_command(&self, command: Command) {
+        if let Err(error) = self.ivars().events.send(Event::Command { command }) {
+            warn!(%error, "unable to send menu bar command");
+        }
+    }
+}
 
 pub struct MenuBarManager {
     mtm: MainThreadMarker,
     status_bar: Retained<NSStatusBar>,
     status_item: Retained<NSStatusItem>,
+    menu: Retained<NSMenu>,
+    action_target: Retained<MenuActionTarget>,
+    width_items: Vec<(i32, Retained<NSMenuItem>)>,
+    window_items: Vec<Retained<NSMenuItem>>,
+    configured_widths: Vec<i32>,
     current_label: Option<String>,
 }
 
@@ -22,27 +89,112 @@ const STATUS_ITEM_BACKGROUND_ALPHA: CGFloat = 0.18;
 const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
 
 impl MenuBarManager {
-    pub fn new(mtm: MainThreadMarker) -> Self {
+    pub fn new(mtm: MainThreadMarker, events: EventSender) -> Self {
         let status_bar = NSStatusBar::systemStatusBar();
         let status_item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
+        let menu = NSMenu::new(mtm);
+        let action_target = MenuActionTarget::new(mtm, events);
+
+        menu.setAutoenablesItems(false);
+        status_item.setMenu(Some(&menu));
         status_item.setVisible(true);
 
         Self {
             mtm,
             status_bar,
             status_item,
+            menu,
+            action_target,
+            width_items: Vec::new(),
+            window_items: Vec::new(),
+            configured_widths: Vec::new(),
             current_label: None,
         }
     }
 
-    pub fn show_virtual_workspace(&mut self, virtual_index: u32) {
-        let label = format_virtual_workspace_label(virtual_index);
+    pub fn update(
+        &mut self,
+        virtual_index: u32,
+        show_virtual_workspace: bool,
+        preset_widths: &[f64],
+        focused_width_ratio: Option<f64>,
+    ) {
+        let widths = normalized_width_percentages(preset_widths);
+        if self.configured_widths != widths {
+            self.rebuild_menu(&widths);
+        }
+
+        let has_focused_window = focused_width_ratio.is_some();
+        for item in &self.window_items {
+            item.setEnabled(has_focused_window);
+        }
+        for (percentage, item) in &self.width_items {
+            let selected = focused_width_ratio
+                .is_some_and(|ratio| (ratio.mul_add(100.0, -f64::from(*percentage))).abs() < 1.0);
+            item.setState(if selected {
+                NSControlStateValueOn
+            } else {
+                NSControlStateValueOff
+            });
+        }
+
+        let label = if show_virtual_workspace {
+            format_virtual_workspace_label(virtual_index)
+        } else {
+            "Paneru".to_owned()
+        };
+        self.show_label(label);
+    }
+
+    fn rebuild_menu(&mut self, widths: &[i32]) {
+        self.menu.removeAllItems();
+        self.width_items.clear();
+        self.window_items.clear();
+
+        let status = self.add_item("Paneru — Running", None);
+        status.setEnabled(false);
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+
+        let width_header = self.add_item("Window width", None);
+        width_header.setEnabled(false);
+        for &percentage in widths {
+            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
+            item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
+            self.window_items.push(item.clone());
+            self.width_items.push((percentage, item));
+        }
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
+        let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
+        self.window_items.extend([center, manage]);
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
+        self.configured_widths = widths.to_vec();
+    }
+
+    fn add_item(&self, title: &str, action: Option<objc2::runtime::Sel>) -> Retained<NSMenuItem> {
+        let item = unsafe {
+            self.menu.addItemWithTitle_action_keyEquivalent(
+                &NSString::from_str(title),
+                action,
+                &NSString::from_str(""),
+            )
+        };
+        if action.is_some() {
+            unsafe { item.setTarget(Some(&self.action_target)) };
+        }
+        item
+    }
+
+    fn show_label(&mut self, label: String) {
         if self.current_label.as_deref() == Some(label.as_str()) {
             return;
         }
 
         let title = NSString::from_str(&label);
-        let tooltip = NSString::from_str("Paneru virtual workspace");
+        let tooltip = NSString::from_str("Paneru window manager");
         let Some(button) = self.status_item.button(self.mtm) else {
             warn!("unable to update menu bar: status item has no button");
             return;
@@ -69,41 +221,72 @@ impl Drop for MenuBarManager {
     }
 }
 
-pub fn update_virtual_workspace_status_item(
+#[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
+pub fn update_menu_bar(
     active_workspace: Query<(Entity, &LayoutStrip), With<ActiveWorkspaceMarker>>,
+    active_display: Query<(&Display, Option<&DockPosition>), With<ActiveDisplayMarker>>,
+    focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
+    config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
-    mut displayed_workspace: Local<Option<(Entity, u32)>>,
 ) {
     let Some(mut menu_bar) = menu_bar else {
         return;
     };
-    let Some((entity, strip)) = active_workspace.iter().next() else {
+    let Some((_, strip)) = active_workspace.iter().next() else {
         return;
     };
 
-    let next = (entity, strip.virtual_index);
-    if displayed_workspace
-        .as_ref()
-        .is_some_and(|displayed| *displayed == next)
-    {
-        return;
-    }
+    let focused_width_ratio = active_display
+        .iter()
+        .next()
+        .zip(focused.iter().next())
+        .and_then(|((display, dock), (bounds, unmanaged))| {
+            (!unmanaged).then(|| {
+                f64::from(bounds.0.x)
+                    / f64::from(display.actual_display_bounds(dock, &config).width())
+            })
+        });
 
-    menu_bar.show_virtual_workspace(strip.virtual_index);
-    *displayed_workspace = Some(next);
+    menu_bar.update(
+        strip.virtual_index,
+        config.workspace_menu_status(),
+        &config.preset_column_widths(),
+        focused_width_ratio,
+    );
 }
 
 pub(crate) fn format_virtual_workspace_label(virtual_index: u32) -> String {
     format!("VW {}", virtual_index + 1)
 }
 
+fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
+    let mut percentages = widths
+        .iter()
+        .copied()
+        .filter(|ratio| ratio.is_finite() && *ratio > 0.0)
+        .map(|ratio| ratio.mul_add(100.0, 0.0).round() as i32)
+        .filter(|percentage| *percentage > 0)
+        .collect::<Vec<_>>();
+    percentages.sort_unstable();
+    percentages.dedup();
+    percentages
+}
+
 #[cfg(test)]
 mod tests {
-    use super::format_virtual_workspace_label;
+    use super::{format_virtual_workspace_label, normalized_width_percentages};
 
     #[test]
     fn label_is_one_based() {
         assert_eq!(format_virtual_workspace_label(0), "VW 1");
         assert_eq!(format_virtual_workspace_label(4), "VW 5");
+    }
+
+    #[test]
+    fn menu_widths_are_sorted_deduplicated_and_valid() {
+        assert_eq!(
+            normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
+            vec![50, 150, 200]
+        );
     }
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -4,8 +4,8 @@ use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
 use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
 use objc2_app_kit::{
-    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSStatusBar,
-    NSStatusItem, NSVariableStatusItemLength,
+    NSColor, NSControlStateValueOff, NSControlStateValueOn, NSEventModifierFlags, NSMenu,
+    NSMenuItem, NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
 };
 use objc2_core_foundation::CGFloat;
 use objc2_foundation::{NSObject, NSString};
@@ -19,6 +19,7 @@ use crate::ecs::{
 };
 use crate::events::{Event, EventSender};
 use crate::manager::Display;
+use crate::platform::Modifiers;
 
 #[derive(Debug, Clone)]
 struct MenuActionTargetIvars {
@@ -83,6 +84,7 @@ pub struct MenuBarManager {
     managed_window_items: Vec<Retained<NSMenuItem>>,
     manage_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
+    configured_shortcuts: MenuShortcuts,
     current_label: Option<String>,
 }
 
@@ -93,6 +95,20 @@ const STATUS_ITEM_CORNER_RADIUS: CGFloat = 5.0;
 struct WindowMenuEnablement {
     managed_actions: bool,
     toggle_managed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MenuShortcut {
+    key: String,
+    modifiers: u8,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct MenuShortcuts {
+    widths: Vec<(i32, Option<MenuShortcut>)>,
+    center: Option<MenuShortcut>,
+    manage: Option<MenuShortcut>,
+    quit: Option<MenuShortcut>,
 }
 
 fn window_menu_enablement(
@@ -126,21 +142,23 @@ impl MenuBarManager {
             managed_window_items: Vec::new(),
             manage_item: None,
             configured_widths: Vec::new(),
+            configured_shortcuts: MenuShortcuts::default(),
             current_label: None,
         }
     }
 
-    pub fn update(
+    fn update(
         &mut self,
         virtual_index: u32,
         show_virtual_workspace: bool,
         preset_widths: &[f64],
         has_focused_window: bool,
         focused_width_ratio: Option<f64>,
+        shortcuts: &MenuShortcuts,
     ) {
         let widths = normalized_width_percentages(preset_widths);
-        if self.configured_widths != widths {
-            self.rebuild_menu(&widths);
+        if self.configured_widths != widths || self.configured_shortcuts != *shortcuts {
+            self.rebuild_menu(&widths, shortcuts);
         }
 
         let enablement = window_menu_enablement(has_focused_window, focused_width_ratio);
@@ -168,37 +186,60 @@ impl MenuBarManager {
         self.show_label(label);
     }
 
-    fn rebuild_menu(&mut self, widths: &[i32]) {
+    fn rebuild_menu(&mut self, widths: &[i32], shortcuts: &MenuShortcuts) {
         self.menu.removeAllItems();
         self.width_items.clear();
         self.managed_window_items.clear();
         self.manage_item = None;
 
-        let status = self.add_item("Paneru — Running", None);
+        let status = self.add_item("Paneru — Running", None, None);
         status.setEnabled(false);
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
 
-        let width_header = self.add_item("Window width", None);
+        let width_header = self.add_item("Window width", None, None);
         width_header.setEnabled(false);
         for &percentage in widths {
-            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)));
+            let shortcut = shortcuts
+                .widths
+                .iter()
+                .find_map(|(width, shortcut)| (*width == percentage).then_some(shortcut))
+                .and_then(Option::as_ref);
+            let item = self.add_item(&format!("{percentage}%"), Some(sel!(setWidth:)), shortcut);
             item.setTag(isize::try_from(percentage).expect("width percentage fits in isize"));
             self.managed_window_items.push(item.clone());
             self.width_items.push((percentage, item));
         }
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
-        let center = self.add_item("Center Window", Some(sel!(centerWindow:)));
-        let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
+        let center = self.add_item(
+            "Center Window",
+            Some(sel!(centerWindow:)),
+            shortcuts.center.as_ref(),
+        );
+        let manage = self.add_item(
+            "Toggle Managed",
+            Some(sel!(toggleManaged:)),
+            shortcuts.manage.as_ref(),
+        );
         self.managed_window_items.push(center);
         self.manage_item = Some(manage);
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
-        self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
+        self.add_item(
+            "Quit Paneru",
+            Some(sel!(quitPaneru:)),
+            shortcuts.quit.as_ref(),
+        );
         self.configured_widths = widths.to_vec();
+        self.configured_shortcuts = shortcuts.clone();
     }
 
-    fn add_item(&self, title: &str, action: Option<objc2::runtime::Sel>) -> Retained<NSMenuItem> {
+    fn add_item(
+        &self,
+        title: &str,
+        action: Option<objc2::runtime::Sel>,
+        shortcut: Option<&MenuShortcut>,
+    ) -> Retained<NSMenuItem> {
         let item = unsafe {
             self.menu.addItemWithTitle_action_keyEquivalent(
                 &NSString::from_str(title),
@@ -208,6 +249,10 @@ impl MenuBarManager {
         };
         if action.is_some() {
             unsafe { item.setTarget(Some(&self.action_target)) };
+        }
+        if let Some(shortcut) = shortcut {
+            item.setKeyEquivalent(&NSString::from_str(&shortcut.key));
+            item.setKeyEquivalentModifierMask(native_modifier_flags(shortcut.modifiers));
         }
         item
     }
@@ -270,12 +315,15 @@ pub fn update_menu_bar(
         },
     );
 
+    let preset_widths = config.preset_column_widths();
+    let shortcuts = menu_shortcuts(&config, &preset_widths);
     menu_bar.update(
         strip.virtual_index,
         config.workspace_menu_status(),
-        &config.preset_column_widths(),
+        &preset_widths,
         focused_window.is_some(),
         focused_width_ratio,
+        &shortcuts,
     );
 }
 
@@ -296,12 +344,88 @@ fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
     percentages
 }
 
+fn menu_shortcuts(config: &Config, widths: &[f64]) -> MenuShortcuts {
+    let widths = normalized_width_percentages(widths)
+        .into_iter()
+        .map(|percentage| {
+            let command_name = format!("window_width_{percentage}");
+            (
+                percentage,
+                config
+                    .first_keybinding(&command_name)
+                    .and_then(|binding| menu_shortcut(&binding.key, binding.modifiers)),
+            )
+        })
+        .collect();
+
+    let shortcut = |command_name| {
+        config
+            .first_keybinding(command_name)
+            .and_then(|binding| menu_shortcut(&binding.key, binding.modifiers))
+    };
+
+    MenuShortcuts {
+        widths,
+        center: shortcut("window_center"),
+        manage: shortcut("window_manage"),
+        quit: shortcut("quit"),
+    }
+}
+
+fn menu_shortcut(key: &str, modifiers: Modifiers) -> Option<MenuShortcut> {
+    let key = match key {
+        "equal" => "=",
+        "minus" => "-",
+        "rightbracket" => "]",
+        "leftbracket" => "[",
+        "quote" => "'",
+        "semicolon" => ";",
+        "backslash" => "\\",
+        "comma" => ",",
+        "slash" => "/",
+        "period" => ".",
+        "grave" => "`",
+        "return" | "keypadenter" => "\r",
+        "tab" => "\t",
+        "space" => " ",
+        "delete" => "\u{8}",
+        "escape" => "\u{1b}",
+        key if key.chars().count() == 1 => key,
+        _ => return None,
+    };
+
+    Some(MenuShortcut {
+        key: key.to_owned(),
+        modifiers: modifiers.bits(),
+    })
+}
+
+fn native_modifier_flags(modifier_bits: u8) -> NSEventModifierFlags {
+    let modifiers = Modifiers::from_bits_retain(modifier_bits);
+    let mut flags = NSEventModifierFlags::empty();
+    if modifiers.intersects(Modifiers::SHIFT) {
+        flags |= NSEventModifierFlags::Shift;
+    }
+    if modifiers.intersects(Modifiers::CTRL) {
+        flags |= NSEventModifierFlags::Control;
+    }
+    if modifiers.intersects(Modifiers::ALT) {
+        flags |= NSEventModifierFlags::Option;
+    }
+    if modifiers.intersects(Modifiers::CMD) {
+        flags |= NSEventModifierFlags::Command;
+    }
+    flags
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        WindowMenuEnablement, format_virtual_workspace_label, normalized_width_percentages,
-        window_menu_enablement,
+        WindowMenuEnablement, format_virtual_workspace_label, menu_shortcut, menu_shortcuts,
+        normalized_width_percentages, window_menu_enablement,
     };
+    use crate::config::Config;
+    use crate::platform::Modifiers;
 
     #[test]
     fn label_is_one_based() {
@@ -314,6 +438,48 @@ mod tests {
         assert_eq!(
             normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
             vec![50, 150, 200]
+        );
+    }
+
+    #[test]
+    fn menu_shortcut_uses_native_key_and_preserves_modifiers() {
+        let shortcut = menu_shortcut("1", Modifiers::LCTRL | Modifiers::RALT | Modifiers::LCMD)
+            .expect("shortcut should be representable");
+        assert_eq!(shortcut.key, "1");
+        assert_eq!(
+            shortcut.modifiers,
+            (Modifiers::LCTRL | Modifiers::RALT | Modifiers::LCMD).bits()
+        );
+    }
+
+    #[test]
+    fn menu_shortcuts_come_from_command_bindings() {
+        let config = Config::try_from(
+            r#"
+[options]
+
+[bindings]
+window_width_150 = "ctrl+alt+cmd-4"
+window_center = "ctrl+alt+cmd-c"
+"#,
+        )
+        .expect("bindings should parse");
+
+        let shortcuts = menu_shortcuts(&config, &[1.0, 1.5]);
+        assert_eq!(shortcuts.widths[0], (100, None));
+        assert_eq!(
+            shortcuts.widths[1]
+                .1
+                .as_ref()
+                .map(|shortcut| shortcut.key.as_str()),
+            Some("4")
+        );
+        assert_eq!(
+            shortcuts
+                .center
+                .as_ref()
+                .map(|shortcut| shortcut.key.as_str()),
+            Some("c")
         );
     }
 

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -100,7 +100,7 @@ struct WindowMenuEnablement {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct MenuShortcut {
     key: String,
-    modifiers: u8,
+    modifiers: u16,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -400,7 +400,7 @@ fn menu_shortcut(key: &str, modifiers: Modifiers) -> Option<MenuShortcut> {
     })
 }
 
-fn native_modifier_flags(modifier_bits: u8) -> NSEventModifierFlags {
+fn native_modifier_flags(modifier_bits: u16) -> NSEventModifierFlags {
     let modifiers = Modifiers::from_bits_retain(modifier_bits);
     let mut flags = NSEventModifierFlags::empty();
     if modifiers.intersects(Modifiers::SHIFT) {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -48,7 +48,7 @@ pub type WorkspaceId = u64;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq)]
-    pub struct Modifiers: u8 {
+    pub struct Modifiers: u16 {
         const LALT   = 1 << 0;
         const RALT   = 1 << 1;
         const LSHIFT = 1 << 2;
@@ -57,6 +57,7 @@ bitflags::bitflags! {
         const RCMD   = 1 << 5;
         const LCTRL  = 1 << 6;
         const RCTRL  = 1 << 7;
+        const FN     = 1 << 8;
         const ALT   = Self::LALT.bits() | Self::RALT.bits();
         const SHIFT = Self::LSHIFT.bits() | Self::RSHIFT.bits();
         const CMD   = Self::LCMD.bits() | Self::RCMD.bits();
@@ -264,11 +265,12 @@ impl Modifiers {
     ///   - If the binding requires the group, the event must have at least one matching side bit.
     ///   - If the binding does NOT require the group, the event must not have any bits from that group.
     pub fn matches(self, event: Modifiers) -> bool {
-        const GROUPS: [Modifiers; 4] = [
+        const GROUPS: [Modifiers; 5] = [
             Modifiers::ALT,
             Modifiers::SHIFT,
             Modifiers::CMD,
             Modifiers::CTRL,
+            Modifiers::FN,
         ];
 
         for group in GROUPS {
@@ -324,6 +326,7 @@ mod tests {
         assert!(!Modifiers::empty().matches(Modifiers::RSHIFT));
         assert!(!Modifiers::empty().matches(Modifiers::LCMD));
         assert!(!Modifiers::empty().matches(Modifiers::RCTRL));
+        assert!(!Modifiers::empty().matches(Modifiers::FN));
     }
 
     #[test]
@@ -347,6 +350,7 @@ mod tests {
         let want_alt = Modifiers::ALT;
         assert!(!want_alt.matches(Modifiers::LALT | Modifiers::LSHIFT));
         assert!(!want_alt.matches(Modifiers::LALT | Modifiers::LCTRL));
+        assert!(!want_alt.matches(Modifiers::LALT | Modifiers::FN));
     }
 
     #[test]
@@ -378,11 +382,36 @@ mod tests {
     }
 
     #[test]
-    fn matches_all_four_groups() {
-        let all = Modifiers::ALT | Modifiers::SHIFT | Modifiers::CMD | Modifiers::CTRL;
+    fn matches_all_five_groups() {
+        let all =
+            Modifiers::ALT | Modifiers::SHIFT | Modifiers::CMD | Modifiers::CTRL | Modifiers::FN;
+        assert!(all.matches(
+            Modifiers::LALT
+                | Modifiers::RSHIFT
+                | Modifiers::LCMD
+                | Modifiers::RCTRL
+                | Modifiers::FN
+        ));
         assert!(
-            all.matches(Modifiers::LALT | Modifiers::RSHIFT | Modifiers::LCMD | Modifiers::RCTRL)
+            !all.matches(Modifiers::LALT | Modifiers::LSHIFT | Modifiers::LCMD | Modifiers::FN)
         );
-        assert!(!all.matches(Modifiers::LALT | Modifiers::LSHIFT | Modifiers::LCMD));
+    }
+
+    #[test]
+    fn matches_fn_modifier() {
+        let want_fn = Modifiers::FN;
+        assert!(want_fn.matches(Modifiers::FN));
+        assert!(!want_fn.matches(Modifiers::empty()));
+        assert!(!want_fn.matches(Modifiers::LALT | Modifiers::FN));
+    }
+
+    #[test]
+    fn matches_fn_combined_with_other_groups() {
+        let fn_alt = Modifiers::FN | Modifiers::ALT;
+        assert!(fn_alt.matches(Modifiers::FN | Modifiers::LALT));
+        assert!(fn_alt.matches(Modifiers::FN | Modifiers::RALT));
+        assert!(!fn_alt.matches(Modifiers::FN));
+        assert!(!fn_alt.matches(Modifiers::LALT));
+        assert!(!fn_alt.matches(Modifiers::FN | Modifiers::LALT | Modifiers::LSHIFT));
     }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,25 +1,28 @@
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use accessibility_sys::{AXError, AXObserverRef, AXUIElementRef};
 use objc2::MainThreadMarker;
 use objc2::rc::{Retained, autoreleasepool};
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSEventMask};
-use objc2_core_foundation::CFString;
+use objc2_core_foundation::{CFRunLoop, CFString, kCFRunLoopDefaultMode};
 use objc2_foundation::{NSDate, NSDefaultRunLoopMode, NSProcessInfo};
 use std::ffi::c_void;
+use std::marker::PhantomData;
 use std::pin::Pin;
+use std::rc::Rc;
 use tracing::error;
 
 use crate::config::{CONFIGURATION_FILE, Config};
 use crate::errors::{Error, Result};
-use crate::events::{Event, EventSender};
+use crate::events::{Event, EventSender, EventWakeSource};
 use crate::manager::{check_ax_privilege, check_separate_spaces};
 use crate::platform::display::PinnedDisplayHandler;
 use crate::platform::input::PinnedInputHandler;
 use crate::platform::notify::{NotifyHandler, PinnedNotifyHandler};
 use crate::platform::process::PinnedProcessHandler;
 use display::DisplayHandler;
-use input::InputHandler;
+use input::{InputHandler, RunningInputMask};
 use mission_control::MissionControlHandler;
 use process::ProcessHandler;
 pub use process::ProcessSerialNumber;
@@ -45,6 +48,22 @@ pub type Pid = i32;
 pub type CFStringRef = *const CFString;
 
 pub type WorkspaceId = u64;
+
+/// Capability proving that a Bevy system is executing in the AppKit/AX owner
+/// world. It is deliberately `!Send`/`!Sync` and can only be constructed from
+/// a `MainThreadMarker` in production.
+pub struct AxMainThread(PhantomData<Rc<()>>);
+
+impl AxMainThread {
+    pub(crate) fn new(_: MainThreadMarker) -> Self {
+        Self(PhantomData)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_tests() -> Self {
+        Self(PhantomData)
+    }
+}
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq)]
@@ -142,10 +161,12 @@ pub struct PlatformCallbacks {
     cocoa_app: Retained<NSApplication>,
     /// The main `EventSender` for dispatching events across the application.
     events: EventSender,
+    _event_wake: EventWakeSource,
     /// Handler for Carbon process events.
     process_handler: Option<PinnedProcessHandler>,
     /// Handler for low-level input events (keyboard, mouse, gestures).
     event_handler: Option<PinnedInputHandler>,
+    input_mask: Option<RunningInputMask>,
     /// Observer for `NSWorkspace` and distributed notifications.
     workspace_observer: Retained<WorkspaceObserver>,
     /// Handler for Mission Control accessibility events.
@@ -179,16 +200,21 @@ impl PlatformCallbacks {
         NSApplication::load();
 
         let workspace_observer = WorkspaceObserver::new(events.clone());
+        let event_wake = events
+            .install_main_run_loop_source()
+            .expect("main CFRunLoop source should be available");
         Box::pin(PlatformCallbacks {
             main_thread_marker,
             cocoa_app,
             process_handler: None,
             event_handler: None,
+            input_mask: None,
             workspace_observer,
             mission_control_observer: MissionControlHandler::new(events.clone()),
             display_handler: None,
             notify_handler: None,
             events,
+            _event_wake: event_wake,
         })
     }
 
@@ -221,6 +247,7 @@ impl PlatformCallbacks {
 
         let config = Config::new(CONFIGURATION_FILE.as_path())?;
         self.events.send(Event::InitialConfig(config.clone()))?;
+        self.input_mask = Some(RunningInputMask::new(&config));
         self.event_handler = Some(InputHandler::new(self.events.clone(), config).start()?);
 
         self.notify_handler = Some(NotifyHandler::new(self.events.clone()).start()?);
@@ -234,17 +261,47 @@ impl PlatformCallbacks {
         self.events.send(Event::ProcessesLoaded)
     }
 
-    pub fn pump_cocoa_event_loop(&mut self, timeout: f64) {
-        autoreleasepool(|_| {
-            let until_date = NSDate::dateWithTimeIntervalSinceNow(timeout);
+    /// Rebuilds the event tap after a successful config reload. The new tap is
+    /// created before replacing the old guard, so a creation failure preserves
+    /// the currently running handler and all existing hotkeys.
+    pub fn reconfigure_input_handler(&mut self, config: &Config) -> Result<bool> {
+        let transition = self
+            .input_mask
+            .unwrap_or_else(|| RunningInputMask::new(config))
+            .transition(config);
+        let replacement = InputHandler::new(self.events.clone(), config.clone()).start()?;
+        self.event_handler = Some(replacement);
+        let mask = self
+            .input_mask
+            .get_or_insert_with(|| RunningInputMask::new(config));
+        mask.commit(transition);
+        Ok(transition.changed())
+    }
 
-            // nextEventMatchingMask:untilDate:inMode:dequeue:
-            // This is the core of the Cocoa event loop.
+    pub fn pump_cocoa_event_loop(&mut self, timeout: Option<Duration>) {
+        autoreleasepool(|_| {
+            // Drain already queued AppKit events before sleeping. Channel
+            // events are drained by ECS first; their custom run-loop source is
+            // latched, so a signal between that drain and `run_in_mode` cannot
+            // be lost.
+            self.dispatch_pending_cocoa_events();
+            let seconds = timeout.map_or(f64::MAX, |duration| duration.as_secs_f64());
+            CFRunLoop::run_in_mode(unsafe { kCFRunLoopDefaultMode }, seconds, true);
+            self.dispatch_pending_cocoa_events();
+
+            // Housekeeping for UI/Notifications
+            self.cocoa_app.updateWindows();
+        });
+    }
+
+    fn dispatch_pending_cocoa_events(&self) {
+        let poll_date = NSDate::distantPast();
+        autoreleasepool(|_| {
             while let Some(event) = unsafe {
                 self.cocoa_app
                     .nextEventMatchingMask_untilDate_inMode_dequeue(
                         NSEventMask::Any,
-                        Some(&until_date),
+                        Some(&poll_date),
                         NSDefaultRunLoopMode,
                         true, // Dequeue so we can handle it
                     )
@@ -252,9 +309,6 @@ impl PlatformCallbacks {
                 // Dispatch the event to the system
                 self.cocoa_app.sendEvent(&event);
             }
-
-            // Housekeeping for UI/Notifications
-            self.cocoa_app.updateWindows();
         });
     }
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -2,7 +2,7 @@ use arc_swap::ArcSwap;
 use core::ptr::NonNull;
 use objc2::msg_send;
 use objc2::rc::Retained;
-use objc2_app_kit::{NSEvent, NSEventType, NSTouch, NSTouchPhase};
+use objc2_app_kit::{NSEvent, NSEventPhase, NSEventType, NSTouch, NSTouchPhase};
 use objc2_core_foundation::{CFMachPort, CFRetained, CFRunLoop, kCFRunLoopCommonModes};
 use objc2_core_graphics::{
     CGEvent, CGEventField, CGEventFlags, CGEventTapLocation, CGEventTapOptions,
@@ -278,6 +278,11 @@ impl InputHandler {
         }
 
         if let Some(events) = &self.events {
+            let (gesture_began, physical_ended, momentum_began, gesture_ended) =
+                NSEvent::eventWithCGEvent(event)
+                    .as_deref()
+                    .map(|event| scroll_gesture_lifecycle(event.phase(), event.momentumPhase()))
+                    .unwrap_or_default();
             let h_delta = CGEvent::double_value_field(
                 Some(event),
                 CGEventField::ScrollWheelEventFixedPtDeltaAxis2,
@@ -295,6 +300,19 @@ impl InputHandler {
                 return true;
             }
 
+            // Exact AppKit phases are available for trackpads. Mouse wheels
+            // and other phase-less devices continue to use the ECS inactivity
+            // fallback instead.
+            if base_match && gesture_began {
+                _ = events.send(Event::TouchpadDown);
+            }
+            if base_match && physical_ended {
+                _ = events.send(Event::TouchpadPhysicalUp);
+            }
+            if base_match && momentum_began {
+                _ = events.send(Event::TouchpadMomentumStart);
+            }
+
             // If we have any horizontal delta, or if there's only vertical delta, use it.
             let delta = if h_delta.abs() > 0.001 {
                 h_delta
@@ -304,8 +322,17 @@ impl InputHandler {
                 0.0
             };
 
-            if delta.abs() > 0.001 {
+            let has_delta = delta.abs() > 0.001;
+            if has_delta {
                 _ = events.send(Event::Scroll { delta });
+            }
+            if base_match && gesture_ended {
+                _ = events.send(Event::TouchpadUp);
+            }
+            if has_delta
+                || (base_match
+                    && (gesture_began || physical_ended || momentum_began || gesture_ended))
+            {
                 return true; // Intercept: don't let the window scroll
             }
         }
@@ -315,9 +342,6 @@ impl InputHandler {
     /// Handles swipe gesture events. Routes to horizontal `Swipe` or vertical
     /// `VerticalSwipe` based on axis dominance. Returns true to intercept the event.
     fn handle_swipe(&mut self, event: &CGEvent) -> bool {
-        const NS_EVENT_PHASE_ENDED: usize = 1 << 3; // 8
-        const NS_EVENT_PHASE_CANCELLED: usize = 1 << 4; // 16
-
         let Some(configured_fingers) = self
             .config
             .swipe_gesture_fingers()
@@ -337,7 +361,7 @@ impl InputHandler {
 
         // Fingers lifted off touchpad.
         let phase = ns_event.phase();
-        if (phase.0 & NS_EVENT_PHASE_CANCELLED != 0 || phase.0 & NS_EVENT_PHASE_ENDED != 0)
+        if phase.intersects(NSEventPhase::Ended | NSEventPhase::Cancelled)
             && let Some(events) = &self.events
         {
             _ = events.send(Event::TouchpadUp);
@@ -463,6 +487,20 @@ fn gesture_should_intercept(configured_fingers: Option<usize>, actual_fingers: u
     configured_fingers.is_some_and(|configured| {
         configured >= GESTURE_MINIMAL_FINGERS && configured == actual_fingers
     })
+}
+
+fn scroll_gesture_lifecycle(
+    phase: NSEventPhase,
+    momentum_phase: NSEventPhase,
+) -> (bool, bool, bool, bool) {
+    // Momentum belongs to the physical gesture that preceded it. Treating its
+    // begin as a new gesture would recapture the paging stop and allow a
+    // second hop from one finger movement.
+    let began = phase.contains(NSEventPhase::Began);
+    let physical_ended = phase.intersects(NSEventPhase::Ended | NSEventPhase::Cancelled);
+    let momentum_began = momentum_phase.contains(NSEventPhase::Began);
+    let momentum_ended = momentum_phase.intersects(NSEventPhase::Ended | NSEventPhase::Cancelled);
+    (began, physical_ended, momentum_began, momentum_ended)
 }
 
 fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
@@ -604,5 +642,36 @@ mod tests {
         assert!(gesture_should_intercept(Some(3), 3));
         assert!(!gesture_should_intercept(Some(4), 3));
         assert!(gesture_should_intercept(Some(4), 4));
+    }
+
+    #[test]
+    fn native_scroll_lifecycle_covers_touch_and_momentum_phases() {
+        assert_eq!(
+            scroll_gesture_lifecycle(NSEventPhase::Began, NSEventPhase::None),
+            (true, false, false, false)
+        );
+        assert_eq!(
+            scroll_gesture_lifecycle(NSEventPhase::Ended, NSEventPhase::None),
+            (false, true, false, false)
+        );
+        assert_eq!(
+            scroll_gesture_lifecycle(NSEventPhase::None, NSEventPhase::Began),
+            (false, false, true, false),
+            "momentum must continue the existing physical gesture"
+        );
+        assert_eq!(
+            scroll_gesture_lifecycle(NSEventPhase::None, NSEventPhase::Ended),
+            (false, false, false, true)
+        );
+        assert_eq!(
+            scroll_gesture_lifecycle(NSEventPhase::Ended, NSEventPhase::Began),
+            (false, true, true, false),
+            "momentum beginning in the same event must keep the gesture active"
+        );
+        assert_eq!(
+            scroll_gesture_lifecycle(NSEventPhase::Ended, NSEventPhase::Changed),
+            (false, true, false, false),
+            "physical end must not end the full gesture while momentum continues"
+        );
     }
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -318,20 +318,20 @@ impl InputHandler {
         const NS_EVENT_PHASE_ENDED: usize = 1 << 3; // 8
         const NS_EVENT_PHASE_CANCELLED: usize = 1 << 4; // 16
 
+        let Some(configured_fingers) = self
+            .config
+            .swipe_gesture_fingers()
+            .filter(|fingers| *fingers >= GESTURE_MINIMAL_FINGERS)
+        else {
+            // No valid gesture is configured, so leave native macOS gestures alone.
+            return false;
+        };
+
         let Some(ns_event) = NSEvent::eventWithCGEvent(event) else {
             error!("{}: Unable to convert CGEvent to NSEvent", function_name!());
             return false;
         };
         if ns_event.r#type() != NSEventType::Gesture {
-            return false;
-        }
-
-        if self
-            .config
-            .swipe_gesture_fingers()
-            .is_some_and(|fingers| fingers < GESTURE_MINIMAL_FINGERS)
-        {
-            // Swipe is disabled, do not intercept the event.
             return false;
         }
 
@@ -345,6 +345,9 @@ impl InputHandler {
         }
 
         let fingers = ns_event.allTouches();
+        if !gesture_should_intercept(Some(configured_fingers), fingers.len()) {
+            return false;
+        }
         if fingers.iter().any(|f| f.phase() == NSTouchPhase::Began)
             && let Some(events) = &self.events
         {
@@ -454,6 +457,12 @@ impl InputHandler {
             })
             .is_some()
     }
+}
+
+fn gesture_should_intercept(configured_fingers: Option<usize>, actual_fingers: usize) -> bool {
+    configured_fingers.is_some_and(|configured| {
+        configured >= GESTURE_MINIMAL_FINGERS && configured == actual_fingers
+    })
 }
 
 fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
@@ -582,10 +591,18 @@ mod tests {
         let generic_alt: u64 = 0x0008_0000;
         assert_eq!(get_modifiers(CGEventFlags(generic_alt)), Modifiers::empty());
     }
-
     #[test]
     fn secondary_fn_flag_is_not_ignored() {
         // Ensure we don't accidentally filter out the fn mask as "device independent"
         assert_eq!(get_modifiers(CGEventFlags(0x0080_0000)), Modifiers::FN);
+    }
+
+    #[test]
+    fn only_intercepts_the_explicitly_configured_gesture() {
+        assert!(!gesture_should_intercept(None, 3));
+        assert!(!gesture_should_intercept(Some(2), 2));
+        assert!(gesture_should_intercept(Some(3), 3));
+        assert!(!gesture_should_intercept(Some(4), 3));
+        assert!(gesture_should_intercept(Some(4), 4));
     }
 }

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -42,6 +42,91 @@ const VERTICAL_GESTURE_SCROLL_SUPPRESS: Duration = Duration::from_millis(1200);
 const SWIPE_THRESHOLD: f64 = 0.001;
 const GESTURE_MINIMAL_FINGERS: usize = 3;
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct InputEventMaskPolicy {
+    mouse_move: bool,
+    mouse_buttons: bool,
+    mouse_drag: bool,
+    scroll: bool,
+    gesture: bool,
+    key_down: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct InputMaskTransition {
+    previous: u64,
+    next: u64,
+}
+
+impl InputMaskTransition {
+    pub(super) fn changed(self) -> bool {
+        self.previous != self.next
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RunningInputMask(u64);
+
+impl RunningInputMask {
+    pub(super) fn new(config: &Config) -> Self {
+        Self(InputEventMaskPolicy::from_config(config).mask())
+    }
+
+    pub(super) fn transition(self, config: &Config) -> InputMaskTransition {
+        InputMaskTransition {
+            previous: self.0,
+            next: InputEventMaskPolicy::from_config(config).mask(),
+        }
+    }
+
+    pub(super) fn commit(&mut self, transition: InputMaskTransition) {
+        self.0 = transition.next;
+    }
+}
+
+impl InputEventMaskPolicy {
+    fn from_config(config: &Config) -> Self {
+        let mouse_resize = config.mouse_resize_modifier().is_some();
+        Self {
+            mouse_move: config.focus_follows_mouse()
+                || config.horizontal_mouse_warp().is_some()
+                || mouse_resize,
+            // Click-to-reveal is enabled whenever some hidden fraction should
+            // force a managed window back into view.
+            mouse_buttons: config.window_hidden_ratio() < 1.0,
+            // No ECS system consumes MouseDragged; subscribing only burns tap
+            // callbacks during drags.
+            mouse_drag: false,
+            scroll: true,
+            gesture: config
+                .swipe_gesture_fingers()
+                .is_some_and(|fingers| fingers >= GESTURE_MINIMAL_FINGERS),
+            key_down: true,
+        }
+    }
+
+    fn mask(self) -> u64 {
+        let mut mask = 0;
+        let mut add = |enabled: bool, event: usize| {
+            if enabled {
+                mask |= 1_u64 << event;
+            }
+        };
+        add(self.mouse_move, CGEventType::MouseMoved.0 as usize);
+        add(self.mouse_buttons, CGEventType::LeftMouseDown.0 as usize);
+        add(self.mouse_buttons, CGEventType::LeftMouseUp.0 as usize);
+        add(self.mouse_buttons, CGEventType::RightMouseDown.0 as usize);
+        add(self.mouse_buttons, CGEventType::RightMouseUp.0 as usize);
+        add(self.mouse_drag, CGEventType::LeftMouseDragged.0 as usize);
+        add(self.mouse_drag, CGEventType::RightMouseDragged.0 as usize);
+        add(self.scroll, CGEventType::ScrollWheel.0 as usize);
+        add(self.gesture, NSEventType::Gesture.0);
+        add(self.key_down, CGEventType::KeyDown.0 as usize);
+        mask
+    }
+}
+
 /// `InputHandler` manages low-level input events from the macOS `CGEventTap`.
 /// It intercepts keyboard and mouse events, processes gestures, and dispatches them as higher-level `Event`s.
 pub(super) struct InputHandler {
@@ -92,16 +177,7 @@ impl InputHandler {
     ///
     /// `Ok(())` if the event tap is created and started successfully, otherwise `Err(Error)`.
     pub(super) fn start(self) -> Result<PinnedInputHandler> {
-        let mouse_event_mask = (1 << CGEventType::MouseMoved.0)
-            | (1 << CGEventType::LeftMouseDown.0)
-            | (1 << CGEventType::LeftMouseUp.0)
-            | (1 << CGEventType::LeftMouseDragged.0)
-            | (1 << CGEventType::RightMouseDown.0)
-            | (1 << CGEventType::RightMouseUp.0)
-            | (1 << CGEventType::RightMouseDragged.0)
-            | (1 << CGEventType::ScrollWheel.0)
-            | (1 << NSEventType::Gesture.0)
-            | (1 << CGEventType::KeyDown.0);
+        let event_mask = InputEventMaskPolicy::from_config(&self.config).mask();
 
         let mut pinned = Box::pin(self);
         let this = unsafe { NonNull::new_unchecked(pinned.as_mut().get_unchecked_mut()) }.as_ptr();
@@ -110,7 +186,7 @@ impl InputHandler {
                 CGEventTapLocation::HIDEventTap,
                 CGEventTapPlacement::HeadInsertEventTap,
                 CGEventTapOptions::Default,
-                mouse_event_mask,
+                event_mask,
                 Some(Self::callback),
                 this.cast(),
             );
@@ -537,6 +613,94 @@ mod tests {
     const NX_DEVICELCTLKEYMASK: u64 = 0x0000_0001;
     const NX_DEVICERCTLKEYMASK: u64 = 0x0000_2000;
     const NX_DEVICEFNKEYMASK: u64 = 0x0080_0000;
+
+    fn manual_config() -> Config {
+        Config::try_from(
+            r#"
+[options]
+focus_follows_mouse = false
+mouse_follows_focus = false
+
+[swipe.scroll]
+modifier = "alt"
+
+[bindings]
+"#,
+        )
+        .unwrap()
+    }
+
+    fn feature_config() -> Config {
+        Config::try_from(
+            r"
+[options]
+focus_follows_mouse = true
+window_hidden_ratio = 1.0
+
+[swipe.gesture]
+fingers_count = 3
+
+[bindings]
+",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn manual_use_case_avoids_move_drag_and_gesture_callbacks() {
+        let config = manual_config();
+        let policy = InputEventMaskPolicy::from_config(&config);
+        assert!(!policy.mouse_move);
+        assert!(!policy.mouse_drag);
+        assert!(!policy.gesture);
+        assert!(policy.mouse_buttons, "click-to-reveal remains enabled");
+        assert!(policy.scroll);
+        assert!(policy.key_down);
+    }
+
+    #[test]
+    fn feature_flags_add_only_required_mouse_and_gesture_events() {
+        let config = feature_config();
+        let policy = InputEventMaskPolicy::from_config(&config);
+        assert!(policy.mouse_move);
+        assert!(!policy.mouse_buttons);
+        assert!(!policy.mouse_drag);
+        assert!(policy.gesture);
+    }
+
+    #[test]
+    fn running_mask_reconciles_enable_and_disable_transitions() {
+        let manual = manual_config();
+        let features = feature_config();
+        let mut running = RunningInputMask::new(&manual);
+
+        let enabled = running.transition(&features);
+        assert!(enabled.changed());
+        running.commit(enabled);
+        assert_eq!(
+            running.0,
+            InputEventMaskPolicy::from_config(&features).mask()
+        );
+        assert_ne!(
+            running.0 & (1_u64 << CGEventType::MouseMoved.0),
+            0,
+            "enabling focus-follows-mouse must add mouse movement"
+        );
+        assert_ne!(
+            running.0 & (1_u64 << NSEventType::Gesture.0),
+            0,
+            "enabling gestures must add gesture callbacks"
+        );
+
+        let disabled = running.transition(&manual);
+        assert!(disabled.changed());
+        running.commit(disabled);
+        assert_eq!(running.0, InputEventMaskPolicy::from_config(&manual).mask());
+        assert_eq!(running.0 & (1_u64 << CGEventType::MouseMoved.0), 0);
+        assert_eq!(running.0 & (1_u64 << NSEventType::Gesture.0), 0);
+        assert_ne!(running.0 & (1_u64 << CGEventType::ScrollWheel.0), 0);
+        assert_ne!(running.0 & (1_u64 << CGEventType::KeyDown.0), 0);
+    }
 
     #[test]
     fn no_modifiers() {

--- a/src/platform/input.rs
+++ b/src/platform/input.rs
@@ -457,7 +457,7 @@ impl InputHandler {
 }
 
 fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
-    const MODIFIER_MASKS: [(Modifiers, u64); 8] = [
+    const MODIFIER_MASKS: [(Modifiers, u64); 9] = [
         (Modifiers::LALT, 0x0000_0020),
         (Modifiers::RALT, 0x0000_0040),
         (Modifiers::LSHIFT, 0x0000_0002),
@@ -466,6 +466,7 @@ fn get_modifiers(eventflags: CGEventFlags) -> Modifiers {
         (Modifiers::RCMD, 0x0000_0010),
         (Modifiers::LCTRL, 0x0000_0001),
         (Modifiers::RCTRL, 0x0000_2000),
+        (Modifiers::FN, 0x0080_0000),
     ];
     let mut mask = Modifiers::empty();
     for (modifier, m) in MODIFIER_MASKS {
@@ -488,10 +489,28 @@ mod tests {
     const NX_DEVICERCMDKEYMASK: u64 = 0x0000_0010;
     const NX_DEVICELCTLKEYMASK: u64 = 0x0000_0001;
     const NX_DEVICERCTLKEYMASK: u64 = 0x0000_2000;
+    const NX_DEVICEFNKEYMASK: u64 = 0x0080_0000;
 
     #[test]
     fn no_modifiers() {
         assert_eq!(get_modifiers(CGEventFlags(0)), Modifiers::empty());
+    }
+
+    #[test]
+    fn fn_modifier() {
+        assert_eq!(
+            get_modifiers(CGEventFlags(NX_DEVICEFNKEYMASK)),
+            Modifiers::FN
+        );
+    }
+
+    #[test]
+    fn fn_with_other_modifiers() {
+        let flags = NX_DEVICEFNKEYMASK | NX_DEVICELCMDKEYMASK | NX_DEVICELALTKEYMASK;
+        assert_eq!(
+            get_modifiers(CGEventFlags(flags)),
+            Modifiers::FN | Modifiers::LCMD | Modifiers::LALT
+        );
     }
 
     #[test]
@@ -562,5 +581,11 @@ mod tests {
     fn device_independent_flags_ignored() {
         let generic_alt: u64 = 0x0008_0000;
         assert_eq!(get_modifiers(CGEventFlags(generic_alt)), Modifiers::empty());
+    }
+
+    #[test]
+    fn secondary_fn_flag_is_not_ignored() {
+        // Ensure we don't accidentally filter out the fn mask as "device independent"
+        assert_eq!(get_modifiers(CGEventFlags(0x0080_0000)), Modifiers::FN);
     }
 }

--- a/src/tests/harness.rs
+++ b/src/tests/harness.rs
@@ -22,7 +22,7 @@ use crate::ecs::{
 };
 use crate::events::Event;
 use crate::manager::{Window, WindowManager};
-use crate::platform::{Pid, WinID, WorkspaceId};
+use crate::platform::{AxMainThread, Pid, WinID, WorkspaceId};
 
 use super::*;
 
@@ -227,6 +227,7 @@ fn setup_world() -> App {
         .insert_resource(FocusFollowsMouse(None))
         .insert_resource(Config::default())
         .insert_resource(Initializing)
+        .insert_non_send_resource(AxMainThread::for_tests())
         .add_plugins(MouseEventsPlugin)
         .add_plugins(ScrollEventsPlugin)
         .add_plugins(WorkspaceEventsPlugin)

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -6,8 +6,11 @@ use objc2_core_foundation::CGPoint;
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, Position, Scrolling, Unmanaged, layout::LayoutStrip};
-use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
+use crate::ecs::{
+    ActiveWorkspaceMarker, FocusedMarker, NativeFullscreenMarker, Position, Unmanaged,
+    layout::LayoutStrip,
+};
+use crate::ecs::{RepositionMarker, Scrolling, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
 use crate::platform::Modifiers;
@@ -31,6 +34,85 @@ fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
             assert!(scrolling.is_user_swiping);
         })
         .run(commands);
+}
+
+#[test]
+fn native_fullscreen_transition_removes_window_from_original_strip_without_focus_marker() {
+    const FULLSCREEN_WORKSPACE_ID: WorkspaceId = TEST_WORKSPACE_ID + 100;
+
+    TestHarness::new()
+        .with_windows(2)
+        .on_iteration(0, |world, state| {
+            let focused = world
+                .query_filtered::<Entity, With<FocusedMarker>>()
+                .iter(world)
+                .collect::<Vec<_>>();
+            for entity in focused {
+                world.entity_mut(entity).remove::<FocusedMarker>();
+            }
+
+            state.update_window(0, |window| {
+                window.workspace_id = FULLSCREEN_WORKSPACE_ID;
+                window.is_full_screen = true;
+            });
+            state.activate_workspace(TEST_DISPLAY_ID, FULLSCREEN_WORKSPACE_ID, true);
+        })
+        .on_iteration(1, |world, _state| {
+            let fullscreen_window = find_window_entity(0, world);
+            let sibling_window = find_window_entity(1, world);
+            let mut strips = world.query::<(&LayoutStrip, Option<&NativeFullscreenMarker>)>();
+
+            let original_strip = strips
+                .iter(world)
+                .find_map(|(strip, marker)| {
+                    (strip.id() == TEST_WORKSPACE_ID && marker.is_none()).then_some(strip)
+                })
+                .expect("original strip");
+            assert!(
+                !original_strip.contains(fullscreen_window),
+                "fullscreen window must not leave a reserved column in the original strip"
+            );
+            assert!(original_strip.contains(sibling_window));
+
+            let (fullscreen_strip, fullscreen_marker) = strips
+                .iter(world)
+                .find(|(strip, _)| strip.id() == FULLSCREEN_WORKSPACE_ID)
+                .expect("fullscreen strip");
+            assert!(fullscreen_strip.contains(fullscreen_window));
+            assert!(fullscreen_marker.is_some());
+        })
+        .on_iteration(2, |world, _state| {
+            let fullscreen_window = find_window_entity(0, world);
+            let sibling_window = find_window_entity(1, world);
+            let mut strips = world.query::<&LayoutStrip>();
+
+            let original_strip = strips
+                .iter(world)
+                .find(|strip| strip.id() == TEST_WORKSPACE_ID)
+                .expect("original strip");
+            assert!(original_strip.contains(fullscreen_window));
+            assert!(original_strip.contains(sibling_window));
+            assert_eq!(
+                original_strip
+                    .index_of(fullscreen_window)
+                    .expect("restored fullscreen window index"),
+                0
+            );
+            assert!(
+                strips
+                    .iter(world)
+                    .all(|strip| strip.id() != FULLSCREEN_WORKSPACE_ID)
+            );
+        })
+        .run(vec![
+            Event::Command {
+                command: Command::PrintState,
+            },
+            Event::SpaceChanged,
+            Event::SpaceDestroyed {
+                space_id: FULLSCREEN_WORKSPACE_ID,
+            },
+        ]);
 }
 
 #[test]

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -116,6 +116,24 @@ fn native_fullscreen_transition_removes_window_from_original_strip_without_focus
 }
 
 #[test]
+fn frontmost_floating_window_is_focused_after_setup() {
+    let mut params = WindowParams::new(".*", None);
+    params.floating = Some(true);
+    let config: Config = (MainOptions::default(), vec![params]).into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .with_focused_window(0)
+        .on_iteration(0, |world, _state| {
+            assert_focused!(world, 0);
+            let entity = find_window_entity(0, world);
+            assert!(world.entity(entity).contains::<Unmanaged>());
+        })
+        .run(vec![Event::MenuOpened { window_id: 0 }]);
+}
+
+#[test]
 fn test_dont_focus() {
     let commands = vec![
         Event::MenuOpened { window_id: 0 }, // 0

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -6,7 +6,7 @@ use objc2_core_foundation::CGPoint;
 use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
-use crate::ecs::{ActiveWorkspaceMarker, Position, Unmanaged, layout::LayoutStrip};
+use crate::ecs::{ActiveWorkspaceMarker, Position, Scrolling, Unmanaged, layout::LayoutStrip};
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
@@ -14,6 +14,24 @@ use crate::platform::Modifiers;
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
+
+#[test]
+fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Scroll { delta: 1.0 },
+    ];
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(1, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query.single(world).expect("active workspace is scrolling");
+            assert_eq!(scrolling.velocity, 0.0);
+            assert!(scrolling.is_user_swiping);
+        })
+        .run(commands);
+}
 
 #[test]
 fn test_dont_focus() {
@@ -151,7 +169,7 @@ fn test_scrolling() {
             command: Command::PrintState,
         },
         Event::Swipe {
-            delta: 0.4,
+            delta: 0.2,
             fingers: 3,
         },
         Event::Command {
@@ -178,8 +196,8 @@ fn test_scrolling() {
         })
         .on_iteration(5, move |world, _state| {
             assert_window_at!(world, 0, -395, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 1, -24, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 2, 376, TEST_MENUBAR_HEIGHT);
+            assert_window_at!(world, 1, -382, TEST_MENUBAR_HEIGHT);
+            assert_window_at!(world, 2, 18, TEST_MENUBAR_HEIGHT);
         })
         .run(commands);
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use bevy::prelude::*;
 use objc2_core_foundation::CGPoint;
@@ -23,6 +24,9 @@ fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
     let commands = vec![
         Event::MenuOpened { window_id: 0 },
         Event::Scroll { delta: 1.0 },
+        Event::Command {
+            command: Command::PrintState,
+        },
     ];
 
     TestHarness::new()
@@ -30,7 +34,7 @@ fn modifier_scroll_uses_native_momentum_without_synthetic_velocity() {
         .on_iteration(1, |world, _state| {
             let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
             let scrolling = query.single(world).expect("active workspace is scrolling");
-            assert_eq!(scrolling.velocity, 0.0);
+            assert!(scrolling.velocity.abs() < f64::EPSILON);
             assert!(scrolling.is_user_swiping);
         })
         .run(commands);
@@ -131,6 +135,52 @@ fn frontmost_floating_window_is_focused_after_setup() {
             assert!(world.entity(entity).contains::<Unmanaged>());
         })
         .run(vec![Event::MenuOpened { window_id: 0 }]);
+}
+
+#[test]
+fn sticky_modifier_scroll_keeps_snap_pending_until_momentum_settles() {
+    let config = Config::try_from(
+        r"
+[options]
+
+[swipe]
+sticky = true
+
+[bindings]
+",
+    )
+    .expect("sticky swipe config should parse");
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(2.0)),
+        },
+        Event::Scroll { delta: 1.0 },
+    ];
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            let mut query = world.query_filtered::<&mut Scrolling, With<ActiveWorkspaceMarker>>();
+            let mut scrolling = query
+                .single_mut(world)
+                .expect("active workspace is scrolling");
+            assert!(scrolling.snap_pending);
+            assert!(scrolling.velocity.abs() < f64::EPSILON);
+            scrolling.last_event = Instant::now()
+                .checked_sub(Duration::from_millis(100))
+                .expect("100ms must fit before the current instant");
+        })
+        .on_iteration(3, |world, _state| {
+            let mut query = world.query_filtered::<&Scrolling, With<ActiveWorkspaceMarker>>();
+            let scrolling = query
+                .single(world)
+                .expect("pending sticky snap must keep scrolling alive");
+            assert!(!scrolling.is_user_swiping);
+            assert!(scrolling.snap_pending);
+        })
+        .run(commands);
 }
 
 #[test]

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -8,8 +8,8 @@ use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams};
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::{
-    ActiveWorkspaceMarker, FocusedMarker, NativeFullscreenMarker, Position, Unmanaged,
-    layout::LayoutStrip,
+    ActiveWorkspaceMarker, FocusedMarker, LayoutPosition, NativeFullscreenMarker, Position,
+    Unmanaged, layout::LayoutStrip,
 };
 use crate::ecs::{RepositionMarker, Scrolling, SpawnWindowTrigger};
 use crate::events::Event;
@@ -320,7 +320,7 @@ fn test_scrolling() {
             command: Command::PrintState,
         },
         Event::Swipe {
-            delta: 0.2,
+            delta: 0.3,
             fingers: 3,
         },
         Event::Command {
@@ -342,9 +342,25 @@ fn test_scrolling() {
             assert_window_at!(world, 2, 800, TEST_MENUBAR_HEIGHT);
         })
         .on_iteration(5, move |world, _state| {
-            assert_window_at!(world, 0, -395, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 1, -382, TEST_MENUBAR_HEIGHT);
-            assert_window_at!(world, 2, 18, TEST_MENUBAR_HEIGHT);
+            let mut strip_query = world.query_filtered::<
+                (&Position, &Scrolling),
+                (With<ActiveWorkspaceMarker>, With<LayoutStrip>),
+            >();
+            let (strip_position, scrolling) = strip_query
+                .single(world)
+                .expect("one active scrolling strip");
+            let strip_x = strip_position.0.x;
+            assert_eq!(strip_x, -800);
+            assert_eq!(scrolling.position as i32, -800);
+
+            // Assert the durable layout contract rather than transient mock AX
+            // frames, which may still be between animation commits.
+            for (window_id, layout_x, screen_x) in [(0, 0, -800), (1, 400, -400), (2, 800, 0)] {
+                let entity = find_window_entity(window_id, world);
+                let layout_position = world.get::<LayoutPosition>(entity).unwrap().0.x;
+                assert_eq!(layout_position, layout_x);
+                assert_eq!(strip_x + layout_position, screen_x);
+            }
         })
         .run(commands);
 }
@@ -1009,15 +1025,19 @@ fn focus_unmanaged_ignores_floats_from_other_workspaces() {
 /// shifts to make room.
 #[test]
 fn test_mid_strip_insertion_preserves_window_x() {
-    let config: Config = (
-        MainOptions {
-            insert_windows_mid_strip: Some(true),
-            swipe_gesture_fingers: Some(3),
-            ..Default::default()
-        },
-        vec![],
+    let config = Config::try_from(
+        r"
+[options]
+insert_windows_mid_strip = true
+swipe_gesture_fingers = 3
+
+[swipe]
+paging = false
+
+[bindings]
+",
     )
-        .into();
+    .expect("mid-strip insertion test requires free scrolling");
 
     let mut h = TestHarness::new().with_config(config).with_windows(8);
 

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -145,6 +145,7 @@ fn sticky_modifier_scroll_keeps_snap_pending_until_momentum_settles() {
 
 [swipe]
 sticky = true
+paging = false
 
 [bindings]
 ",
@@ -327,14 +328,10 @@ fn test_scrolling() {
         },
     ];
 
-    let config: Config = (
-        MainOptions {
-            swipe_gesture_fingers: Some(3),
-            ..Default::default()
-        },
-        vec![],
+    let config = Config::try_from(
+        "[options]\nswipe_gesture_fingers = 3\n\n[swipe]\npaging = false\n\n[bindings]\n",
     )
-        .into();
+    .expect("legacy free-scroll config should parse");
 
     TestHarness::new()
         .with_config(config)
@@ -399,16 +396,10 @@ fn test_window_hidden_ratio() {
         },
     ];
 
-    let config: Config = (
-        MainOptions {
-            window_hidden_ratio: Some(0.5),
-            animation_speed: Some(10000.0),
-            swipe_gesture_fingers: Some(3),
-            ..Default::default()
-        },
-        vec![],
+    let config = Config::try_from(
+        "[options]\nwindow_hidden_ratio = 0.5\nanimation_speed = 10000.0\nswipe_gesture_fingers = 3\n\n[swipe]\npaging = false\n\n[bindings]\n",
     )
-        .into();
+    .expect("legacy hidden-window scrolling config should parse");
 
     TestHarness::new()
         .with_config(config)

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, RwLock};
 
 use bevy::prelude::*;
@@ -81,6 +81,7 @@ struct MockStateInner {
     apps: HashMap<Pid, MockAppData>,
     windows: HashMap<WinID, MockWindowData>,
     displays: HashMap<u32, MockDisplayData>,
+    fullscreen_spaces: HashSet<WorkspaceId>,
     active_display_id: u32,
     cursor_position: Origin,
     event_queue: VecDeque<Event>,
@@ -98,6 +99,7 @@ impl MockState {
                 apps: HashMap::new(),
                 windows: HashMap::new(),
                 displays: HashMap::new(),
+                fullscreen_spaces: HashSet::new(),
                 active_display_id: 0,
                 cursor_position: Origin::ZERO,
                 event_queue: VecDeque::new(),
@@ -196,6 +198,28 @@ impl MockState {
 
     pub fn active_display(&self) -> CGDirectDisplayID {
         self.inner.force_read().active_display_id
+    }
+
+    pub(crate) fn activate_workspace(
+        &self,
+        display_id: u32,
+        workspace_id: WorkspaceId,
+        fullscreen: bool,
+    ) {
+        let mut inner = self.inner.force_write();
+        {
+            let display = inner
+                .displays
+                .get_mut(&display_id)
+                .expect("finding display");
+            display.workspaces.retain(|id| *id != workspace_id);
+            display.workspaces.insert(0, workspace_id);
+        }
+        if fullscreen {
+            inner.fullscreen_spaces.insert(workspace_id);
+        } else {
+            inner.fullscreen_spaces.remove(&workspace_id);
+        }
     }
 
     pub fn drain_events(&self) -> Vec<Event> {
@@ -559,6 +583,17 @@ impl MockState {
                 .map(|d| d.workspaces[0])
                 .ok_or(Error::InvalidWindow)
         });
+
+        let s = self.clone();
+        wm.expect_is_fullscreen_space()
+            .returning(move |display_id| {
+                let inner = s.inner.force_read();
+                inner
+                    .displays
+                    .get(&display_id)
+                    .and_then(|display| display.workspaces.first())
+                    .is_some_and(|workspace_id| inner.fullscreen_spaces.contains(workspace_id))
+            });
 
         let s = self.clone();
         wm.expect_present_displays().returning(move || {

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -207,3 +207,60 @@ fn test_window_resize_grow_and_shrink_cycle() {
         })
         .run(commands);
 }
+
+#[test]
+fn test_window_can_resize_to_two_display_widths_and_scroll() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(2.0)),
+        },
+        Event::Swipe {
+            delta: 0.3,
+            fingers: 3,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Snap),
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            swipe_gesture_fingers: Some(3),
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(1)
+        .on_iteration(1, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .on_iteration(2, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .on_iteration(3, |world, _state| {
+            assert_window_size!(world, 0, 2048, 748);
+            assert_oversized_window_is_pannable(world, 0);
+        })
+        .run(commands);
+}
+
+fn assert_oversized_window_is_pannable(world: &mut World, id: i32) {
+    let mut query = world.query::<&crate::manager::Window>();
+    let window = query
+        .iter(world)
+        .find(|window| window.id() == id)
+        .expect("window not found");
+    let x = window.frame().min.x;
+    assert!(
+        (-TEST_DISPLAY_WIDTH..=0).contains(&x),
+        "oversized window must stay within its pannable range, got x={x}"
+    );
+}

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -277,16 +277,10 @@ fn test_multiple_oversized_windows_scroll_across_the_full_strip() {
         },
     ];
 
-    let config: Config = (
-        MainOptions {
-            swipe_gesture_fingers: Some(3),
-            continuous_swipe: Some(true),
-            animation_speed: Some(10000.0),
-            ..Default::default()
-        },
-        vec![],
+    let config = Config::try_from(
+        "[options]\nswipe_gesture_fingers = 3\ncontinuous_swipe = true\nanimation_speed = 10000.0\n\n[swipe]\npaging = false\n\n[bindings]\n",
     )
-        .into();
+    .expect("legacy multi-window free-scroll config should parse");
 
     TestHarness::new()
         .with_config(config)

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -252,6 +252,74 @@ fn test_window_can_resize_to_two_display_widths_and_scroll() {
         .run(commands);
 }
 
+#[test]
+fn test_multiple_oversized_windows_scroll_across_the_full_strip() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(1.5)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::SetWidth(1.5)),
+        },
+        Event::TouchpadDown,
+        Event::Swipe {
+            delta: 100.0,
+            fingers: 3,
+        },
+        Event::TouchpadDown,
+        Event::Swipe {
+            delta: -100.0,
+            fingers: 3,
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            swipe_gesture_fingers: Some(3),
+            continuous_swipe: Some(true),
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(2)
+        .on_iteration(3, |world, _state| {
+            assert_window_size!(world, 0, 1536, 748);
+            assert_window_size!(world, 1, 1536, 748);
+            assert_active_strip_x(world, -1536);
+        })
+        .on_iteration(4, |world, _state| {
+            assert_active_strip_x(world, -1536);
+        })
+        .on_iteration(5, |world, _state| {
+            assert_active_strip_x(world, -2048);
+        })
+        .on_iteration(6, |world, _state| {
+            assert_active_strip_x(world, -2048);
+        })
+        .on_iteration(7, |world, _state| {
+            assert_active_strip_x(world, 0);
+        })
+        .run(commands);
+}
+
+fn assert_active_strip_x(world: &mut World, expected: i32) {
+    let mut query = world.query_filtered::<&crate::ecs::Position, (
+        With<crate::ecs::layout::LayoutStrip>,
+        With<crate::ecs::ActiveWorkspaceMarker>,
+    )>();
+    let position = query.single(world).expect("active layout strip not found");
+    assert_eq!(position.0.x, expected);
+}
+
 fn assert_oversized_window_is_pannable(world: &mut World, id: i32) {
     let mut query = world.query::<&crate::manager::Window>();
     let window = query


### PR DESCRIPTION
> [!WARNING]
> **STACKED ON #307 — review after #307.**
> The previous mixed runtime + observation + persistence patch has been split. This PR now contains only the event-driven runtime and scroll scheduling slice.

## Why

Paneru used fixed-rate polling even while idle, and a single global scroll state could make independent strips interfere with one another. This patch makes the runtime wake for actual work or explicit deadlines and keeps scroll animation state per strip.

## What changed

- pump native events before all Bevy event readers
- wake the main run loop when background or synthetic events arrive
- replace repeated timer polling with monotonic deadlines
- preserve the existing one-minute low-power/state-save fallback wake
- keep upstream brute-force window discovery unchanged
- keep existing persistence and restore behavior unchanged
- scope scrolling, timeout cleanup, and reconciliation to each strip
- narrow the input event mask to configured features
- keep Accessibility/CoreGraphics calls that require it on the main thread
- make configuration reload replace input taps transactionally

## Explicitly not in this PR

- Accessibility window observers
- persistence coalescing or restore-policy changes
- opt-in window management
- updater or menu-bar behavior

Those changes will be proposed separately so each trade-off can be reviewed independently.

- #312 — scoped window observation and coalesced persistence
- #309 — optional per-window management
- #311 — display-synchronized frame pacing

## Verification

- `cargo test` — 208 passed
- `cargo clippy --bin paneru -- -D warnings` — passed
- regression coverage includes queued-event wakeups, synthetic-event latching, monotonic deadlines, per-strip scrolling, main-thread AX/CG access, and input-mask transitions

## Pre-merge validation

- repeat idle and active-scroll power sampling on the isolated branch
- manually verify native scroll feel on 60 Hz and ProMotion displays

The code is ready for review; these measurements remain required before merge.
