### PR TITLE
Accessibility permission onboarding without prompt loops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ notify = { version = "8.2", features = ["macos_fsevent"] }
 num_enum = "0.7"
 objc2 = { version = "0.6", features = ["catch-all", "exception"] }
 objc2-app-kit = { version = "0.3", features = [
+  "NSAlert",
   "NSBezierPath",
   "NSColor",
   "NSGraphics",

--- a/src/accessibility_prompt.rs
+++ b/src/accessibility_prompt.rs
@@ -1,0 +1,38 @@
+use objc2::MainThreadMarker;
+use objc2_app_kit::{NSAlert, NSAlertFirstButtonReturn, NSApplication};
+use objc2_foundation::NSString;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccessibilitySetupAction {
+    Continue,
+    NotNow,
+}
+
+pub(crate) fn show_accessibility_setup(
+    main_thread_marker: MainThreadMarker,
+) -> AccessibilitySetupAction {
+    let app = NSApplication::sharedApplication(main_thread_marker);
+    if objc2::available!(macos = 14.0) {
+        app.activate();
+    } else {
+        #[allow(deprecated)]
+        app.activateIgnoringOtherApps(true);
+    }
+
+    let alert = NSAlert::new(main_thread_marker);
+    alert.setMessageText(&NSString::from_str("Allow Paneru to Control Windows"));
+    alert.setInformativeText(&NSString::from_str(
+        "Paneru needs Accessibility access to move, resize, and arrange windows.\n\n\
+         In System Settings, open Privacy & Security → Accessibility, then turn on Paneru.\n\n\
+         If Paneru is already listed but access still does not work, remove the old entry with \
+         the – button, add Paneru.app again with the + button, and turn it on.",
+    ));
+    alert.addButtonWithTitle(&NSString::from_str("Continue"));
+    alert.addButtonWithTitle(&NSString::from_str("Not Now"));
+
+    if alert.runModal() == NSAlertFirstButtonReturn {
+        AccessibilitySetupAction::Continue
+    } else {
+        AccessibilitySetupAction::NotNow
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 #![allow(clippy::cast_possible_truncation)]
 
+use std::sync::mpsc::{Receiver, TryRecvError};
+
 use clap::{Parser, Subcommand};
 use tracing::{error, warn};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+mod accessibility_prompt;
 mod commands;
 mod config;
 mod ecs;
@@ -21,7 +24,7 @@ mod tests;
 
 embed_plist::embed_info_plist!("../assets/Info.plist");
 
-use events::EventSender;
+use events::{Event, EventSender};
 
 use ecs::state::StateQueryKind;
 use errors::Result;
@@ -29,6 +32,10 @@ use platform::service;
 use reader::CommandReader;
 
 use crate::ecs::setup_bevy_app;
+use crate::manager::{check_ax_privilege, request_ax_privilege};
+use crate::menubar::MenuBarManager;
+use crate::platform::PlatformCallbacks;
+use accessibility_prompt::{AccessibilitySetupAction, show_accessibility_setup};
 
 /// `Paneru` is the main command-line interface structure for the window manager.
 /// It defines the available subcommands for controlling the Paneru daemon.
@@ -145,6 +152,9 @@ fn main() -> Result<()> {
             })
             .expect("setting Ctrl-C handler should succeed");
             CommandReader::new(sender.clone()).start();
+            if !check_ax_privilege() && !wait_for_accessibility(sender.clone(), &receiver) {
+                return Ok(());
+            }
             match setup_bevy_app(sender, receiver) {
                 Ok(mut app) => {
                     app.run();
@@ -171,6 +181,45 @@ fn main() -> Result<()> {
         SubCmd::Subscribe { json: _ } => CommandReader::subscribe_json()?,
     }
     Ok(())
+}
+
+fn wait_for_accessibility(sender: EventSender, receiver: &Receiver<Event>) -> bool {
+    let mut platform_callbacks = PlatformCallbacks::new(sender.clone());
+    let _menu_bar =
+        MenuBarManager::new_accessibility_required(platform_callbacks.main_thread_marker, sender);
+
+    if show_accessibility_setup(platform_callbacks.main_thread_marker)
+        == AccessibilitySetupAction::Continue
+    {
+        request_ax_privilege();
+    }
+
+    warn!(
+        "Accessibility access is required. Paneru will remain in the menu bar and start automatically once access is granted."
+    );
+
+    loop {
+        platform_callbacks.pump_cocoa_event_loop(1.0);
+
+        if check_ax_privilege() {
+            return true;
+        }
+
+        match receiver.try_recv() {
+            Ok(
+                Event::Exit
+                | Event::Command {
+                    command: commands::Command::Quit,
+                },
+            )
+            | Err(TryRecvError::Disconnected) => return false,
+            Ok(event) => warn!(
+                ?event,
+                "ignoring event while waiting for Accessibility access"
+            ),
+            Err(TryRecvError::Empty) => {}
+        }
+    }
 }
 
 impl QueryCmd {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,6 @@
-use accessibility_sys::{AXIsProcessTrustedWithOptions, kAXTrustedCheckOptionPrompt};
+use accessibility_sys::{
+    AXIsProcessTrusted, AXIsProcessTrustedWithOptions, kAXTrustedCheckOptionPrompt,
+};
 use bevy::ecs::resource::Resource;
 use bevy::math::{IRect, IVec2};
 use core::ptr::NonNull;
@@ -782,13 +784,20 @@ pub fn bruteforce_windows(
     found_windows
 }
 
-/// Checks if the application has Accessibility privileges.
-/// It will prompt the user to grant permission if not already granted.
+/// Checks if the application has Accessibility privileges without showing UI.
 ///
 /// # Returns
 ///
 /// `true` if Accessibility privileges are granted, `false` otherwise.
 pub fn check_ax_privilege() -> bool {
+    unsafe { AXIsProcessTrusted() }
+}
+
+/// Requests Accessibility privileges once through the native macOS prompt.
+///
+/// Subsequent permission polling must use [`check_ax_privilege`] so the system
+/// dialog is not requested repeatedly while the application waits.
+pub fn request_ax_privilege() -> bool {
     unsafe {
         let keys = [kAXTrustedCheckOptionPrompt
             .cast::<CFString>()

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -11,6 +11,7 @@ use objc2_core_foundation::CGFloat;
 use objc2_foundation::{NSObject, NSString};
 use tracing::warn;
 
+use crate::accessibility_prompt::{AccessibilitySetupAction, show_accessibility_setup};
 use crate::commands::{Command, Operation};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
@@ -18,7 +19,7 @@ use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Unmanaged,
 };
 use crate::events::{Event, EventSender};
-use crate::manager::Display;
+use crate::manager::{Display, request_ax_privilege};
 
 #[derive(Debug, Clone)]
 struct MenuActionTargetIvars {
@@ -51,6 +52,30 @@ define_class!(
         #[unsafe(method(toggleManaged:))]
         fn toggle_managed(&self, _: &NSMenuItem) {
             self.send_command(Command::Window(Operation::Manage));
+        }
+
+        #[unsafe(method(openAccessibilitySettings:))]
+        fn open_accessibility_settings(&self, _: &NSMenuItem) {
+            if let Err(error) = std::process::Command::new("/usr/bin/open")
+                .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+                .spawn()
+            {
+                warn!(%error, "unable to open Accessibility settings");
+            }
+        }
+
+        #[unsafe(method(showAccessibilityInstructions:))]
+        fn show_accessibility_instructions(&self, _: &NSMenuItem) {
+            let Some(main_thread_marker) = MainThreadMarker::new() else {
+                warn!("unable to show Accessibility instructions outside the main thread");
+                return;
+            };
+
+            if show_accessibility_setup(main_thread_marker)
+                == AccessibilitySetupAction::Continue
+            {
+                request_ax_privilege();
+            }
         }
 
         #[unsafe(method(quitPaneru:))]
@@ -128,6 +153,36 @@ impl MenuBarManager {
             configured_widths: Vec::new(),
             current_label: None,
         }
+    }
+
+    pub fn new_accessibility_required(mtm: MainThreadMarker, events: EventSender) -> Self {
+        let mut manager = Self::new(mtm, events);
+        manager.rebuild_accessibility_menu();
+        manager.show_label("Paneru !".to_owned());
+        manager
+    }
+
+    fn rebuild_accessibility_menu(&mut self) {
+        self.menu.removeAllItems();
+
+        let status = self.add_item("Paneru — Accessibility Required", None);
+        status.setEnabled(false);
+
+        let hint = self.add_item("Grant access; Paneru will start automatically", None);
+        hint.setEnabled(false);
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        self.add_item(
+            "Show Setup Instructions…",
+            Some(sel!(showAccessibilityInstructions:)),
+        );
+        self.add_item(
+            "Open Accessibility Settings…",
+            Some(sel!(openAccessibilitySettings:)),
+        );
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));
     }
 
     pub fn update(


### PR DESCRIPTION
> [!WARNING]
> **Manual macOS TCC validation remains before merge.**
> This PR is now Accessibility-only. Display frame pacing has been removed and will be proposed separately on top of the runtime PR.

## Problem

`AXIsProcessTrustedWithOptions(... prompt = true)` was used as a permission check. Repeating that check could repeatedly ask macOS to show the Accessibility prompt.

## What changed

- split the silent trust check from the one-shot system prompt request
- show a native setup explanation before requesting the system prompt
- explain how to remove and re-add a stale Paneru entry in System Settings
- keep Paneru alive in the menu bar while permission is missing
- provide menu actions to reopen the instructions or Accessibility settings
- start the window manager automatically after permission becomes available
- allow quitting cleanly while Paneru is waiting

The passive wait loop uses `AXIsProcessTrusted()` only. The prompting API is called only after an explicit **Continue** action.

## Independence

- based directly on `testing`
- no dependency on opt-in management
- no dependency on the event-driven runtime
- no display-link or animation changes

## Verification

- `cargo check --all-targets` — passed
- `cargo test` — 161 passed
- `cargo clippy --bin paneru -- -D warnings` — passed

## Pre-merge manual validation

- first launch with no Accessibility entry
- denied / **Not Now** flow
- stale already-listed TCC entry
- granting permission while Paneru is waiting
- quitting from the permission-required menu

Those cases modify real macOS TCC state. The code is ready for review, but they must be exercised on a packaged app before merge.
