### PR TITLE
Grid-positioned floating windows relative to display origin

### DIFF
--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -566,8 +566,8 @@ pub(super) fn window_unmanaged_trigger(
     // Skip the active-display reposition/resize during init; the strip
     // removal below still has to run.
     if let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
-        let x = (f64::from(display_bounds.width()) * rx) as i32;
-        let y = (f64::from(display_bounds.height()) * ry) as i32;
+        let x = display_bounds.min.x + (f64::from(display_bounds.width()) * rx) as i32;
+        let y = display_bounds.min.y + (f64::from(display_bounds.height()) * ry) as i32;
         let w = (f64::from(display_bounds.width()) * rw) as i32;
         let h = (f64::from(display_bounds.height()) * rh) as i32;
         commands.reposition_entity(entity, Origin::new(x, y));
@@ -966,8 +966,8 @@ pub(super) fn apply_window_defaults(
             // Skip grid_ratios during init: we don't know this window's display.
             if !initializing && let Some((rx, ry, rw, rh)) = properties.grid_ratios() {
                 let bounds = active_display.actual_bounds(&config);
-                let x = (f64::from(bounds.width()) * rx) as i32;
-                let y = (f64::from(bounds.height()) * ry) as i32;
+                let x = bounds.min.x + (f64::from(bounds.width()) * rx) as i32;
+                let y = bounds.min.y + (f64::from(bounds.height()) * ry) as i32;
                 let w = (f64::from(bounds.width()) * rw) as i32;
                 let h = (f64::from(bounds.height()) * rh) as i32;
                 window.reposition(Origin::new(x, y));

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -133,6 +133,53 @@ fn frontmost_floating_window_is_focused_after_setup() {
         .run(vec![Event::MenuOpened { window_id: 0 }]);
 }
 
+/// Regression: a floating window placed by a grid rule must land at the active
+/// display's usable origin (menubar + padding offset), not at (0, 0). Dropping
+/// the display bounds origin previously sent grid windows to the primary
+/// display's top-left corner (and onto the wrong display in multi-display
+/// setups).
+#[test]
+fn floating_grid_window_uses_active_display_usable_origin() {
+    let options = MainOptions {
+        padding_left: Some(40),
+        padding_top: Some(15),
+        ..MainOptions::default()
+    };
+
+    let mut params = WindowParams::new(".*", None);
+    params.floating = Some(true);
+    // Cell (0,0) spanning the full 1x1 grid: origin should equal the usable
+    // top-left, independent of the display size.
+    params.grid = Some("1:1:0:0:1:1".to_string());
+    let config: Config = (options, vec![params]).into();
+
+    TestHarness::new()
+        .with_config(config)
+        .on_iteration(1, |world, state| {
+            let origin = Origin::new(0, 0);
+            let size = Size::new(TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT);
+            let frame = IRect::from_corners(origin, origin + size);
+            let window = state.spawn_window(TEST_PROCESS_ID, TEST_WORKSPACE_ID, 0, frame);
+            world.trigger(SpawnWindowTrigger(vec![window]));
+        })
+        .on_iteration(3, |world, _state| {
+            // usable origin = (pad_left, menubar + pad_top) = (40, 20 + 15).
+            assert_window_at!(world, 0, 40, TEST_MENUBAR_HEIGHT + 15);
+        })
+        .run(vec![
+            Event::MenuOpened { window_id: 0 },
+            Event::Command {
+                command: Command::PrintState,
+            },
+            Event::Command {
+                command: Command::PrintState,
+            },
+            Event::Command {
+                command: Command::PrintState,
+            },
+        ]);
+}
+
 #[test]
 fn test_dont_focus() {
     let commands = vec![


### PR DESCRIPTION
# Issue

apply_window_defaults and window_unmanaged_trigger computed grid placement from the display's usable width/height but omitted the bounds origin, so coordinates were relative to (0, 0). On a non-primary display the window landed on the primary display instead, and on any display the top row overlapped the menubar.

# Change

Add display_bounds.min to the computed x/y so grid cells are positioned relative to the active display's usable area, consistent with the use of `display_bounds.width()/height()`.

# Testing
* Added a regression test for the multi window case
* Built and tested on an M3 MBP, confirmed that a window with this config now centers correctly on the active display

```
floating = true
grid = "4:4:1:1:2:2"
```

fixes: #315 