### PR TITLE
Fix window positioning when switching virtual desktop and width mismatch and off-screen focus while stacking/unstacking

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1263,6 +1263,13 @@ pub fn stack_windows_handler(
         } else {
             _ = strip.unstack(entity);
         }
+
+        // Stacking/unstacking moves the focused window to a new column slot
+        // (onto the left master, or out to its own column on the right).
+        // Reshuffle around it so it is brought fully back into view; the
+        // edge-clamp in reshuffle_layout_strip keeps the strip pinned so the
+        // leftmost window touches the left edge and the rightmost the right.
+        commands.reshuffle_around(entity);
     }
 }
 

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -1002,7 +1002,7 @@ fn reshuffle_layout_strip(
         if let Ok(mut cmd) = commands.get_entity(entity) {
             cmd.try_remove::<ReshuffleAroundMarker>();
         }
-        let Some((_, strip_entity, active_strip, child, active_marker)) =
+        let Some((strip, strip_entity, active_strip, child, active_marker)) =
             strips.into_iter().find(|strip| strip.0.contains(entity))
         else {
             return;
@@ -1029,7 +1029,34 @@ fn reshuffle_layout_strip(
             .clamp(display_bounds.min, display_bounds.max - size);
         frame.max = frame.min + size;
 
-        let strip_position = (frame.min - layout_position.0).with_y(display_bounds.min.y);
+        let mut strip_position = (frame.min - layout_position.0).with_y(display_bounds.min.y);
+
+        // Enforce the edge invariant when auto-center is off: the leftmost
+        // window must touch the left edge and the rightmost the right edge
+        // if more than 1 windows in workspace.
+        if !config.auto_center()
+            && let Some(total_strip_width) = strip
+                .last()
+                .ok()
+                .and_then(|column| column.top())
+                .and_then(|last| {
+                    windows
+                        .layout_position(last)
+                        .map(|position| position.0.x)
+                        .zip(windows.moving_frame(last).map(|frame| frame.width()))
+                })
+                .map(|(last_x, last_width)| last_x + last_width)
+        {
+            strip_position.x = if display_bounds.width() < total_strip_width {
+                strip_position.x.clamp(
+                    display_bounds.max.x - total_strip_width,
+                    display_bounds.min.x,
+                )
+            } else {
+                // Strip fits entirely: pin the leftmost window to the left edge.
+                display_bounds.min.x
+            };
+        }
 
         // Check how much of the window is hidden. Slivers don't count as
         // meaningfully visible, so subtract sliver_width from the visible

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -676,6 +676,17 @@ impl LayoutStrip {
                 let heights =
                     binpack_heights(&current_heights, MIN_WINDOW_HEIGHT, layout_strip_height)?;
 
+                // Every window in a column shares the master's (top item's)
+                // width, so a window stacked onto a master of a different width
+                // resizes to match it instead of keeping its own width. This
+                // also matches the column slot width from column_positions,
+                // which is the widest member.
+                let column_width = items
+                    .first()
+                    .and_then(StackItem::top)
+                    .and_then(&get_window_frame)
+                    .map(|frame| frame.width())?;
+
                 let mut next_y = 0;
                 let frames = items
                     .into_iter()
@@ -683,9 +694,8 @@ impl LayoutStrip {
                     .filter_map(|(item, height)| {
                         let entity = item.top()?;
                         let mut frame = get_window_frame(entity)?;
-                        let width = frame.width();
                         frame.min.x = position;
-                        frame.max.x = frame.min.x + width;
+                        frame.max.x = frame.min.x + column_width;
 
                         frame.min.y = next_y;
                         frame.max.y = frame.min.y + height;
@@ -1577,10 +1587,12 @@ mod tests {
         strip.stack(entities[1]).unwrap();
         strip.stack(entities[2]).unwrap();
 
-        // Give different heights; top window (e0) is 400px wide, others 300px.
+        // Give the master (e0) a distinct width so we can verify children
+        // adopt it. Here e0 is 500px while its stacked children are 300px;
+        // children must widen to the master's 500, not keep their own width.
         let get_window_frame = |e: Entity| {
             if e == entities[0] {
-                Some(IRect::new(0, 0, 400, 200))
+                Some(IRect::new(0, 0, 500, 200))
             } else if e == entities[1] || e == entities[2] {
                 Some(IRect::new(0, 0, 300, 200))
             } else {
@@ -1590,6 +1602,16 @@ mod tests {
 
         let out: Vec<_> = strip.relative_positions(600, &get_window_frame).collect();
         assert_eq!(out.len(), 4);
+
+        // Every window in the stacked column must adopt the master's width.
+        for e in [entities[0], entities[1], entities[2]] {
+            let frame = out.iter().find(|(entity, _)| *entity == e).unwrap().1;
+            assert_eq!(
+                frame.width(),
+                500,
+                "stacked window must share the master's (top) width"
+            );
+        }
 
         // Stacked heights should sum to viewport height.
         let stack_heights: i32 = out

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -987,17 +987,15 @@ pub(crate) fn show_active_workspace(
 
         let bounds = active_display.bounds();
 
+        if let Ok(mut cmd) = commands.get_entity(entity) {
+            cmd.try_remove::<Scrolling>()
+                .try_remove::<RepositionMarker>();
+        }
+
         if config.virtual_workspace_animations() {
             commands.reposition_entity(entity, bounds.max - 10);
         } else {
             position.0 = bounds.max - 10;
-        }
-        // Stop any in-flight animation and scroll state so the hidden strip
-        // doesn't continue moving off-screen and doesn't corrupt the saved
-        // position when it is restored.
-        if let Ok(mut cmd) = commands.get_entity(entity) {
-            cmd.try_remove::<Scrolling>()
-                .try_remove::<RepositionMarker>();
         }
     }
 
@@ -1014,12 +1012,10 @@ pub(crate) fn show_active_workspace(
         }
 
         if config.virtual_workspace_animations() {
-            // Focus on the previous window
             if let Some(entity) = focus
                 && strip.contains(*entity)
             {
                 commands.focus_entity(*entity, false);
-                commands.reshuffle_around(*entity);
             }
 
             commands.reposition_entity(*activated, *origin);

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1499,3 +1499,109 @@ fn test_virtual_workspace_switch_hides_old_strip_with_animations() {
         TEST_DISPLAY_WIDTH - 10
     );
 }
+
+/// Stacking or unstacking the focused window must bring it fully back into
+/// view. Regression: stack_windows_handler mutated the strip but never
+/// reshuffled, so when the strip was scrolled such that the focused window's
+/// new column slot fell off-screen, the window stayed partially or fully
+/// invisible even though it kept focus. It now reshuffles around the focused
+/// window; the edge-clamp in reshuffle_layout_strip keeps the strip pinned to
+/// the edges.
+#[test]
+fn test_stack_unstack_brings_focused_window_into_view() {
+    use crate::ecs::{Bounds, Position, Scrolling};
+
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(false),
+            animation_speed: Some(10000.0),
+            swipe_gesture_fingers: Some(3),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    // 5 windows @ 400px = 2000px strip on a 1024px display → scrollable.
+    let mut h = TestHarness::new().with_config(config).with_windows(5);
+
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        for _ in 0..16 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    // Emulate the real-app settled state after a swipe: the strip is scrolled
+    // and the transient Scrolling has been removed (swiping_timeout drops it
+    // within ~50ms in the app; the test harness's fast wall-clock wouldn't).
+    let settle_scroll_offset = |h: &mut TestHarness| {
+        h.app.world_mut().write_message::<Event>(Event::Swipe {
+            delta: 0.9,
+            fingers: 3,
+        });
+        for _ in 0..16 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<Entity, With<Scrolling>>();
+        for e in q.iter(world).collect::<Vec<_>>() {
+            if let Ok(mut em) = world.get_entity_mut(e) {
+                em.remove::<Scrolling>();
+            }
+        }
+        for _ in 0..4 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    let is_fully_onscreen = |h: &mut TestHarness, id: i32| {
+        let e = find_window_entity(id, h.app.world_mut());
+        let world = h.app.world();
+        let p = world.get::<Position>(e).unwrap().0;
+        let b = world.get::<Bounds>(e).unwrap().0;
+        p.x >= 0 && p.x + b.x <= TEST_DISPLAY_WIDTH
+    };
+
+    pump(&mut h, Command::PrintState);
+
+    // Focus window 1, scroll it off the left edge, then stack it onto window 0.
+    pump(&mut h, Command::Window(Operation::Focus(Direction::First)));
+    pump(&mut h, Command::Window(Operation::Focus(Direction::East)));
+    settle_scroll_offset(&mut h);
+    assert!(
+        !is_fully_onscreen(&mut h, 1),
+        "test setup: focused window should be off-screen before stacking"
+    );
+
+    pump(&mut h, Command::Window(Operation::Stack(true)));
+    assert!(
+        is_fully_onscreen(&mut h, 1),
+        "stacking must bring the focused window fully back into view"
+    );
+
+    // Scroll off-screen again, then unstack: the focused window moves out to
+    // its own column and must likewise be brought into view.
+    settle_scroll_offset(&mut h);
+    assert!(
+        !is_fully_onscreen(&mut h, 1),
+        "test setup: focused window should be off-screen before unstacking"
+    );
+
+    pump(&mut h, Command::Window(Operation::Stack(false)));
+    assert!(
+        is_fully_onscreen(&mut h, 1),
+        "unstacking must bring the focused window fully back into view"
+    );
+}

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1282,3 +1282,220 @@ fn test_virtual_workspace_switch_stops_in_flight_strip_animation() {
         "strip x drifted after restore: was {saved_x}, now {final_x}"
     );
 }
+
+/// With `auto_center` off, a reshuffle around the leftmost window of a
+/// scrollable strip must pin the strip to the left edge — the leftmost
+/// window's left edge must touch the display's left edge, never leaving empty
+/// space to its left.
+///
+/// Regression: after a virtual-workspace switch parks the inactive strip at
+/// `bounds.max - 10`, every window's on-screen frame is momentarily stale at
+/// the right-edge sliver. A focus-driven `reshuffle_layout_strip` that read
+/// that stale frame computed a large positive strip offset and pushed column 0
+/// away from the left edge (leftmost window ended up right-aligned). This test
+/// injects the stale right-edge frame directly (the real trigger is a delayed
+/// duplicate OS focus event that the mock platform doesn't emit) and asserts
+/// the reshuffle clamps the strip back to the left edge.
+#[test]
+fn test_reshuffle_leftmost_pins_strip_to_left_edge_with_stale_frame() {
+    use crate::ecs::{Position, ReshuffleAroundMarker};
+
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(false),
+            animation_speed: Some(30.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    // 5 windows @ 400px = 2000px strip on a 1024px display → scrollable.
+    let mut h = TestHarness::new().with_config(config).with_windows(5);
+
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        for _ in 0..10 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    // Boot the strip; column 0 (window id 0) sits at layout x 0.
+    pump(&mut h, Command::PrintState);
+
+    let leftmost = find_window_entity(0, h.app.world_mut());
+
+    // Simulate the stale post-VW-switch state: the leftmost window's on-screen
+    // frame is parked at the right-edge sliver while its layout position is
+    // still 0. Clear any in-flight animation so moving_frame reads the origin.
+    {
+        let world = h.app.world_mut();
+        if let Ok(mut e) = world.get_entity_mut(leftmost) {
+            e.insert(Position(Origin::new(
+                TEST_DISPLAY_WIDTH - 5,
+                TEST_MENUBAR_HEIGHT,
+            )));
+            e.remove::<RepositionMarker>();
+            // Trigger a reshuffle around the leftmost window, as focus would.
+            e.insert(ReshuffleAroundMarker);
+        }
+    }
+
+    for _ in 0..15 {
+        h.app.update();
+        for e in h.mock_state.drain_events() {
+            h.app.world_mut().write_message::<Event>(e);
+        }
+    }
+
+    // The strip must be pinned to the left edge (offset 0): column 0 has
+    // layout x 0, so its on-screen left edge lands at the display's left edge.
+    let world = h.app.world_mut();
+    let mut q = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+    let strip_x = q.single(world).expect("exactly one active strip").0.x;
+    assert_eq!(
+        strip_x, 0,
+        "reshuffle around leftmost window must pin strip to left edge (offset 0), got {strip_x}"
+    );
+}
+
+/// With `virtual_workspace_animations = true`, switching away from a scrolled
+/// strip and back must restore its saved scroll position, not reset it.
+///
+/// Regression: the animated restore branch of `show_active_workspace` called
+/// `reshuffle_around(focus)` in addition to animating the strip to its saved
+/// origin. That reshuffle read stale mid-animation window frames a frame later
+/// and overwrote the restore target with a different offset, discarding the
+/// saved scroll (the strip jumped back to 0). The animated branch now restores
+/// the origin without reshuffling, mirroring the non-animated branch.
+#[test]
+fn test_virtual_workspace_switch_preserves_scroll_with_animations() {
+    use crate::ecs::Position;
+
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(false),
+            animation_speed: Some(30.0),
+            swipe_gesture_fingers: Some(3),
+            virtual_workspace_animations: Some(true),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    // 5 windows @ 400px = 2000px strip on a 1024px display → scrollable.
+    let mut h = TestHarness::new().with_config(config).with_windows(5);
+
+    let pump_event = |h: &mut TestHarness, ev: Event| {
+        h.app.world_mut().write_message::<Event>(ev);
+        for _ in 0..14 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+    let pump = |h: &mut TestHarness, c: Command| pump_event(h, Event::Command { command: c });
+
+    // Boot and scroll the strip off the left edge to a non-zero offset.
+    pump(&mut h, Command::PrintState);
+    pump_event(
+        &mut h,
+        Event::Swipe {
+            delta: 0.4,
+            fingers: 3,
+        },
+    );
+
+    let strip_x_after_scroll = {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+        q.single(world).expect("active strip after scroll").0.x
+    };
+    assert_ne!(
+        strip_x_after_scroll, 0,
+        "test setup: strip should be scrolled off the left edge, got 0"
+    );
+
+    // Switch to an empty VW and back.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    pump(&mut h, Command::Window(Operation::VirtualNumber(0)));
+
+    let strip_x_restored = {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+        q.single(world).expect("active strip after restore").0.x
+    };
+    assert_eq!(
+        strip_x_restored, strip_x_after_scroll,
+        "animated VW restore must preserve the saved scroll position. \
+         Expected {strip_x_after_scroll}, got {strip_x_restored}"
+    );
+}
+
+/// With `virtual_workspace_animations = true`, switching to another virtual
+/// workspace must move the previously-active strip (and therefore its windows)
+/// off-screen. Regression: `show_active_workspace` queued a `RepositionMarker`
+/// to animate the old strip to `bounds.max - 10`, but a cleanup block right
+/// after removed the very same marker in the same command flush — so the strip
+/// never moved and all of the old workspace's windows stayed visible on top of
+/// the workspace we switched to. The cleanup now runs before the hide
+/// reposition is queued.
+#[test]
+fn test_virtual_workspace_switch_hides_old_strip_with_animations() {
+    use crate::ecs::{Position, layout::LayoutStrip};
+
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(false),
+            animation_speed: Some(30.0),
+            swipe_gesture_fingers: Some(3),
+            virtual_workspace_animations: Some(true),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new().with_config(config).with_windows(5);
+
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        for _ in 0..14 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    pump(&mut h, Command::PrintState);
+    // Leave a window on VW0 (Stay) and spawn VW1 with one window, then switch.
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+    );
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+
+    // The inactive VW0 strip must have moved off-screen (its origin parked at
+    // bounds.max - 10 = 1014), taking its windows with it.
+    let world = h.app.world_mut();
+    let mut q = world.query::<(&LayoutStrip, &Position, Has<ActiveWorkspaceMarker>)>();
+    let inactive_x = q
+        .iter(world)
+        .find_map(|(_, pos, active)| (!active).then_some(pos.0.x))
+        .expect("an inactive strip exists after switching workspaces");
+    assert!(
+        inactive_x >= TEST_DISPLAY_WIDTH - 10,
+        "inactive strip must be parked off-screen (>= {}), got {inactive_x}",
+        TEST_DISPLAY_WIDTH - 10
+    );
+}


### PR DESCRIPTION
## Issue

Three related bugs when navigating virtual workspaces (`window_virtual_{north,south}`):

1. **Leftmost window pinned to the right edge** while `auto_center = false`. After switching workspaces, focusing the leftmost window of a scrollable strip could leave it attached to the right edge instead of the left, with empty space to its left. Intermittent, but reproducible when focusing a window of an app that already had another window open (e.g. a second web browser window launched via `open -n Firefox.app`).
2. **Scroll position reset** while `virtual_workspace_animations = true`. Switching away from a scrolled strip and back snapped it to offset `0`, losing the scroll position.
3. **Old workspace's windows never disappear** while `virtual_workspace_animations = true`. After switching, all windows from the previous workspace stayed visible on top of the new one.

And three related bugs when stacking/unstacking windows (`window_stack` / `window_unstack`):

4. **Stacked window keeps its own width.** Stacking a window onto a master of a different width left the child at its old width instead of matching the master.
5. **Stacked window off-screen.** When the strip was scrolled so the focused window's new column slot fell off-screen, stacking left the focused window partially or fully invisible even though it kept focus.
6. **Unstacked window off-screen.** Same as above when unstacking: the focused window moved out to its own column off-screen and was not brought back into view.

## Root Cause

1. `reshuffle_layout_strip` only guaranteed the focused window was *visible*.  It computed the strip offset from the window's current on-screen frame. Right after a switch, that frame is momentarily stale (hidden strips are parked at the right-edge sliver), so for the leftmost window it produced a large offset that right-aligned the whole strip. This occurred mostly on "same app, different window" case: `focus_without_raise`'s same-PSN path emits a 20ms-delayed duplicate focus event that re-triggers the stale reshuffle at the worst moment.
2. The animated restore branch of `show_active_workspace` called `reshuffle_around(focus)` alongside animating the strip to its saved origin. That reshuffle read stale mid-animation frames a frame later and overwrote the restore target with a different offset.
3. The hide logic queued a `RepositionMarker` to animate the old strip off-screen, but a cleanup block immediately after removed the same marker in the same command flush. Commands apply in queue order, so the removal cancelled the animation and the strip (with its windows) never moved.
4. `relative_positions` gave each window in a column its own width, so a stacked child kept its own width rather than adopting the master's, even though `column_positions` sized the column slot to the widest member.
5 & 6. `stack_windows_handler` mutated the layout strip but never reshuffled, so the focused window was left wherever its new column slot landed (off-screen if the strip was scrolled).

## Fix

1. `reshuffle_layout_strip` now clamps the computed strip offset to the display edges when `auto_center` is off with the principle of: "leftmost window touches the left edge, rightmost touches the right if more than 1 window", so it holds regardless of stale-frame timing.
2. The animated restore branch restores the saved origin without reshuffling (the origin already had the focus window visible), mirroring the non-animated branch.
3. The stale-marker cleanup now runs *before* the hide reposition is queued, so the off-screen `RepositionMarker` survives and the old strip animates away.
4. `relative_positions` gives every window in a column the master's (top item's) width, so a stacked child resizes to match the master. This also matches the column slot width from `column_positions`.
5 & 6. `stack_windows_handler` now reshuffles around the focused window after stacking/unstacking; the edge-clamp from fix 1 keeps the strip pinned to the edges, so the focused window is brought fully back into view.

Note: Each fix has a regression test verified to fail without it.