### PR TITLE
fix: Suppress focus-echo recenter after virtual workspace restore.

### DIFF
--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -18,6 +18,7 @@ use super::{FocusedMarker, MouseHeldMarker, SystemTheme, Unmanaged};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
+use crate::ecs::workspace::RestoreFocusMarker;
 use crate::ecs::{
     ActiveWorkspaceMarker, Scrolling, SendMessageTrigger, SpawnCommandsExt, StrayFocusEvent,
 };
@@ -148,6 +149,7 @@ fn maintain_focus_singleton(
 fn autocenter_window_on_focus(
     focused: Single<Entity, Added<FocusedMarker>>,
     mouse_held: Query<&MouseHeldMarker>,
+    restored: Query<&RestoreFocusMarker>,
     windows: Windows,
     global_state: GlobalState,
     active_display: ActiveDisplay,
@@ -155,6 +157,15 @@ fn autocenter_window_on_focus(
     mut commands: Commands,
 ) {
     let entity = *focused;
+
+    // A workspace restore re-focuses the remembered window after the strip was
+    // already placed at its saved origin; centering that focus would slide the
+    // strip away from the restored position. The guard outlives this system on
+    // purpose — window_focused_trigger despawns it once focus moves on, and
+    // timeout_ticker expires it otherwise.
+    if restored.iter().any(|marker| marker.entity == entity) {
+        return;
+    }
 
     if global_state.skip_reshuffle() || global_state.initializing() || !mouse_held.is_empty() {
         return;

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -22,6 +22,7 @@ use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
+use crate::ecs::workspace::RestoreFocusMarker;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, Position,
     ResizeMarker, RestoreWindowState, Scrolling, SendMessageTrigger, SpawnCommandsExt,
@@ -180,6 +181,7 @@ pub(super) fn window_focused_trigger(
     applications: Query<&Application>,
     windows: Windows,
     mut workspaces: Query<(Entity, &mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    restore_guards: Query<(Entity, &RestoreFocusMarker)>,
     mut focus_history: ResMut<FocusHistory>,
     config: Res<Config>,
     global_state: GlobalState,
@@ -284,7 +286,26 @@ pub(super) fn window_focused_trigger(
             focus_history.record(workspace_id, entity, unmanaged);
         }
 
+        // The restore guard absorbs the OS acknowledgment(s) of the focus
+        // `show_active_workspace` issued — reshuffling on those would slide
+        // the strip away from the position the restore just placed it at.
+        // The acknowledgment can arrive more than once (front_switched_trigger
+        // synthesizes a duplicate), so a matching event leaves the guard in
+        // place; focus moving to any other window means the restore sequence
+        // is over and despawns it (timeout_ticker expires it otherwise).
+        let mut restored_focus = false;
+        for (guard_entity, guard) in &restore_guards {
+            if guard.entity == entity {
+                restored_focus = true;
+            } else if let Ok(mut entity_commands) = commands.get_entity(guard_entity) {
+                entity_commands.try_despawn();
+            }
+        }
+
         if already_focused {
+            if restored_focus {
+                continue;
+            }
             if !global_state.skip_reshuffle() && !global_state.initializing() {
                 commands.reshuffle_around(entity);
             }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -85,6 +85,35 @@ pub(crate) struct PreviousStripPosition {
     pub focus: Option<Entity>,
 }
 
+/// Guard spawned by [`show_active_workspace`] alongside the re-focus of the
+/// remembered window when a strip is restored to its saved position. That
+/// focus lands after the strip was already placed at its saved origin —
+/// `focus_entity` inserts `FocusedMarker` a command-flush later, and the OS
+/// acknowledges with one or more `WindowFocused` events several ticks later
+/// still (the front-switch handler synthesizes an extra one), long after the
+/// `is_added` guards in the layout systems have expired. Each of those would
+/// recenter or reshuffle the strip away from the restored position (visible
+/// as a wiggle on every switch). While the guard is alive,
+/// `autocenter_window_on_focus` and the duplicate-focus reshuffle in
+/// `window_focused_trigger` skip the named entity. The guard lives on its own
+/// entity next to a [`Timeout`]: focus moving to any other window despawns it
+/// immediately, and `timeout_ticker` expires it otherwise — so later genuine
+/// re-focus events reshuffle normally.
+#[derive(Component, Debug)]
+pub(crate) struct RestoreFocusMarker {
+    pub entity: Entity,
+}
+
+/// Long enough for the OS focus acknowledgments to arrive, short enough that
+/// a user re-clicking the restored window soon after the switch gets the
+/// normal expose-reshuffle back.
+const RESTORE_FOCUS_GUARD_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn spawn_restore_focus_guard(entity: Entity, commands: &mut Commands) {
+    let timeout = Timeout::new(RESTORE_FOCUS_GUARD_TIMEOUT, None, commands);
+    commands.spawn((timeout, RestoreFocusMarker { entity }));
+}
+
 fn fullscreen_window_in_strip(
     workspace_id: WorkspaceId,
     strip: &LayoutStrip,
@@ -1047,6 +1076,7 @@ pub(crate) fn show_active_workspace(
             if let Some(entity) = focus
                 && strip.contains(*entity)
             {
+                spawn_restore_focus_guard(*entity, &mut commands);
                 commands.focus_entity(*entity, false);
             }
 
@@ -1065,6 +1095,7 @@ pub(crate) fn show_active_workspace(
         if let Some(entity) = focus
             && strip.contains(*entity)
         {
+            spawn_restore_focus_guard(*entity, &mut commands);
             commands.focus_entity(*entity, false);
         }
     }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1450,6 +1450,106 @@ fn test_virtual_workspace_switch_stops_in_flight_strip_animation() {
     );
 }
 
+/// A virtual-workspace switch restores the strip to its saved position and
+/// re-focuses the remembered window. macOS acknowledges that focus with a
+/// `WindowFocused` event several ticks later — after the `is_added` guards in
+/// `reshuffle_layout_strip` / `ensure_visible_in_strip` have expired. With
+/// `auto_center` enabled, that acknowledgment used to run
+/// `autocenter_window_on_focus`, re-centering the remembered window and
+/// sliding the strip away from the position it was just restored to — visible
+/// as a "wiggle" on every switch.
+#[test]
+fn test_virtual_workspace_switch_focus_echo_does_not_recenter_strip() {
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(true),
+            virtual_workspace_animations: Some(false),
+            animation_speed: Some(12.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new().with_config(config).with_windows(6);
+
+    let settle = |h: &mut TestHarness| {
+        for _ in 0..10 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        settle(h);
+    };
+    let strip_x = |h: &mut TestHarness| -> i32 {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+        q.single(world).expect("exactly one active strip").0.x
+    };
+
+    pump(&mut h, Command::PrintState);
+
+    // Seed VW1 with one window so focus genuinely moves across the switch.
+    h.mock_state.focus_window(5);
+    settle(&mut h);
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+    );
+
+    // Focus window 0 and let auto-center settle the strip on it.
+    h.mock_state.focus_window(0);
+    settle(&mut h);
+    let centered_x = strip_x(&mut h);
+
+    // Displace the strip so the focused window is off its centered position,
+    // as any scroll would leave it. Written directly instead of swiping: the
+    // swipe pipeline's finger-lift threshold is wall-clock based, which makes
+    // event order load-dependent and the test flaky.
+    let saved_x = centered_x - 250;
+    {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&mut Position, With<ActiveWorkspaceMarker>>();
+        q.single_mut(world).expect("exactly one active strip").0.x = saved_x;
+    }
+    settle(&mut h);
+    assert_eq!(
+        strip_x(&mut h),
+        saved_x,
+        "test setup: the displaced strip position must stick"
+    );
+
+    // Switch to VW1; deliver the OS focus acknowledgment for its window.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    h.mock_state.focus_window(5);
+    settle(&mut h);
+
+    // Switch back to VW0: the strip must restore to its saved scroll position.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(0)));
+    assert_eq!(
+        strip_x(&mut h),
+        saved_x,
+        "strip must restore to its saved position on switch-back"
+    );
+
+    // The delayed focus acknowledgment for the remembered window must not
+    // re-center the strip away from the restored position.
+    h.mock_state.focus_window(0);
+    settle(&mut h);
+    let final_x = strip_x(&mut h);
+    assert_eq!(
+        final_x, saved_x,
+        "late focus acknowledgment re-centered the strip (wiggle): \
+         restored to {saved_x}, ended at {final_x} (centered would be {centered_x})"
+    );
+}
+
 /// With `auto_center` off, a reshuffle around the leftmost window of a
 /// scrollable strip must pin the strip to the left edge — the leftmost
 /// window's left edge must touch the display's left edge, never leaving empty


### PR DESCRIPTION
## Summary

Three related bugs when switching virtual workspaces (closes #321):

**Bug 1: strip drifts sideways after switching back** (`virtual_workspace_animations = false`)
The hidden strip kept its `Scrolling` component (with residual swipe velocity). `scrolling_integrator` kept updating `scroll.position` while the strip was off-screen; on restore, `apply_scrolling_constraints` applied the drifted value and overrode the correctly saved position.

**Bug 2: in-flight strip animation continues after switching away**
If the strip had a live `RepositionMarker` (mid-animation) at the moment of switching, `animate_entities` kept moving the hidden strip every frame — making both strips briefly visible at the same time, and potentially corrupting the saved restore position.

**Fix for 1 & 2** (`show_active_workspace`): remove both `Scrolling` and `RepositionMarker` from a strip when hiding it. The saved origin already captures the `RepositionMarker` destination (the intended final position), so restoring still lands in the right place.

**Bug 3: window "wiggles" on every switch (restore, then slide to a second position)**
`show_active_workspace` restores the strip to its saved origin and re-focuses the remembered window. That focus lands *after* the strip is already placed, through two delayed paths, and each re-moved the strip:

1. `focus_entity` inserts `FocusedMarker` directly, one command-flush after the restore. `autocenter_window_on_focus` reacts to `Added<FocusedMarker>` and (with `auto_center` on) re-centered the remembered window, sliding the strip away from the position it was just restored to.
2. The OS acknowledges the focus with `WindowFocused` events several ticks later still (plus a duplicate synthesized by `front_switched_trigger`). Those hit the `already_focused` branch of `window_focused_trigger`, which called `reshuffle_around` and could scroll the strip again to "expose" the window.

The existing `is_added(ActiveWorkspaceMarker)` guards in `reshuffle_layout_strip` / `ensure_visible_in_strip` only cover the activation tick itself, so both delayed paths sailed past them. Visible result: on every VW switch the window appears at its previous position, then animates a short distance to a "corrected" one.

**Fix for 3** (`RestoreFocusMarker`): when `show_active_workspace` issues the restore-focus, it spawns a guard entity naming the focused window, paired with a `Timeout` so the existing `timeout_ticker` expires it after 2 s. While the guard is alive:

- `autocenter_window_on_focus` skips the named entity (no re-centering of the restore-focus);
- the duplicate-focus reshuffle in `window_focused_trigger` skips the named entity, absorbing however many acknowledgments arrive.

Focus moving to *any other* window despawns the guard immediately, so user-initiated focus changes right after a switch behave exactly as before. The guard rides the existing `Timeout` machinery rather than a new system: adding a system to the `Update` schedule measurably perturbed the ordering-sensitive scroll tests.

## Test plan

- [x] `cargo test` — full suite, 167 tests, green (verified over 15 consecutive runs; the new test is stable)
- [x] New regression test `test_virtual_workspace_switch_focus_echo_does_not_recenter_strip`: displaces the strip off its auto-centered position, round-trips VW0 → VW1 → VW0, then delivers the delayed OS focus acknowledgment and asserts the strip stays at its restored position. Fails with the guard removed (strip re-centers), passes with it.
- [x] `cargo clippy` clean, `cargo fmt` applied

## Notes

- `test_scrolling` and `test_mid_strip_insertion_preserves_window_x` flake under parallel load on this branch **and** on clean `testing` (~3/15 full-suite runs): the swipe pipeline's finger-lift threshold (`swiping_timeout`, 50 ms) is wall-clock based, so heavily loaded runs end swipes earlier than fast ones. Pre-existing, not touched here; worth a follow-up that mocks the clock out of `Scrolling.last_event`.