### PR TITLE
fix: Preserve window width ratio when moving between displays

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -983,6 +983,9 @@ fn to_next_display(
     let Some(size) = windows.size(entity) else {
         return;
     };
+    // Capture the window's width ratio (width relative to the source display's
+    // width) before the move so it can be preserved on the target display.
+    let width_ratio = windows.width_ratio(entity);
     let dest = other.bounds().min.with_x(center - size.x / 2);
     commands.reposition_entity(entity, dest);
 
@@ -1015,26 +1018,30 @@ fn to_next_display(
         target_strip.append(entity);
         commands.reshuffle_around(entity);
 
-        // Add a delayed refresh of the window size - because the otehr display can have different bounds.
+        // Add a delayed refresh of the window size - because the other display can have different bounds.
         let display_entity = child.parent();
         let moved_window = entity;
         let refresh_size = move |windows: Query<&Bounds, With<Window>>,
                                  displays: Query<(&Display, Option<&DockPosition>)>,
                                  mut commands: Commands,
                                  config: Res<Config>| {
-            let viewport = displays
-                .get(display_entity)
-                .ok()
-                .map(|(display, dock)| display.actual_display_bounds(dock, &config));
-            if let Some(viewport_bounds) = viewport
-                && let Ok(Bounds(bounds)) = windows.get(moved_window)
-            {
+            let Ok((display, dock)) = displays.get(display_entity) else {
+                return;
+            };
+            let viewport_bounds = display.actual_display_bounds(dock, &config);
+            if let Ok(Bounds(bounds)) = windows.get(moved_window) {
                 debug!("Refreshing size of window {entity}");
-                commands.resize_entity(moved_window, bounds.with_y(viewport_bounds.height()));
+                // Preserve the window's width ratio relative to the display width
+                let width = width_ratio.map_or(bounds.x, |ratio| {
+                    (ratio * f64::from(display.bounds().width())).round() as i32
+                });
+                let size = Size::new(width, viewport_bounds.height());
+                commands.resize_entity(moved_window, size);
+                commands.reshuffle_around(moved_window);
             }
         };
         let system_id = commands.register_system(refresh_size);
-        Timeout::callback(Duration::from_secs(1), system_id, &mut commands);
+        Timeout::callback(Duration::from_millis(150), system_id, &mut commands);
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -945,6 +945,7 @@ fn to_next_display(
         (With<SelectedVirtualMarker>, Without<ActiveWorkspaceMarker>),
     >,
     window_manager: Res<WindowManager>,
+    config: Res<Config>,
     mut commands: Commands,
 ) {
     let Some(Operation::ToNextDisplay(move_focus)) =
@@ -966,6 +967,13 @@ fn to_next_display(
         return;
     }
 
+    // Width relative to the source display's usable viewport (dock- and
+    // padding-adjusted). Captured before `other()` mutably borrows
+    // `active_display`. This matches how `resize_window` computes the ratio
+    // against `actual_bounds`, so a fixed (non-auto-hiding) dock is accounted
+    // for on both the source and target displays.
+    let source_viewport_width = active_display.actual_bounds(&config).width();
+
     let Some(other) = active_display.other().next() else {
         debug!("no other display to move window to.");
         return;
@@ -983,9 +991,8 @@ fn to_next_display(
     let Some(size) = windows.size(entity) else {
         return;
     };
-    // Capture the window's width ratio (width relative to the source display's
-    // width) before the move so it can be preserved on the target display.
-    let width_ratio = windows.width_ratio(entity);
+    let width_ratio =
+        (source_viewport_width > 0).then(|| f64::from(size.x) / f64::from(source_viewport_width));
     let dest = other.bounds().min.with_x(center - size.x / 2);
     commands.reposition_entity(entity, dest);
 
@@ -1031,9 +1038,11 @@ fn to_next_display(
             let viewport_bounds = display.actual_display_bounds(dock, &config);
             if let Ok(Bounds(bounds)) = windows.get(moved_window) {
                 debug!("Refreshing size of window {entity}");
-                // Preserve the window's width ratio relative to the display width
+                // Preserve the window's width ratio relative to the target
+                // display's usable viewport (dock- and padding-adjusted), so a
+                // fixed dock is accounted for consistently with the source.
                 let width = width_ratio.map_or(bounds.x, |ratio| {
-                    (ratio * f64::from(display.bounds().width())).round() as i32
+                    (ratio * f64::from(viewport_bounds.width())).round() as i32
                 });
                 let size = Size::new(width, viewport_bounds.height());
                 commands.resize_entity(moved_window, size);


### PR DESCRIPTION
## Problem

When a window is moved to another display, its **absolute** pixel width was preserved. Moving a window from a high-resolution display to a lower-resolution one therefore made it too wide, and moving the other way made it too narrow. (Height was already reconciled with the destination display.)

## Fix

- Capture the window's width ratio (width relative to the **source** display's width) before the move, and reapply it against the destination display's width in the delayed resize. This matches how `commit_window_size` defines `WidthRatio`, so the proportional size is preserved across displays of differing resolutions.
- Re-run `reshuffle_around` after the delayed resize so the edge invariant (leftmost window flush-left, rightmost flush-right when there's more than one) is re-enforced against the new width. Previously the reshuffle ran at move time with the old width, so shrinking the window afterwards left a gap on the right and the window only partially visible.
- Shorten the post-move resize delay from `1s` to `150ms`. The reposition is a non-animated AX call that lands within a frame or two, so a full second was far more than needed and produced a visible lag before the width adjusted.

## Testing

Manually verified moving a focused window between displays of differing resolutions in both directions. The window keeps its proportional width and the strip edges stay flush.