### PR TITLE
fix: floating windows query state

### DIFF
--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -11,13 +11,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
+use tracing::warn;
 
 use super::{Command, Operation};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::Windows;
 use crate::ecs::state::{PaneruActiveState, PaneruQueryState, PaneruVirtualWorkspaceState};
 use crate::ecs::{
-    ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker, SelectedVirtualMarker,
+    ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker, SelectedVirtualMarker, Unmanaged,
 };
 use crate::events::Event;
 use crate::manager::{Application, Display, WindowManager};
@@ -75,6 +76,7 @@ impl From<&PaneruActiveState> for FocusBroadcastSnapshot {
 #[derive(Clone, Copy, Default)]
 struct StateBroadcastSignals {
     virtual_workspace_changed: bool,
+    windows_changed: bool,
     window_focused: bool,
 }
 
@@ -96,6 +98,7 @@ impl StateBroadcastIntent {
     ) -> Self {
         let mut intent = Self {
             virtual_workspace_changed: signals.virtual_workspace_changed,
+            windows_changed: signals.windows_changed,
             window_focused: signals.window_focused,
             ..Self::default()
         };
@@ -110,7 +113,6 @@ impl StateBroadcastIntent {
                 | Event::WindowDestroyed { .. }
                 | Event::WindowMinimized { .. }
                 | Event::WindowDeminimized { .. }
-                | Event::WindowMoved { .. }
                 | Event::Command {
                     command:
                         Command::Window(
@@ -186,11 +188,11 @@ fn state_query_handler(
             continue;
         };
 
-        let state =
-            PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager);
-        let response = state
-            .to_query_json(*kind)
-            .unwrap_or_else(|err| json!({ "error": err.to_string() }).to_string());
+        let response =
+            PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager)
+                .map_err(|err| err.to_string())
+                .and_then(|state| state.to_query_json(*kind).map_err(|err| err.to_string()))
+                .unwrap_or_else(|err| json!({ "error": err }).to_string());
         _ = respond_to.send(response);
     }
 }
@@ -350,6 +352,15 @@ fn state_event_broadcast_handler(
 
     let signals = StateBroadcastSignals {
         virtual_workspace_changed: !active_workspace_changes.is_empty(),
+        windows_changed: events.iter().any(|event| {
+            let Event::WindowMoved { window_id } = event else {
+                return false;
+            };
+            windows
+                .find(*window_id)
+                .and_then(|(_, entity)| windows.get_managed(entity))
+                .is_some_and(|(_, _, unmanaged)| matches!(unmanaged, Some(Unmanaged::Floating)))
+        }),
         window_focused: !focused_changes.is_empty(),
     };
     let intent = StateBroadcastIntent::from_events(events, signals);
@@ -357,9 +368,17 @@ fn state_event_broadcast_handler(
         return;
     }
 
-    let state = intent.requires_state().then(|| {
-        PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager)
-    });
+    let state = if intent.requires_state() {
+        match PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager) {
+            Ok(state) => Some(state),
+            Err(err) => {
+                warn!("extracting query state for broadcast: {err}");
+                return;
+            }
+        }
+    } else {
+        None
+    };
     let outgoing = collect_state_broadcast_events_for_intent(
         &intent,
         state.as_ref(),
@@ -479,32 +498,26 @@ mod tests {
     }
 
     #[test]
-    fn test_state_broadcasts_window_moves_and_skips_unchanged_state() {
+    fn test_state_broadcasts_floating_window_moves_and_skips_unchanged_state() {
         let state =
             query_state_with_active_window(26_261, "com.cmuxterm.app", "term", 2, vec![26_261]);
         let mut cache = StateBroadcastCache::default();
         let events = [PaneruEvent::WindowMoved { window_id: 26_261 }];
+        let signals = StateBroadcastSignals {
+            windows_changed: true,
+            ..StateBroadcastSignals::default()
+        };
 
-        let outgoing = collect_state_broadcast_events(
-            events.iter(),
-            &state,
-            &mut cache,
-            |_| None,
-            StateBroadcastSignals::default(),
-        );
+        let outgoing =
+            collect_state_broadcast_events(events.iter(), &state, &mut cache, |_| None, signals);
 
         assert_eq!(outgoing.len(), 1);
         assert_eq!(outgoing[0]["event"], "windows_changed");
         assert_eq!(outgoing[0]["virtual_workspace_number"], 2);
         assert_eq!(outgoing[0]["active"]["focused_window_id"], 26_261);
 
-        let duplicate = collect_state_broadcast_events(
-            events.iter(),
-            &state,
-            &mut cache,
-            |_| None,
-            StateBroadcastSignals::default(),
-        );
+        let duplicate =
+            collect_state_broadcast_events(events.iter(), &state, &mut cache, |_| None, signals);
 
         assert!(duplicate.is_empty());
 
@@ -520,7 +533,7 @@ mod tests {
             &changed_state,
             &mut cache,
             |_| None,
-            StateBroadcastSignals::default(),
+            signals,
         );
 
         assert_eq!(changed.len(), 1);
@@ -566,6 +579,7 @@ mod tests {
         let unrelated = StateBroadcastIntent::from_events(
             [
                 PaneruEvent::ThemeChanged,
+                PaneruEvent::WindowMoved { window_id: 10 },
                 PaneruEvent::MouseUp {
                     point: objc2_core_foundation::CGPoint::default(),
                     modifiers: crate::platform::Modifiers::empty(),

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -16,9 +16,11 @@ use super::{Command, Operation};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::Windows;
 use crate::ecs::state::{PaneruActiveState, PaneruQueryState, PaneruVirtualWorkspaceState};
-use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker};
+use crate::ecs::{
+    ActiveDisplayMarker, ActiveWorkspaceMarker, FocusedMarker, SelectedVirtualMarker,
+};
 use crate::events::Event;
-use crate::manager::{Application, Display};
+use crate::manager::{Application, Display, WindowManager};
 use crate::platform::WinID;
 
 #[derive(Default, Resource)]
@@ -167,17 +169,24 @@ pub(super) fn register_query_commands(app: &mut App) {
 #[allow(clippy::needless_pass_by_value)]
 fn state_query_handler(
     mut messages: MessageReader<Event>,
-    workspaces: Query<(&ChildOf, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    workspaces: Query<(
+        &ChildOf,
+        &LayoutStrip,
+        Has<ActiveWorkspaceMarker>,
+        Has<SelectedVirtualMarker>,
+    )>,
     displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
     windows: Windows,
     apps: Query<&Application>,
+    window_manager: Res<WindowManager>,
 ) {
     for event in messages.read() {
         let Event::StateQuery { kind, respond_to } = event else {
             continue;
         };
 
-        let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
+        let state =
+            PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager);
         let response = state
             .to_query_json(*kind)
             .unwrap_or_else(|err| json!({ "error": err.to_string() }).to_string());
@@ -319,12 +328,18 @@ fn state_event_broadcast_handler(
     mut messages: MessageReader<Event>,
     mut subscribers: ResMut<StateSubscribers>,
     mut cache: ResMut<StateBroadcastCache>,
-    workspaces: Query<(&ChildOf, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    workspaces: Query<(
+        &ChildOf,
+        &LayoutStrip,
+        Has<ActiveWorkspaceMarker>,
+        Has<SelectedVirtualMarker>,
+    )>,
     focused_changes: Query<Entity, Added<FocusedMarker>>,
     active_workspace_changes: Query<Entity, Added<ActiveWorkspaceMarker>>,
     displays: Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
     windows: Windows,
     apps: Query<&Application>,
+    window_manager: Res<WindowManager>,
 ) {
     let events = messages.read().collect::<Vec<_>>();
 
@@ -341,9 +356,9 @@ fn state_event_broadcast_handler(
         return;
     }
 
-    let state = intent
-        .requires_state()
-        .then(|| PaneruQueryState::extract(&workspaces, &displays, &windows, &apps));
+    let state = intent.requires_state().then(|| {
+        PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager)
+    });
     let outgoing = collect_state_broadcast_events_for_intent(
         &intent,
         state.as_ref(),

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -110,6 +110,7 @@ impl StateBroadcastIntent {
                 | Event::WindowDestroyed { .. }
                 | Event::WindowMinimized { .. }
                 | Event::WindowDeminimized { .. }
+                | Event::WindowMoved { .. }
                 | Event::Command {
                     command:
                         Command::Window(
@@ -478,14 +479,11 @@ mod tests {
     }
 
     #[test]
-    fn test_state_broadcast_coalesces_windows_changed_and_skips_unchanged_state() {
+    fn test_state_broadcasts_window_moves_and_skips_unchanged_state() {
         let state =
             query_state_with_active_window(26_261, "com.cmuxterm.app", "term", 2, vec![26_261]);
         let mut cache = StateBroadcastCache::default();
-        let events = [
-            PaneruEvent::WindowMinimized { window_id: 26_261 },
-            PaneruEvent::WindowDeminimized { window_id: 26_261 },
-        ];
+        let events = [PaneruEvent::WindowMoved { window_id: 26_261 }];
 
         let outgoing = collect_state_broadcast_events(
             events.iter(),

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -16,8 +16,8 @@ use crate::{
     config::Config,
     ecs::{
         ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, FullWidthMarker, Initializing,
-        LayoutPosition, NativeFullscreenMarker, Position, PreviousManagedStrip, RepositionMarker,
-        ResizeMarker, Unmanaged, WidthRatio, layout::LayoutStrip,
+        LayoutPosition, NativeFullscreenMarker, Position, RepositionMarker, ResizeMarker,
+        Unmanaged, WidthRatio, layout::LayoutStrip,
     },
     manager::{Application, Display, Origin, Size, Window},
     platform::{ProcessSerialNumber, WinID},
@@ -211,7 +211,6 @@ pub struct Windows<'w, 's> {
         ),
     >,
     focus: Query<'w, 's, (&'static Window, Entity), With<FocusedMarker>>,
-    previous_managed_strip: Query<'w, 's, &'static PreviousManagedStrip>,
     previous_size: Query<
         'w,
         's,
@@ -273,10 +272,6 @@ impl Windows<'_, '_> {
         self.all.iter().find_map(|(window, entity, _, unmanaged)| {
             (unmanaged.is_none() && window.id() == window_id).then_some((window, entity))
         })
-    }
-
-    pub(crate) fn previous_managed_strip(&self, entity: Entity) -> Option<&PreviousManagedStrip> {
-        self.previous_managed_strip.get(entity).ok()
     }
 
     pub fn focused(&self) -> Option<(&Window, Entity)> {

--- a/src/ecs/params.rs
+++ b/src/ecs/params.rs
@@ -16,8 +16,8 @@ use crate::{
     config::Config,
     ecs::{
         ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, FullWidthMarker, Initializing,
-        LayoutPosition, NativeFullscreenMarker, Position, RepositionMarker, ResizeMarker,
-        Unmanaged, WidthRatio, layout::LayoutStrip,
+        LayoutPosition, NativeFullscreenMarker, Position, PreviousManagedStrip, RepositionMarker,
+        ResizeMarker, Unmanaged, WidthRatio, layout::LayoutStrip,
     },
     manager::{Application, Display, Origin, Size, Window},
     platform::{ProcessSerialNumber, WinID},
@@ -211,6 +211,7 @@ pub struct Windows<'w, 's> {
         ),
     >,
     focus: Query<'w, 's, (&'static Window, Entity), With<FocusedMarker>>,
+    previous_managed_strip: Query<'w, 's, &'static PreviousManagedStrip>,
     previous_size: Query<
         'w,
         's,
@@ -272,6 +273,10 @@ impl Windows<'_, '_> {
         self.all.iter().find_map(|(window, entity, _, unmanaged)| {
             (unmanaged.is_none() && window.id() == window_id).then_some((window, entity))
         })
+    }
+
+    pub(crate) fn previous_managed_strip(&self, entity: Entity) -> Option<&PreviousManagedStrip> {
+        self.previous_managed_strip.get(entity).ok()
     }
 
     pub fn focused(&self) -> Option<(&Window, Entity)> {

--- a/src/ecs/state.rs
+++ b/src/ecs/state.rs
@@ -17,9 +17,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::Windows;
-use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, Unmanaged};
-use crate::manager::Application;
-use crate::manager::Display;
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, SelectedVirtualMarker, Unmanaged};
+use crate::manager::{Application, Display, WindowManager};
 use crate::platform::{Pid, ProcessSerialNumber, WinID, WorkspaceId};
 
 pub const STATE_FILE_NAME: &str = "state.json";
@@ -425,18 +424,22 @@ struct SavedWorkspaceBuilder {
 impl PaneruQueryState {
     #[allow(clippy::type_complexity)]
     pub fn extract(
-        workspaces: &Query<(&ChildOf, &LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+        workspaces: &Query<(
+            &ChildOf,
+            &LayoutStrip,
+            Has<ActiveWorkspaceMarker>,
+            Has<SelectedVirtualMarker>,
+        )>,
         displays: &Query<(&Display, Entity, Has<ActiveDisplayMarker>)>,
         windows: &Windows,
         apps: &Query<&Application>,
+        window_manager: &WindowManager,
     ) -> Self {
-        let focused = windows.focused();
-        let focused_entity = focused.map(|(_, entity)| entity);
+        let focused_entity = windows.focused().map(|(_, entity)| entity);
 
         let active_display = displays
             .iter()
-            .find(|(_, _, active)| *active)
-            .map(|(display, entity, _)| (display.id(), entity));
+            .find_map(|(display, entity, active)| active.then_some((display.id(), entity)));
 
         let mut virtual_workspaces = Vec::new();
         let mut workspace_max_numbers: HashMap<WorkspaceId, u32> = HashMap::new();
@@ -445,19 +448,25 @@ impl PaneruQueryState {
             ..PaneruActiveState::default()
         };
 
-        for (child, strip, active_workspace) in workspaces {
+        for (child, strip, active_workspace, selected_workspace) in workspaces {
+            let floating = (active_workspace || selected_workspace)
+                .then(|| {
+                    window_manager
+                        .windows_in_workspace(strip.id())
+                        .unwrap_or_default()
+                })
+                .into_iter()
+                .flatten()
+                .filter_map(|window_id| {
+                    let (_, entity) = windows.find(window_id)?;
+                    let (_, _, unmanaged) = windows.get_managed(entity)?;
+                    (matches!(unmanaged, Some(Unmanaged::Floating)) && !strip.contains(entity))
+                        .then_some(entity)
+                });
             let row_windows = strip
                 .all_windows()
                 .into_iter()
-                .chain(windows.iter().filter_map(|(_, entity)| {
-                    let (_, _, unmanaged) = windows.get_managed(entity)?;
-                    let previous = windows.previous_managed_strip(entity)?;
-                    (matches!(unmanaged, Some(Unmanaged::Floating))
-                        && !strip.contains(entity)
-                        && previous.workspace_id == strip.id()
-                        && previous.virtual_index == strip.virtual_index)
-                        .then_some(entity)
-                }))
+                .chain(floating)
                 .filter_map(|entity| {
                     let (window, _, unmanaged) = windows.get_managed(entity)?;
                     let (_, _, app_entity) = windows.find_parent(window.id())?;

--- a/src/ecs/state.rs
+++ b/src/ecs/state.rs
@@ -422,7 +422,7 @@ struct SavedWorkspaceBuilder {
 }
 
 impl PaneruQueryState {
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_lines, clippy::type_complexity)]
     pub fn extract(
         workspaces: &Query<(
             &ChildOf,
@@ -434,12 +434,15 @@ impl PaneruQueryState {
         windows: &Windows,
         apps: &Query<&Application>,
         window_manager: &WindowManager,
-    ) -> Self {
+    ) -> crate::errors::Result<Self> {
         let focused_entity = windows.focused().map(|(_, entity)| entity);
 
         let active_display = displays
             .iter()
             .find_map(|(display, entity, active)| active.then_some((display.id(), entity)));
+        let active_workspace_id = workspaces
+            .iter()
+            .find_map(|(_, strip, active, _)| active.then_some(strip.id()));
 
         let mut virtual_workspaces = Vec::new();
         let mut workspace_max_numbers: HashMap<WorkspaceId, u32> = HashMap::new();
@@ -449,20 +452,20 @@ impl PaneruQueryState {
         };
 
         for (child, strip, active_workspace, selected_workspace) in workspaces {
-            let floating = (active_workspace || selected_workspace)
-                .then(|| {
-                    window_manager
-                        .windows_in_workspace(strip.id())
-                        .unwrap_or_default()
-                })
-                .into_iter()
-                .flatten()
-                .filter_map(|window_id| {
-                    let (_, entity) = windows.find(window_id)?;
-                    let (_, _, unmanaged) = windows.get_managed(entity)?;
-                    (matches!(unmanaged, Some(Unmanaged::Floating)) && !strip.contains(entity))
-                        .then_some(entity)
-                });
+            let floating = if active_workspace
+                || selected_workspace && active_workspace_id != Some(strip.id())
+            {
+                window_manager.windows_in_workspace(strip.id())?
+            } else {
+                Vec::new()
+            }
+            .into_iter()
+            .filter_map(|window_id| {
+                let (_, entity) = windows.find(window_id)?;
+                let (_, _, unmanaged) = windows.get_managed(entity)?;
+                (matches!(unmanaged, Some(Unmanaged::Floating)) && !strip.contains(entity))
+                    .then_some(entity)
+            });
             let row_windows = strip
                 .all_windows()
                 .into_iter()
@@ -539,12 +542,12 @@ impl PaneruQueryState {
         virtual_workspaces
             .sort_by_key(|workspace| (workspace.native_workspace_id, workspace.number));
 
-        Self {
+        Ok(Self {
             version: 1,
             timestamp: now_timestamp(),
             active,
             virtual_workspaces,
-        }
+        })
     }
 
     pub fn to_query_json(&self, kind: StateQueryKind) -> serde_json::Result<String> {

--- a/src/ecs/state.rs
+++ b/src/ecs/state.rs
@@ -17,7 +17,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::ecs::layout::{Column, LayoutStrip, StackItem};
 use crate::ecs::params::Windows;
-use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, Unmanaged};
 use crate::manager::Application;
 use crate::manager::Display;
 use crate::platform::{Pid, ProcessSerialNumber, WinID, WorkspaceId};
@@ -448,9 +448,18 @@ impl PaneruQueryState {
         for (child, strip, active_workspace) in workspaces {
             let row_windows = strip
                 .all_windows()
-                .iter()
+                .into_iter()
+                .chain(windows.iter().filter_map(|(_, entity)| {
+                    let (_, _, unmanaged) = windows.get_managed(entity)?;
+                    let previous = windows.previous_managed_strip(entity)?;
+                    (matches!(unmanaged, Some(Unmanaged::Floating))
+                        && !strip.contains(entity)
+                        && previous.workspace_id == strip.id()
+                        && previous.virtual_index == strip.virtual_index)
+                        .then_some(entity)
+                }))
                 .filter_map(|entity| {
-                    let (window, _, unmanaged) = windows.get_managed(*entity)?;
+                    let (window, _, unmanaged) = windows.get_managed(entity)?;
                     let (_, _, app_entity) = windows.find_parent(window.id())?;
                     let app = apps.get(app_entity).ok()?;
                     let bundle_id = app.bundle_id().unwrap_or_default().clone();
@@ -461,8 +470,8 @@ impl PaneruQueryState {
                         bundle_id,
                         app_name,
                         title,
-                        focused: focused_entity == Some(*entity),
-                        floating: unmanaged.is_some(),
+                        focused: focused_entity == Some(entity),
+                        floating: matches!(unmanaged, Some(Unmanaged::Floating)),
                     })
                 })
                 .collect::<Vec<_>>();

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -599,9 +599,20 @@ pub(super) fn window_unmanaged_trigger(
 
     workspaces.into_iter().for_each(|mut strip| {
         if strip.contains(entity) {
+            remember_managed_strip(entity, &strip, &mut commands);
             strip.remove(entity);
         }
     });
+}
+
+fn remember_managed_strip(entity: Entity, strip: &LayoutStrip, commands: &mut Commands) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
+        entity_commands.try_insert(PreviousManagedStrip {
+            workspace_id: strip.id(),
+            virtual_index: strip.virtual_index,
+            index: strip.index_of(entity).unwrap_or(strip.len()),
+        });
+    }
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -633,15 +644,7 @@ pub(super) fn window_minimized_trigger(
                 );
             }
             if strip.contains(entity) {
-                if let Ok(index) = strip.index_of(entity)
-                    && let Ok(mut entity_commands) = commands.get_entity(entity)
-                {
-                    entity_commands.try_insert(PreviousManagedStrip {
-                        workspace_id: strip.id(),
-                        virtual_index: strip.virtual_index,
-                        index,
-                    });
-                }
+                remember_managed_strip(entity, &strip, &mut commands);
                 strip.remove(entity);
             }
         }
@@ -1042,23 +1045,37 @@ pub(super) fn apply_window_positions(
             continue;
         }
 
-        // During startup, the window is already inserted into some strip.
-        let allready_inserted = workspaces
-            .iter_mut()
-            .find_map(|(strip, _)| strip.contains(entity).then_some(strip));
         let properties = WindowProperties::new(app, window, &config);
 
         if properties.floating() {
+            let remembered = if let Some(mut strip) = workspaces
+                .iter_mut()
+                .find_map(|(strip, _)| strip.contains(entity).then_some(strip))
+            {
+                remember_managed_strip(entity, &strip, &mut commands);
+                strip.remove(entity);
+                true
+            } else {
+                false
+            };
+            if !remembered
+                && let Some(strip) = workspaces
+                    .iter()
+                    .find_map(|(strip, active)| active.then_some(strip))
+            {
+                remember_managed_strip(entity, strip, &mut commands);
+            }
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 // Avoid managing window if it's floating.
                 entity_commands.try_insert(Unmanaged::Floating);
             }
-            if let Some(mut strip) = allready_inserted {
-                strip.remove(entity);
-            }
             continue;
         }
 
+        // During startup, the window is already inserted into some strip.
+        let allready_inserted = workspaces
+            .iter_mut()
+            .find_map(|(strip, _)| strip.contains(entity).then_some(strip));
         if allready_inserted.is_none()
             && let Some(mut strip) = workspaces
                 .iter_mut()

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -599,7 +599,6 @@ pub(super) fn window_unmanaged_trigger(
 
     workspaces.into_iter().for_each(|mut strip| {
         if strip.contains(entity) {
-            remember_managed_strip(entity, &strip, &mut commands);
             strip.remove(entity);
         }
     });
@@ -1048,22 +1047,11 @@ pub(super) fn apply_window_positions(
         let properties = WindowProperties::new(app, window, &config);
 
         if properties.floating() {
-            let remembered = if let Some(mut strip) = workspaces
+            if let Some(mut strip) = workspaces
                 .iter_mut()
                 .find_map(|(strip, _)| strip.contains(entity).then_some(strip))
             {
-                remember_managed_strip(entity, &strip, &mut commands);
                 strip.remove(entity);
-                true
-            } else {
-                false
-            };
-            if !remembered
-                && let Some(strip) = workspaces
-                    .iter()
-                    .find_map(|(strip, active)| active.then_some(strip))
-            {
-                remember_managed_strip(entity, strip, &mut commands);
             }
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
                 // Avoid managing window if it's floating.

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -799,6 +799,36 @@ fn toggle_floating_layer_flips_state() {
 }
 
 #[test]
+fn test_unfloat_after_virtual_switch_uses_active_workspace() {
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Manage),
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Manage),
+        },
+    ];
+
+    TestHarness::new()
+        .with_windows(2)
+        .on_iteration(3, |world, _state| {
+            let entity = find_window_entity(0, world);
+            let mut query = world.query_filtered::<&LayoutStrip, With<ActiveWorkspaceMarker>>();
+            let strip = query.single(world).expect("an active virtual workspace");
+
+            assert_eq!(strip.virtual_index, 1);
+            assert!(strip.contains(entity));
+        })
+        .run(commands);
+}
+
+#[test]
 fn focus_unmanaged_ignores_floats_from_other_workspaces() {
     let workspaces = vec![TEST_WORKSPACE_ID, TEST_WORKSPACE_ID + 1];
     let harness = TestHarness::new()

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -579,7 +579,7 @@ impl MockState {
         wm.expect_find_existing_application_windows()
             .returning(move |app, spaces, _config| {
                 let pid = app.pid();
-                let windows = s
+                let mut windows = s
                     .inner
                     .force_read()
                     .windows
@@ -589,6 +589,7 @@ impl MockState {
                             .then_some(s.create_window(w.id))
                     })
                     .collect::<Vec<_>>();
+                windows.sort_unstable_by_key(|window| window.id());
                 Ok((windows, vec![]))
             });
 

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -8,6 +8,7 @@ use crate::ecs::state::{
     SavedStrip, SavedWindow, SavedWorkspace,
 };
 use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::events::Event;
 use crate::manager::{Application, Display};
 use crate::platform::{Pid, ProcessSerialNumber, WinID};
 use crate::tests::{
@@ -47,6 +48,12 @@ type QueryStateExtractionState<'w, 's> = SystemState<(
     Windows<'w, 's>,
     Query<'w, 's, &'static Application>,
 )>;
+
+fn extract_query_state(world: &mut World) -> PaneruQueryState {
+    let mut system_state: QueryStateExtractionState<'_, '_> = SystemState::new(world);
+    let (workspaces, displays, windows, apps) = system_state.get(world);
+    PaneruQueryState::extract(&workspaces, &displays, &windows, &apps)
+}
 
 #[test]
 fn test_state_serialization() {
@@ -536,10 +543,7 @@ fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
         ChildOf(display_entity),
     ));
 
-    let mut system_state: QueryStateExtractionState<'_, '_> = SystemState::new(world);
-    let (workspaces, displays, windows, apps) = system_state.get(world);
-
-    let state = PaneruQueryState::extract(&workspaces, &displays, &windows, &apps);
+    let state = extract_query_state(world);
 
     assert_eq!(state.version, 1);
     assert_eq!(state.active.virtual_workspace_number, Some(1));
@@ -564,4 +568,42 @@ fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
         json["virtual_workspaces"][0]["windows"][0]["bundle_id"],
         "test"
     );
+}
+
+#[test]
+fn test_query_state_includes_floating_windows() {
+    use crate::commands::{Command, Operation};
+    use crate::tests::harness::TestHarness;
+
+    let mut harness = TestHarness::new().with_windows(1);
+    harness.app.update();
+    harness.app.world_mut().write_message(Event::Command {
+        command: Command::Window(Operation::Manage),
+    });
+    harness.app.update();
+
+    let state = extract_query_state(harness.world());
+
+    assert_eq!(state.active.focused_window_id, Some(0));
+    assert_eq!(state.virtual_workspaces[0].windows.len(), 1);
+    assert!(state.virtual_workspaces[0].windows[0].focused);
+    assert!(state.virtual_workspaces[0].windows[0].floating);
+}
+
+#[test]
+fn test_query_state_includes_configured_floating_windows() {
+    use crate::config::{Config, MainOptions, WindowParams};
+    use crate::tests::harness::TestHarness;
+
+    let mut params = WindowParams::new(".*", Some("test".to_string()));
+    params.floating = Some(true);
+    let config: Config = (MainOptions::default(), vec![params]).into();
+    let mut harness = TestHarness::new().with_config(config).with_windows(1);
+    harness.app.update();
+    harness.app.update();
+
+    let state = extract_query_state(harness.world());
+
+    assert_eq!(state.virtual_workspaces[0].windows.len(), 1);
+    assert!(state.virtual_workspaces[0].windows[0].floating);
 }

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -7,9 +7,9 @@ use crate::ecs::state::{
     PaneruQueryState, PaneruState, SavedColumn, SavedDisplay, SavedRect, SavedStackItem,
     SavedStrip, SavedWindow, SavedWorkspace,
 };
-use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker};
+use crate::ecs::{ActiveDisplayMarker, ActiveWorkspaceMarker, SelectedVirtualMarker};
 use crate::events::Event;
-use crate::manager::{Application, Display};
+use crate::manager::{Application, Display, WindowManager};
 use crate::platform::{Pid, ProcessSerialNumber, WinID};
 use crate::tests::{
     TEST_DISPLAY_HEIGHT, TEST_DISPLAY_ID, TEST_DISPLAY_WIDTH, TEST_MENUBAR_HEIGHT,
@@ -42,17 +42,19 @@ type QueryStateExtractionState<'w, 's> = SystemState<(
             &'static ChildOf,
             &'static LayoutStrip,
             Has<ActiveWorkspaceMarker>,
+            Has<SelectedVirtualMarker>,
         ),
     >,
     Query<'w, 's, (&'static Display, Entity, Has<ActiveDisplayMarker>)>,
     Windows<'w, 's>,
     Query<'w, 's, &'static Application>,
+    Res<'w, WindowManager>,
 )>;
 
 fn extract_query_state(world: &mut World) -> PaneruQueryState {
     let mut system_state: QueryStateExtractionState<'_, '_> = SystemState::new(world);
-    let (workspaces, displays, windows, apps) = system_state.get(world);
-    PaneruQueryState::extract(&workspaces, &displays, &windows, &apps)
+    let (workspaces, displays, windows, apps, window_manager) = system_state.get(world);
+    PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager)
 }
 
 #[test]
@@ -606,4 +608,86 @@ fn test_query_state_includes_configured_floating_windows() {
 
     assert_eq!(state.virtual_workspaces[0].windows.len(), 1);
     assert!(state.virtual_workspaces[0].windows[0].floating);
+}
+
+#[test]
+fn test_query_state_tracks_float_after_virtual_workspace_is_reaped() {
+    use crate::commands::{Command, MoveFocus, Operation};
+    use crate::config::{Config, MainOptions};
+    use crate::tests::harness::TestHarness;
+
+    let config: Config = (
+        MainOptions {
+            reap_empty_workspaces: Some(true),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+    let mut harness = TestHarness::new()
+        .with_config(config)
+        .with_display(
+            TEST_DISPLAY_ID,
+            IRect::new(0, 0, TEST_DISPLAY_WIDTH, TEST_DISPLAY_HEIGHT),
+            vec![TEST_WORKSPACE_ID, TEST_WORKSPACE_ID + 1],
+        )
+        .with_windows(1);
+    harness.app.update();
+
+    let send = |harness: &mut TestHarness, command| {
+        harness
+            .app
+            .world_mut()
+            .write_message(Event::Command { command });
+        for _ in 0..4 {
+            harness.app.update();
+            for event in harness.mock_state.drain_events() {
+                harness.app.world_mut().write_message(event);
+            }
+        }
+    };
+    send(
+        &mut harness,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+    );
+    send(&mut harness, Command::Window(Operation::Manage));
+    send(&mut harness, Command::Window(Operation::VirtualNumber(0)));
+
+    let state = extract_query_state(harness.world());
+    let active = state
+        .virtual_workspaces
+        .iter()
+        .find(|workspace| workspace.active)
+        .expect("active virtual workspace");
+
+    assert_eq!(state.active.virtual_workspace_number, Some(1));
+    assert_eq!(state.active.focused_window_id, Some(0));
+    assert!(
+        !state.virtual_workspaces.iter().any(|workspace| {
+            workspace.native_workspace_id == TEST_WORKSPACE_ID && workspace.number == 2
+        }),
+        "the empty remembered row should be reaped"
+    );
+    assert_eq!(active.windows.len(), 1);
+    assert!(active.windows[0].focused);
+    assert!(active.windows[0].floating);
+
+    harness
+        .mock_state
+        .update_window(0, |window| window.workspace_id = TEST_WORKSPACE_ID + 1);
+    let moved = extract_query_state(harness.world());
+    let original_workspace = moved
+        .virtual_workspaces
+        .iter()
+        .find(|workspace| workspace.native_workspace_id == TEST_WORKSPACE_ID)
+        .expect("original native workspace");
+    let live_workspace = moved
+        .virtual_workspaces
+        .iter()
+        .find(|workspace| workspace.native_workspace_id == TEST_WORKSPACE_ID + 1)
+        .expect("live native workspace");
+
+    assert!(original_workspace.windows.is_empty());
+    assert_eq!(live_workspace.windows.len(), 1);
+    assert!(live_workspace.windows[0].floating);
 }

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -51,7 +51,7 @@ type QueryStateExtractionState<'w, 's> = SystemState<(
     Res<'w, WindowManager>,
 )>;
 
-fn extract_query_state(world: &mut World) -> PaneruQueryState {
+fn extract_query_state(world: &mut World) -> crate::errors::Result<PaneruQueryState> {
     let mut system_state: QueryStateExtractionState<'_, '_> = SystemState::new(world);
     let (workspaces, displays, windows, apps, window_manager) = system_state.get(world);
     PaneruQueryState::extract(&workspaces, &displays, &windows, &apps, &window_manager)
@@ -545,7 +545,7 @@ fn test_query_state_contract_exposes_active_virtual_workspace_and_windows() {
         ChildOf(display_entity),
     ));
 
-    let state = extract_query_state(world);
+    let state = extract_query_state(world).expect("query state extraction");
 
     assert_eq!(state.version, 1);
     assert_eq!(state.active.virtual_workspace_number, Some(1));
@@ -584,12 +584,81 @@ fn test_query_state_includes_floating_windows() {
     });
     harness.app.update();
 
-    let state = extract_query_state(harness.world());
+    let state = extract_query_state(harness.world()).expect("query state extraction");
 
     assert_eq!(state.active.focused_window_id, Some(0));
     assert_eq!(state.virtual_workspaces[0].windows.len(), 1);
     assert!(state.virtual_workspaces[0].windows[0].focused);
     assert!(state.virtual_workspaces[0].windows[0].floating);
+}
+
+#[test]
+fn test_query_state_assigns_float_only_to_active_row() {
+    use crate::commands::{Command, Operation};
+    use crate::tests::harness::TestHarness;
+
+    let mut harness = TestHarness::new().with_windows(1);
+    harness.app.update();
+    harness.app.world_mut().write_message(Event::Command {
+        command: Command::Window(Operation::Manage),
+    });
+    harness.app.update();
+
+    let world = harness.world();
+    let display_entity = world
+        .query_filtered::<Entity, With<ActiveDisplayMarker>>()
+        .single(world)
+        .expect("active display");
+    let active_strip_entity = world
+        .query_filtered::<Entity, With<ActiveWorkspaceMarker>>()
+        .single(world)
+        .expect("active workspace");
+    world
+        .entity_mut(active_strip_entity)
+        .remove::<SelectedVirtualMarker>();
+    world.spawn((
+        LayoutStrip::new(TEST_WORKSPACE_ID, 1),
+        ChildOf(display_entity),
+        SelectedVirtualMarker,
+    ));
+
+    let state = extract_query_state(world).expect("query state extraction");
+    let occurrences = state
+        .virtual_workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.windows)
+        .filter(|window| window.window_id == 0)
+        .count();
+    let active = state
+        .virtual_workspaces
+        .iter()
+        .find(|workspace| workspace.active)
+        .expect("active workspace state");
+
+    assert_eq!(occurrences, 1);
+    assert_eq!(active.windows[0].window_id, 0);
+}
+
+#[test]
+fn test_query_state_propagates_workspace_query_failure() {
+    use crate::errors::Error;
+    use crate::manager::MockWindowManagerApi;
+    use crate::tests::harness::TestHarness;
+
+    let mut harness = TestHarness::new().with_windows(1);
+    harness.app.update();
+
+    let mut window_manager = MockWindowManagerApi::new();
+    window_manager
+        .expect_windows_in_workspace()
+        .returning(|_| Err(Error::Generic("workspace query failed".to_string())));
+    harness
+        .world()
+        .insert_resource(WindowManager(Box::new(window_manager)));
+
+    let error = extract_query_state(harness.world()).expect_err("workspace query should fail");
+
+    assert_eq!(error.to_string(), "Generic error: workspace query failed");
 }
 
 #[test]
@@ -604,7 +673,7 @@ fn test_query_state_includes_configured_floating_windows() {
     harness.app.update();
     harness.app.update();
 
-    let state = extract_query_state(harness.world());
+    let state = extract_query_state(harness.world()).expect("query state extraction");
 
     assert_eq!(state.virtual_workspaces[0].windows.len(), 1);
     assert!(state.virtual_workspaces[0].windows[0].floating);
@@ -653,7 +722,7 @@ fn test_query_state_tracks_float_after_virtual_workspace_is_reaped() {
     send(&mut harness, Command::Window(Operation::Manage));
     send(&mut harness, Command::Window(Operation::VirtualNumber(0)));
 
-    let state = extract_query_state(harness.world());
+    let state = extract_query_state(harness.world()).expect("query state extraction");
     let active = state
         .virtual_workspaces
         .iter()
@@ -675,7 +744,7 @@ fn test_query_state_tracks_float_after_virtual_workspace_is_reaped() {
     harness
         .mock_state
         .update_window(0, |window| window.workspace_id = TEST_WORKSPACE_ID + 1);
-    let moved = extract_query_state(harness.world());
+    let moved = extract_query_state(harness.world()).expect("query state extraction");
     let original_workspace = moved
         .virtual_workspaces
         .iter()


### PR DESCRIPTION
## Related Issue
Closes #320 

## Changes
- Include floating windows in query state using
  their live native workspace.

- Prevent floating windows from appearing in
  multiple virtual workspaces.

- Restore un-floated windows into the currently
  active virtual workspace.

- Broadcast windows_changed only for floating-
  window moves.

- Propagate workspace enumeration errors without
  corrupting subscriber state.

- Added regression tests and deterministic mock
  window ordering.

- Validation: 159 tests passed; Clippy,
  formatting, and checks passed.

## Test Result
https://github.com/user-attachments/assets/46d45f0b-fe2b-418f-a0bd-8eba87350ce7