### PR TITLE
fix: Expose moved window and refresh menu bar on follow-move to virtual workspace

### DIFF
--- a/src/ecs/focus.rs
+++ b/src/ecs/focus.rs
@@ -18,6 +18,7 @@ use super::{FocusedMarker, MouseHeldMarker, SystemTheme, Unmanaged};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
+use crate::ecs::workspace::RestoreFocusMarker;
 use crate::ecs::{
     ActiveWorkspaceMarker, Scrolling, SendMessageTrigger, SpawnCommandsExt, StrayFocusEvent,
 };
@@ -148,6 +149,7 @@ fn maintain_focus_singleton(
 fn autocenter_window_on_focus(
     focused: Single<Entity, Added<FocusedMarker>>,
     mouse_held: Query<&MouseHeldMarker>,
+    restored: Query<&RestoreFocusMarker>,
     windows: Windows,
     global_state: GlobalState,
     active_display: ActiveDisplay,
@@ -155,6 +157,15 @@ fn autocenter_window_on_focus(
     mut commands: Commands,
 ) {
     let entity = *focused;
+
+    // A workspace restore re-focuses the remembered window after the strip was
+    // already placed at its saved origin; centering that focus would slide the
+    // strip away from the restored position. The guard outlives this system on
+    // purpose — window_focused_trigger despawns it once focus moves on, and
+    // timeout_ticker expires it otherwise.
+    if restored.iter().any(|marker| marker.entity == entity) {
+        return;
+    }
 
     if global_state.skip_reshuffle() || global_state.initializing() || !mouse_held.is_empty() {
         return;

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -22,6 +22,7 @@ use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, GlobalState, Windows};
 use crate::ecs::state::PaneruState;
+use crate::ecs::workspace::RestoreFocusMarker;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, LayoutPosition, Position,
     ResizeMarker, RestoreWindowState, Scrolling, SendMessageTrigger, SpawnCommandsExt,
@@ -180,6 +181,7 @@ pub(super) fn window_focused_trigger(
     applications: Query<&Application>,
     windows: Windows,
     mut workspaces: Query<(Entity, &mut LayoutStrip, Has<ActiveWorkspaceMarker>)>,
+    restore_guards: Query<(Entity, &RestoreFocusMarker)>,
     mut focus_history: ResMut<FocusHistory>,
     config: Res<Config>,
     global_state: GlobalState,
@@ -284,7 +286,26 @@ pub(super) fn window_focused_trigger(
             focus_history.record(workspace_id, entity, unmanaged);
         }
 
+        // The restore guard absorbs the OS acknowledgment(s) of the focus
+        // `show_active_workspace` issued — reshuffling on those would slide
+        // the strip away from the position the restore just placed it at.
+        // The acknowledgment can arrive more than once (front_switched_trigger
+        // synthesizes a duplicate), so a matching event leaves the guard in
+        // place; focus moving to any other window means the restore sequence
+        // is over and despawns it (timeout_ticker expires it otherwise).
+        let mut restored_focus = false;
+        for (guard_entity, guard) in &restore_guards {
+            if guard.entity == entity {
+                restored_focus = true;
+            } else if let Ok(mut entity_commands) = commands.get_entity(guard_entity) {
+                entity_commands.try_despawn();
+            }
+        }
+
         if already_focused {
+            if restored_focus {
+                continue;
+            }
             if !global_state.skip_reshuffle() && !global_state.initializing() {
                 commands.reshuffle_around(entity);
             }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -85,6 +85,35 @@ pub(crate) struct PreviousStripPosition {
     pub focus: Option<Entity>,
 }
 
+/// Guard spawned by [`show_active_workspace`] alongside the re-focus of the
+/// remembered window when a strip is restored to its saved position. That
+/// focus lands after the strip was already placed at its saved origin —
+/// `focus_entity` inserts `FocusedMarker` a command-flush later, and the OS
+/// acknowledges with one or more `WindowFocused` events several ticks later
+/// still (the front-switch handler synthesizes an extra one), long after the
+/// `is_added` guards in the layout systems have expired. Each of those would
+/// recenter or reshuffle the strip away from the restored position (visible
+/// as a wiggle on every switch). While the guard is alive,
+/// `autocenter_window_on_focus` and the duplicate-focus reshuffle in
+/// `window_focused_trigger` skip the named entity. The guard lives on its own
+/// entity next to a [`Timeout`]: focus moving to any other window despawns it
+/// immediately, and `timeout_ticker` expires it otherwise — so later genuine
+/// re-focus events reshuffle normally.
+#[derive(Component, Debug)]
+pub(crate) struct RestoreFocusMarker {
+    pub entity: Entity,
+}
+
+/// Long enough for the OS focus acknowledgments to arrive, short enough that
+/// a user re-clicking the restored window soon after the switch gets the
+/// normal expose-reshuffle back.
+const RESTORE_FOCUS_GUARD_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn spawn_restore_focus_guard(entity: Entity, commands: &mut Commands) {
+    let timeout = Timeout::new(RESTORE_FOCUS_GUARD_TIMEOUT, None, commands);
+    commands.spawn((timeout, RestoreFocusMarker { entity }));
+}
+
 fn fullscreen_window_in_strip(
     workspace_id: WorkspaceId,
     strip: &LayoutStrip,
@@ -1054,6 +1083,7 @@ pub(crate) fn show_active_workspace(
             if let Some(entity) = focus
                 && strip.contains(*entity)
             {
+                spawn_restore_focus_guard(*entity, &mut commands);
                 commands.focus_entity(*entity, false);
             }
 
@@ -1072,6 +1102,7 @@ pub(crate) fn show_active_workspace(
         if let Some(entity) = focus
             && strip.contains(*entity)
         {
+            spawn_restore_focus_guard(*entity, &mut commands);
             commands.focus_entity(*entity, false);
         }
     }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -22,9 +22,9 @@ use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, Bounds, DockPosition, Initializing, NativeFullscreenMarker, Position,
-    RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker, SpawnCommandsExt,
-    Timeout, Unmanaged,
+    ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Initializing,
+    NativeFullscreenMarker, Position, RefreshWindowSizes, RepositionMarker, Scrolling,
+    SelectedVirtualMarker, SpawnCommandsExt, Timeout, Unmanaged,
 };
 use crate::errors::Result;
 use crate::events::Event;
@@ -764,6 +764,13 @@ fn handle_virtual_window_moves(
                 previous.focus = Some(window_entity);
             }
             commands.reshuffle_around(window_entity);
+
+            if mid_placement.is_none()
+                && let Ok(mut entity_commands) = commands.get_entity(window_entity)
+            {
+                entity_commands.try_remove::<FocusedMarker>();
+                commands.focus_entity(window_entity, false);
+            }
         }
         debug!(
             "Moved window {} to virtual workspace {}",

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,6 +1,5 @@
-use bevy::ecs::entity::Entity;
 use bevy::ecs::query::{Added, Has, With};
-use bevy::ecs::system::{NonSendMut, Populated, Query, Res};
+use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
 use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
 use objc2_app_kit::{
@@ -15,7 +14,7 @@ use crate::accessibility_prompt::{AccessibilitySetupAction, show_accessibility_s
 use crate::commands::{Command, Operation};
 use crate::config::Config;
 use crate::ecs::params::ActiveDisplay;
-use crate::ecs::{Bounds, FocusedMarker, Unmanaged};
+use crate::ecs::{ActiveWorkspaceMarker, Bounds, FocusedMarker, Unmanaged};
 use crate::events::{Event, EventSender};
 use crate::manager::request_ax_privilege;
 
@@ -300,12 +299,16 @@ impl Drop for MenuBarManager {
 
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 pub fn update_menu_bar(
-    _guard: Populated<Entity, Added<FocusedMarker>>,
+    focus_changed: Query<(), Added<FocusedMarker>>,
+    workspace_changed: Query<(), Added<ActiveWorkspaceMarker>>,
     active_display: ActiveDisplay,
     focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
     config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
 ) {
+    if focus_changed.is_empty() && workspace_changed.is_empty() {
+        return;
+    }
     let Some(mut menu_bar) = menu_bar else {
         return;
     };

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,5 +1,6 @@
-use bevy::ecs::query::{Added, Has, With};
-use bevy::ecs::system::{NonSendMut, Query, Res};
+use bevy::ecs::entity::Entity;
+use bevy::ecs::query::{Added, Has, Or, With};
+use bevy::ecs::system::{NonSendMut, Populated, Query, Res};
 use objc2::rc::Retained;
 use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
 use objc2_app_kit::{
@@ -299,16 +300,12 @@ impl Drop for MenuBarManager {
 
 #[allow(clippy::needless_pass_by_value, clippy::type_complexity)]
 pub fn update_menu_bar(
-    focus_changed: Query<(), Added<FocusedMarker>>,
-    workspace_changed: Query<(), Added<ActiveWorkspaceMarker>>,
+    _guard: Populated<Entity, Or<(Added<FocusedMarker>, Added<ActiveWorkspaceMarker>)>>,
     active_display: ActiveDisplay,
     focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
     config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
 ) {
-    if focus_changed.is_empty() && workspace_changed.is_empty() {
-        return;
-    }
     let Some(mut menu_bar) = menu_bar else {
         return;
     };

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1179,6 +1179,68 @@ fn test_move_appends_to_end_by_default() {
     );
 }
 
+/// A follow-move that appends the window to an already-populated destination
+/// strip must bring the moved window on-screen. The window keeps focus across
+/// the move, so no `Added<FocusedMarker>` fires on its own and the reshuffle
+/// issued at move time is swallowed by `reshuffle_layout_strip`'s
+/// newly-active-workspace skip. Regression test for the moved window landing
+/// off the right edge until manually centered.
+#[test]
+fn test_follow_move_brings_appended_window_on_screen() {
+    // Enough windows that the destination strip overflows the display width
+    // (each window is 400px wide, display is 1024px), so an appended window
+    // lands off the right edge unless the strip scrolls to expose it.
+    let mut h = TestHarness::new().with_windows(5);
+
+    let pump = |h: &mut TestHarness, cmd: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: cmd });
+        for _ in 0..8 {
+            h.app.update();
+            for event in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(event);
+            }
+        }
+    };
+
+    // Seed VW1 with three windows (Stay keeps us on VW0), making the
+    // destination strip wider than the display before the follow-move appends
+    // to it.
+    for _ in 0..3 {
+        pump(
+            &mut h,
+            Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        );
+    }
+
+    let mover = focused_window_id(h.app.world_mut());
+
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+    );
+
+    // The moved window keeps focus and must be brought fully on-screen (right
+    // edge within the display), not left appended off the right edge.
+    assert_focused!(h.app.world_mut(), mover);
+    let frame = {
+        let world = h.app.world_mut();
+        let mut q = world.query::<&Window>();
+        q.iter(world)
+            .find(|w| w.id() == mover)
+            .expect("moved window")
+            .frame()
+    };
+    assert!(
+        frame.min.x >= 0 && frame.max.x <= TEST_DISPLAY_WIDTH,
+        "moved window must be fully on-screen, got frame x {}..{} (display width {})",
+        frame.min.x,
+        frame.max.x,
+        TEST_DISPLAY_WIDTH,
+    );
+}
+
 /// With `insert_windows_mid_strip` enabled and a smooth `animation_speed`, moving
 /// a window to another virtual workspace must not animate: every window snaps to
 /// its final spot. Checked per-update, since markers created and consumed

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -1542,6 +1542,106 @@ fn test_virtual_workspace_switch_stops_in_flight_strip_animation() {
     );
 }
 
+/// A virtual-workspace switch restores the strip to its saved position and
+/// re-focuses the remembered window. macOS acknowledges that focus with a
+/// `WindowFocused` event several ticks later — after the `is_added` guards in
+/// `reshuffle_layout_strip` / `ensure_visible_in_strip` have expired. With
+/// `auto_center` enabled, that acknowledgment used to run
+/// `autocenter_window_on_focus`, re-centering the remembered window and
+/// sliding the strip away from the position it was just restored to — visible
+/// as a "wiggle" on every switch.
+#[test]
+fn test_virtual_workspace_switch_focus_echo_does_not_recenter_strip() {
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(true),
+            virtual_workspace_animations: Some(false),
+            animation_speed: Some(12.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new().with_config(config).with_windows(6);
+
+    let settle = |h: &mut TestHarness| {
+        for _ in 0..10 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        settle(h);
+    };
+    let strip_x = |h: &mut TestHarness| -> i32 {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&Position, With<ActiveWorkspaceMarker>>();
+        q.single(world).expect("exactly one active strip").0.x
+    };
+
+    pump(&mut h, Command::PrintState);
+
+    // Seed VW1 with one window so focus genuinely moves across the switch.
+    h.mock_state.focus_window(5);
+    settle(&mut h);
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+    );
+
+    // Focus window 0 and let auto-center settle the strip on it.
+    h.mock_state.focus_window(0);
+    settle(&mut h);
+    let centered_x = strip_x(&mut h);
+
+    // Displace the strip so the focused window is off its centered position,
+    // as any scroll would leave it. Written directly instead of swiping: the
+    // swipe pipeline's finger-lift threshold is wall-clock based, which makes
+    // event order load-dependent and the test flaky.
+    let saved_x = centered_x - 250;
+    {
+        let world = h.app.world_mut();
+        let mut q = world.query_filtered::<&mut Position, With<ActiveWorkspaceMarker>>();
+        q.single_mut(world).expect("exactly one active strip").0.x = saved_x;
+    }
+    settle(&mut h);
+    assert_eq!(
+        strip_x(&mut h),
+        saved_x,
+        "test setup: the displaced strip position must stick"
+    );
+
+    // Switch to VW1; deliver the OS focus acknowledgment for its window.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    h.mock_state.focus_window(5);
+    settle(&mut h);
+
+    // Switch back to VW0: the strip must restore to its saved scroll position.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(0)));
+    assert_eq!(
+        strip_x(&mut h),
+        saved_x,
+        "strip must restore to its saved position on switch-back"
+    );
+
+    // The delayed focus acknowledgment for the remembered window must not
+    // re-center the strip away from the restored position.
+    h.mock_state.focus_window(0);
+    settle(&mut h);
+    let final_x = strip_x(&mut h);
+    assert_eq!(
+        final_x, saved_x,
+        "late focus acknowledgment re-centered the strip (wiggle): \
+         restored to {saved_x}, ended at {final_x} (centered would be {centered_x})"
+    );
+}
+
 /// With `auto_center` off, a reshuffle around the leftmost window of a
 /// scrollable strip must pin the strip to the left edge — the leftmost
 /// window's left edge must touch the display's left edge, never leaving empty


### PR DESCRIPTION
## Problem

When moving a window to another virtual workspace with focus-follow
(`virtualmove` / `virtualmovenum`), two things were broken:

1. **The moved window could end up off-screen.** After the move, the window was
   appended to the far right of the destination strip and stayed there,
   partially or fully off the right edge until it was manually centered or
   re-focused.

2. **The menu bar's virtual workspace label did not update** to reflect the new
   active VW.

## Root cause

Both stem from the fact that on a follow-move the moved window *keeps* focus, so
nothing that keys off `Added<FocusedMarker>` fires:

- `handle_virtual_window_moves` appends the window, activates the destination
  workspace, and calls `reshuffle_around`, all in one frame. But
  `reshuffle_layout_strip` removes the reshuffle marker and then skips the
  strip because its `ActiveWorkspaceMarker` is `is_added()` that frame (a
  deliberate guard against a workspace-switch scheduling race). The reshuffle
  request never occurs, and `show_active_workspace` only restores a saved
  scroll position, which a freshly-appended window isn't part of.

- `update_menu_bar` ran only on `Added<FocusedMarker>`hence the focused window is
  unchanged on a follow-move, so it never re-ran.

## Fix

- **Visibility:** In the append branch of `handle_virtual_window_moves`, force a
  genuine re-focus of the moved window (remove `FocusedMarker` first, since
  Bevy's `try_insert` on a present component won't re-fire `Added`). This makes
  `autocenter_window_on_focus` re-issue the reshuffle on a later frame after the
  active marker is no longer `is_added`, bringing the window on screen.
  Gated on `mid_placement.is_none()` so the `insert_windows_mid_strip` feature's
  "keep exact x / no animation" invariant is untouched (that path already keeps
  the window visible).

- **Menu bar:** `update_menu_bar` now also refreshes on
  `Added<ActiveWorkspaceMarker>`, so the VW label updates on any active-workspace
  change, covering both append and mid-strip follow-moves, independent of focus.

## Testing

- Added `test_follow_move_brings_appended_window_on_screen`, which seeds a
  destination strip wider than the display and asserts an appended follow-moved
  window is brought fully on-screen. Verified it fails without the fix (window at
  x 800..1200 on a 1024px display) and passes with it.
- Full suite: 173 passed, clippy clean.