### PR TITLE
fix: keep unmatched restored windows on the same workspace

### DIFF
--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -322,6 +322,10 @@ impl LayoutStrip {
         self.columns.push_back(Column::Single(entity));
     }
 
+    pub(crate) fn append_strip(&mut self, other: &mut Self) {
+        self.columns.append(&mut other.columns);
+    }
+
     pub fn append_tab_group(&mut self, entities: &[Entity]) {
         let group = dedup_entities(entities);
         if group.is_empty() {

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -509,14 +509,16 @@ pub(super) fn restore_window_state(
             continue;
         }
 
-        // Keep unmatched startup windows on this row instead of creating a
-        // duplicate index that renumber_virtual_indexes would turn into VW2.
-        if let Some((entity, mut existing, _, _)) =
-            workspaces.iter_mut().find(|(entity, existing, _, _)| {
-                !emptied_existing_strips.contains(entity)
-                    && existing.id() == planned.workspace_id
-                    && existing.virtual_index == planned.virtual_index
-            })
+        // Keep unmatched startup windows on the same normal row. Fullscreen
+        // strips must remain single-column, so leave those rows separate.
+        if !strip.is_fullscreen()
+            && let Some((entity, mut existing, _, _)) =
+                workspaces.iter_mut().find(|(entity, existing, _, _)| {
+                    !emptied_existing_strips.contains(entity)
+                        && existing.id() == planned.workspace_id
+                        && existing.virtual_index == planned.virtual_index
+                        && !existing.is_fullscreen()
+                })
         {
             strip.append_strip(&mut existing);
             emptied_existing_strips.insert(entity);

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -504,9 +504,25 @@ pub(super) fn restore_window_state(
             continue;
         };
 
-        let strip = layout_strip_from_plan(planned);
+        let mut strip = layout_strip_from_plan(planned);
         if strip.all_windows().is_empty() {
             continue;
+        }
+
+        // Keep unmatched startup windows on this row instead of creating a
+        // duplicate index that renumber_virtual_indexes would turn into VW2.
+        if let Some((entity, mut existing, _, _)) =
+            workspaces.iter_mut().find(|(entity, existing, _, _)| {
+                !emptied_existing_strips.contains(entity)
+                    && existing.id() == planned.workspace_id
+                    && existing.virtual_index == planned.virtual_index
+            })
+        {
+            strip.append_strip(&mut existing);
+            emptied_existing_strips.insert(entity);
+            if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                entity_commands.try_despawn();
+            }
         }
 
         let is_active = plan

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -129,8 +129,8 @@ fn test_startup_restore_keeps_unmatched_windows_on_the_restored_row() {
 }
 
 #[test]
-fn test_startup_restore_preserves_fullscreen_strip() {
-    let mut harness = TestHarness::new().with_windows(1);
+fn test_startup_restore_keeps_fullscreen_separate_from_unmatched_windows() {
+    let mut harness = TestHarness::new().with_windows(2);
 
     harness.world().insert_resource(PaneruState {
         version: 2,
@@ -153,20 +153,24 @@ fn test_startup_restore_preserves_fullscreen_strip() {
     }
 
     let world = harness.world();
+    let restored_window = find_window_entity(0, world);
+    let unmatched_window = find_window_entity(1, world);
     let mut query = world.query::<&LayoutStrip>();
     let matching = query
         .iter(world)
-        .filter(|strip| strip.id() == TEST_WORKSPACE_ID && strip.virtual_index == 0)
+        .filter(|strip| strip.id() == TEST_WORKSPACE_ID)
         .collect::<Vec<_>>();
 
-    assert_eq!(
-        matching.len(),
-        1,
-        "restore should replace the emptied startup row 0 instead of leaving a duplicate"
-    );
+    assert_eq!(matching.len(), 2);
+    let fullscreen = matching
+        .iter()
+        .find(|strip| strip.is_fullscreen())
+        .expect("fullscreen restore should rebuild a fullscreen strip");
+    assert_eq!(fullscreen.all_windows(), vec![restored_window]);
     assert!(
-        matching[0].is_fullscreen(),
-        "fullscreen restore should rebuild a fullscreen strip"
+        matching
+            .iter()
+            .any(|strip| !strip.is_fullscreen() && strip.contains(unmatched_window))
     );
 }
 

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -79,7 +79,7 @@ fn test_startup_restore_rebuilds_virtual_workspace_layout() {
 }
 
 #[test]
-fn test_startup_restore_replaces_consumed_empty_virtual_zero_strip() {
+fn test_startup_restore_keeps_unmatched_windows_on_the_restored_row() {
     let mut harness = TestHarness::new().with_windows(2);
 
     harness.world().insert_resource(PaneruState {
@@ -93,10 +93,7 @@ fn test_startup_restore_replaces_consumed_empty_virtual_zero_strip() {
             active_virtual_index: Some(0),
             strips: vec![SavedStrip {
                 virtual_index: 0,
-                columns: vec![
-                    SavedColumn::Single(saved_window(0)),
-                    SavedColumn::Single(saved_window(1)),
-                ],
+                columns: vec![SavedColumn::Single(saved_window(0))],
             }],
         }],
     });
@@ -109,14 +106,15 @@ fn test_startup_restore_replaces_consumed_empty_virtual_zero_strip() {
     let mut query = world.query::<&LayoutStrip>();
     let matching = query
         .iter(world)
-        .filter(|strip| strip.id() == TEST_WORKSPACE_ID && strip.virtual_index == 0)
+        .filter(|strip| strip.id() == TEST_WORKSPACE_ID)
         .collect::<Vec<_>>();
 
     assert_eq!(
         matching.len(),
         1,
-        "restore should replace the emptied startup row 0 instead of leaving a duplicate"
+        "restore should keep unmatched windows on row 0 instead of creating VW2"
     );
+    assert_eq!(matching[0].virtual_index, 0);
 
     let windows = matching[0].all_windows();
     assert_eq!(windows.len(), 2);


### PR DESCRIPTION
## Related Issue
Closes #304

## Changes
- Keep unmatched startup windows on the restored normal row, preventing accidental
  VW2 creation.

- Preserve fullscreen strips as single-column layouts by keeping unmatched windows
  separate.

- Add regression coverage for partial session restores and fullscreen restoration.


## Test Result
```bash
[{"number":1,"native_workspace_id":1,"active":true,"windows":[{"window_id":15806,"bundle_id":"com.mitchellh.ghostty","app_name":"Ghostty","title":"~/d/o/paneru","focused":true,"floating":false},{"window_id":15764,"bundle_id":"org.mozilla.firefox","app_name":"Firefox","title":"Mozilla Firefox","focused":false,"floating":false},{"window_id":15830,"bundle_id":"org.mozilla.firefox","app_name":"Firefox","title":"Mozilla Firefox","focused":false,"floating":false},{"window_id":15749,"bundle_id":"org.mozilla.firefox","app_name":"Firefox","title":"Mozilla Firefox","focused":false,"floating":false},{"window_id":15779,"bundle_id":"org.mozilla.firefox","app_name":"Firefox","title":"Mozilla Firefox","focused":false,"floating":false}]}]
```

https://github.com/user-attachments/assets/62e473a1-e1d5-437f-8f64-56e319e0b819

