### PR TITLE
feat: focus windows by column number

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ $ paneru send-cmd <command> [args...]
 
 | Command                    | Description                                      |
 | -------------------------- | ------------------------------------------------ |
-| `window focus <direction>` | Move focus to a window in the given direction    |
+| `window focus <direction\|number>` | Move focus by direction or column number |
 | `window swap <direction>`  | Swap the focused window with a neighbour         |
 | `window center`            | Center the focused window on screen              |
 | `window resize`            | Cycle through `preset_column_widths`             |
@@ -241,6 +241,7 @@ $ paneru send-cmd <command> [args...]
 | `restart`                  | Restart the Paneru service                         |
 
 Where `<direction>` is one of: `west`, `east`, `north`, `south`, `first`, `last`.
+Window numbers are 1-based and count columns from left to right.
 
 #### Examples
 
@@ -262,6 +263,9 @@ $ paneru send-cmd window shrink
 
 # Jump to the left-most window.
 $ paneru send-cmd window focus first
+
+# Jump to the second window from the left.
+$ paneru send-cmd window focus 2
 
 # Switch directly to virtual workspace 3.
 $ paneru send-cmd window virtualnum 3

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,6 +35,7 @@ pub enum Direction {
     East,
     First,
     Last,
+    Nth(usize),
 }
 
 impl Direction {
@@ -46,6 +47,7 @@ impl Direction {
             Direction::East => Direction::West,
             Direction::First => Direction::Last,
             Direction::Last => Direction::First,
+            Direction::Nth(index) => Direction::Nth(*index),
         }
     }
 }
@@ -206,6 +208,8 @@ fn get_window_in_direction(
 
         Direction::Last => strip.last().ok().and_then(|column| column.top()),
 
+        Direction::Nth(index) => strip.get(*index).ok().and_then(|column| column.top()),
+
         Direction::North => match strip.get(index).ok()? {
             Column::Single(_) | Column::Tabs(_) | Column::Fullscren(_) => None,
             Column::Stack(stack) => stack
@@ -249,7 +253,7 @@ fn pick_nearest_in_direction(
                 Direction::West => dx < 0 && dy.abs() <= dx.abs(),
                 Direction::North => dy < 0 && dx.abs() <= dy.abs(),
                 Direction::South => dy > 0 && dx.abs() <= dy.abs(),
-                Direction::First | Direction::Last => return None,
+                Direction::First | Direction::Last | Direction::Nth(_) => return None,
             };
             in_direction.then_some((entity, dx * dx + dy * dy))
         })
@@ -360,7 +364,9 @@ fn command_move_focus(
         return;
     };
 
-    if let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(focused_entity) {
+    if let Some((_, _, Some(Unmanaged::Floating))) = windows.get_managed(focused_entity)
+        && !matches!(direction, Direction::Nth(_))
+    {
         if let Some(entity) = nearest_float_in_direction(
             direction,
             focused_entity,
@@ -401,6 +407,10 @@ fn command_move_focus(
                 active_strip.first().ok().and_then(|col| col.top())
             }
             Direction::West | Direction::Last => active_strip.last().ok().and_then(|col| col.top()),
+            Direction::Nth(index) => active_strip
+                .get(*index)
+                .ok()
+                .and_then(|column| column.top()),
             Direction::North | Direction::South => None,
         }
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,17 @@ fn parse_direction(dir: &str) -> Result<Direction> {
     })
 }
 
+fn parse_focus_direction(dir: &str) -> Result<Direction> {
+    match dir.parse::<usize>() {
+        Ok(0) => Err(Error::InvalidConfig(format!(
+            "{}: Window numbers start at 1",
+            function_name!()
+        ))),
+        Ok(number) => Ok(Direction::Nth(number - 1)),
+        Err(_) => parse_direction(dir),
+    }
+}
+
 fn parse_virtual_workspace_number(input: &str) -> Result<u32> {
     let number = input.parse::<u32>().map_err(|_| {
         Error::InvalidConfig(format!(
@@ -239,7 +250,7 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         "focus" => match *argv.get(1).ok_or(err.clone())? {
             "unmanaged" => Operation::FocusUnmanaged,
             "managed" => Operation::FocusManaged,
-            dir => Operation::Focus(parse_direction(dir)?),
+            dir => Operation::Focus(parse_focus_direction(dir)?),
         },
         "raise" => match *argv.get(1).ok_or(err.clone())? {
             "floating" => Operation::RaiseFloating,

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use objc2_core_foundation::CGPoint;
 
 use crate::commands::{Command, Direction, MoveFocus, Operation};
-use crate::config::{Config, MainOptions, WindowParams};
+use crate::config::{Config, MainOptions, WindowParams, parse_command};
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::{
     ActiveWorkspaceMarker, FocusedMarker, NativeFullscreenMarker, Position, Unmanaged,
@@ -220,6 +220,28 @@ fn test_dont_focus() {
             assert_focused!(world, 0);
         })
         .run(commands);
+}
+
+#[test]
+fn test_focus_window_by_number() {
+    assert!(parse_command(&["window", "focus", "0"]).is_err());
+    let command = parse_command(&["window", "focus", "2"]).unwrap();
+
+    TestHarness::new()
+        .with_windows(3)
+        .on_iteration(1, |world, _state| assert_focused!(world, 1))
+        .on_iteration(2, |world, _state| assert_focused!(world, 1))
+        .on_iteration(3, |world, _state| assert_focused!(world, 2))
+        .run(vec![
+            Event::MenuOpened { window_id: 0 },
+            Event::Command {
+                command: command.clone(),
+            },
+            Event::Command {
+                command: Command::Window(Operation::Manage),
+            },
+            Event::Command { command },
+        ]);
 }
 
 #[test]


### PR DESCRIPTION
## Related Issue
Closes #330 

## Changes
- Add paneru send-cmd window focus <number> support.
- Use 1-based numbering from left to right.
- Reject focus 0 as invalid.
- Focus the top window when the selected column is
  stacked/tabbed.

- Allow numbered focus to leave a currently focused
  floating window.

- Add regression coverage for managed and floating-
  window scenarios.

- Document numbered focus usage in the README.

## Test Result

https://github.com/user-attachments/assets/e6c76494-d0bf-4867-85e1-c730a9823bff

