### PR TITLE
fix: clamp windows after display disconnect

### DIFF
--- a/src/ecs/display.rs
+++ b/src/ecs/display.rs
@@ -31,6 +31,9 @@ const ORPHANED_SPACES_TIMEOUT_SEC: u64 = 30;
 
 pub struct DisplayEventsPlugin;
 
+#[derive(Component)]
+pub(crate) struct ClampWindowBounds;
+
 impl Plugin for DisplayEventsPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreUpdate, display_change_handler);
@@ -263,7 +266,7 @@ fn remove_display(
             commands,
         );
         if let Ok(mut commands) = commands.get_entity(entity) {
-            commands.try_insert(timeout);
+            commands.try_insert((timeout, ClampWindowBounds));
         }
         if let Ok(mut commands) = commands.get_entity(display_entity) {
             commands.detach_child(entity);

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -506,13 +506,12 @@ fn refresh_workspace_window_sizes(
 
     debug!("refreshing workspace {} sizes", strip.id());
     let viewport = active_display.actual_bounds(&config);
+    let mut retry_clamp = false;
     let mut in_workspace = match window_manager.windows_in_workspace(strip.id()) {
         Ok(windows) => windows,
         Err(err) => {
             warn!("getting windows in workspace: {err}");
-            if clamp_bounds {
-                return;
-            }
+            retry_clamp = clamp_bounds;
             Vec::new()
         }
     };
@@ -522,10 +521,9 @@ fn refresh_workspace_window_sizes(
         let Ok((_, ref mut window, ref mut bounds, _)) = windows.get_mut(entity) else {
             continue;
         };
-        let frame = match window.update_frame() {
-            Ok(frame) => frame,
-            Err(_) if clamp_bounds => return,
-            Err(_) => continue,
+        let Ok(frame) = window.update_frame() else {
+            retry_clamp |= clamp_bounds;
+            continue;
         };
         bounds.0 = if clamp_bounds {
             frame.size().with_x(frame.width().min(viewport.width()))
@@ -556,12 +554,14 @@ fn refresh_workspace_window_sizes(
         if clamp_bounds
             && let Ok((_, ref mut window, ref mut bounds, _)) = windows.get_mut(window_entity)
         {
-            let Ok(frame) = window.update_frame() else {
-                return;
-            };
-            let size = frame.size().min(viewport.size());
-            if frame.size() != size {
-                bounds.0 = size;
+            match window.update_frame() {
+                Ok(frame) => {
+                    let size = frame.size().min(viewport.size());
+                    if frame.size() != size {
+                        bounds.0 = size;
+                    }
+                }
+                Err(_) => retry_clamp = true,
             }
         }
         debug!("repositioning floating window {window_entity}");
@@ -575,7 +575,7 @@ fn refresh_workspace_window_sizes(
         );
     }
 
-    if let Ok(mut cmds) = commands.get_entity(strip_entity) {
+    if !retry_clamp && let Ok(mut cmds) = commands.get_entity(strip_entity) {
         cmds.try_remove::<RefreshWindowSizes>()
             .try_remove::<ClampWindowBounds>();
     }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -18,6 +18,7 @@ use tracing::{Level, debug, error, instrument, warn};
 use super::{ActiveDisplayMarker, SpawnWindowTrigger};
 use crate::commands::{Direction, MoveFocus, Operation, filter_window_operations};
 use crate::config::Config;
+use crate::ecs::display::ClampWindowBounds;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::{ActiveDisplay, Windows};
@@ -483,34 +484,54 @@ fn find_orphaned_workspaces(
 
 #[allow(clippy::needless_pass_by_value)]
 fn refresh_workspace_window_sizes(
-    layout_strip: Single<(&LayoutStrip, Entity, &RefreshWindowSizes), With<ActiveWorkspaceMarker>>,
+    layout_strip: Single<
+        (
+            &LayoutStrip,
+            Entity,
+            &RefreshWindowSizes,
+            Has<ClampWindowBounds>,
+        ),
+        With<ActiveWorkspaceMarker>,
+    >,
     mut windows: Query<(Entity, &mut Window, &mut Bounds, Option<&Unmanaged>)>,
     active_display: ActiveDisplay,
     window_manager: Res<WindowManager>,
+    config: Res<Config>,
     mut commands: Commands,
 ) {
-    let (strip, strip_entity, marker) = *layout_strip;
+    let (strip, strip_entity, marker, clamp_bounds) = *layout_strip;
     if !marker.ready() {
         return;
     }
 
     debug!("refreshing workspace {} sizes", strip.id());
-    let mut in_workspace = window_manager
-        .windows_in_workspace(strip.id())
-        .inspect_err(|err| {
+    let viewport = active_display.actual_bounds(&config);
+    let mut in_workspace = match window_manager.windows_in_workspace(strip.id()) {
+        Ok(windows) => windows,
+        Err(err) => {
             warn!("getting windows in workspace: {err}");
-        })
-        .unwrap_or_default();
+            if clamp_bounds {
+                return;
+            }
+            Vec::new()
+        }
+    };
 
     // Resize windows for the new display dimensions.
     for entity in strip.all_windows() {
         let Ok((_, ref mut window, ref mut bounds, _)) = windows.get_mut(entity) else {
             continue;
         };
-        let Ok(frame) = window.update_frame() else {
-            continue;
+        let frame = match window.update_frame() {
+            Ok(frame) => frame,
+            Err(_) if clamp_bounds => return,
+            Err(_) => continue,
         };
-        bounds.0 = frame.size();
+        bounds.0 = if clamp_bounds {
+            frame.size().with_x(frame.width().min(viewport.width()))
+        } else {
+            frame.size()
+        };
         debug!("refreshing window {} frame {:?}", window.id(), frame);
 
         in_workspace.retain(|window_id| *window_id != window.id());
@@ -529,14 +550,34 @@ fn refresh_workspace_window_sizes(
         })
         .filter_map(|(unmanaged, entity)| {
             matches!(unmanaged, Unmanaged::Floating).then_some(entity)
-        });
+        })
+        .collect::<Vec<_>>();
     for window_entity in floating {
+        if clamp_bounds
+            && let Ok((_, ref mut window, ref mut bounds, _)) = windows.get_mut(window_entity)
+        {
+            let Ok(frame) = window.update_frame() else {
+                return;
+            };
+            let size = frame.size().min(viewport.size());
+            if frame.size() != size {
+                bounds.0 = size;
+            }
+        }
         debug!("repositioning floating window {window_entity}");
-        commands.reposition_entity(window_entity, active_display.bounds().min);
+        commands.reposition_entity(
+            window_entity,
+            if clamp_bounds {
+                viewport.min
+            } else {
+                active_display.bounds().min
+            },
+        );
     }
 
     if let Ok(mut cmds) = commands.get_entity(strip_entity) {
-        cmds.try_remove::<RefreshWindowSizes>();
+        cmds.try_remove::<RefreshWindowSizes>()
+            .try_remove::<ClampWindowBounds>();
     }
 }
 

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -480,6 +480,7 @@ fn test_wake_refreshes_active_workspace() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn test_unplug_clamps_windows_to_the_replacement_display_bounds() {
     let mut floating = WindowParams::new("Window 10[12]", None);
     floating.floating = Some(true);
@@ -490,7 +491,7 @@ fn test_unplug_clamps_windows_to_the_replacement_display_bounds() {
         1600,
         -EXT_DISPLAY_HEIGHT + TEST_MENUBAR_HEIGHT + TEST_WINDOW_HEIGHT,
     );
-    let harness = TestHarness::new()
+    let mut harness = TestHarness::new()
         .with_config(config)
         .with_display(
             EXT_DISPLAY_ID,
@@ -506,6 +507,11 @@ fn test_unplug_clamps_windows_to_the_replacement_display_bounds() {
         .with_workspace_window(102, EXT_WORKSPACE_ID, move |window| {
             window.frame = wide_frame;
         });
+    harness
+        .app
+        .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
+            250,
+        )));
 
     let commands = vec![
         Event::MenuOpened { window_id: 100 },
@@ -548,13 +554,27 @@ fn test_unplug_clamps_windows_to_the_replacement_display_bounds() {
                     .checked_sub(Duration::from_secs(6))
                     .expect("six seconds before now should be representable");
             }
-            state.fail_window_frame_updates(100, true);
+            state.fail_workspace_queries(EXT_WORKSPACE_ID, true);
         })
         .on_iteration(4, |world, state| {
             let mut clamped = world
                 .query_filtered::<Entity, (With<ClampWindowBounds>, With<RefreshWindowSizes>)>();
             assert!(clamped.single(world).is_ok());
-            state.fail_window_frame_updates(100, false);
+            assert_window_size!(
+                world,
+                100,
+                TEST_DISPLAY_WIDTH,
+                TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT
+            );
+            state.fail_workspace_queries(EXT_WORKSPACE_ID, false);
+            state.fail_window_frame_updates(101, true);
+        })
+        .on_iteration(5, |world, state| {
+            let mut clamped = world
+                .query_filtered::<Entity, (With<ClampWindowBounds>, With<RefreshWindowSizes>)>();
+            assert!(clamped.single(world).is_ok());
+            assert_window_size!(world, 102, 400, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT);
+            state.fail_window_frame_updates(101, false);
         })
         .on_iteration(6, |world, _| {
             for id in [101, 102] {

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -1,12 +1,13 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bevy::prelude::*;
 use bevy::time::TimeUpdateStrategy;
 
 use crate::commands::{Command, MouseMove, MoveFocus, Operation};
-use crate::config::Config;
+use crate::config::{Config, MainOptions, WindowParams};
+use crate::ecs::display::ClampWindowBounds;
 use crate::ecs::layout::LayoutStrip;
-use crate::ecs::{ActiveWorkspaceMarker, DockPosition, RefreshWindowSizes, Timeout};
+use crate::ecs::{ActiveWorkspaceMarker, DockPosition, RefreshWindowSizes, Timeout, Unmanaged};
 use crate::events::Event;
 use crate::manager::{Display, Origin, Size};
 use crate::{assert_not_on_workspace, assert_on_workspace, assert_window_at, assert_window_size};
@@ -474,6 +475,100 @@ fn test_wake_refreshes_active_workspace() {
                 refreshed,
                 "wake should mark the active workspace for a window-size refresh"
             );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_unplug_clamps_windows_to_the_replacement_display_bounds() {
+    let mut floating = WindowParams::new("Window 10[12]", None);
+    floating.floating = Some(true);
+    let config: Config = (MainOptions::default(), vec![floating]).into();
+    let wide_frame = IRect::new(
+        0,
+        -EXT_DISPLAY_HEIGHT + TEST_MENUBAR_HEIGHT,
+        1600,
+        -EXT_DISPLAY_HEIGHT + TEST_MENUBAR_HEIGHT + TEST_WINDOW_HEIGHT,
+    );
+    let harness = TestHarness::new()
+        .with_config(config)
+        .with_display(
+            EXT_DISPLAY_ID,
+            IRect::new(0, -EXT_DISPLAY_HEIGHT, EXT_DISPLAY_WIDTH, 0),
+            vec![EXT_WORKSPACE_ID],
+        )
+        .with_workspace_window(100, EXT_WORKSPACE_ID, move |window| {
+            window.frame = wide_frame;
+        })
+        .with_workspace_window(101, EXT_WORKSPACE_ID, move |window| {
+            window.frame = wide_frame;
+        })
+        .with_workspace_window(102, EXT_WORKSPACE_ID, move |window| {
+            window.frame = wide_frame;
+        });
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 100 },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::DisplayRemoved {
+            display_id: EXT_DISPLAY_ID,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    harness
+        .on_iteration(1, |_, state| {
+            let origin = Origin::new(0, -EXT_DISPLAY_HEIGHT + TEST_MENUBAR_HEIGHT);
+            state.update_window(101, |window| {
+                window.frame = IRect::from_corners(origin, origin + Size::new(1600, 400));
+            });
+            state.update_window(102, |window| {
+                window.frame = IRect::from_corners(origin, origin + Size::new(400, 1000));
+            });
+            state.remove_display(EXT_DISPLAY_ID);
+            state.activate_workspace(TEST_DISPLAY_ID, EXT_WORKSPACE_ID, false);
+        })
+        .on_iteration(3, |world, state| {
+            let mut refreshes = world.query::<&mut RefreshWindowSizes>();
+            for mut refresh in refreshes.iter_mut(world) {
+                refresh.0 = Instant::now()
+                    .checked_sub(Duration::from_secs(6))
+                    .expect("six seconds before now should be representable");
+            }
+            state.fail_window_frame_updates(100, true);
+        })
+        .on_iteration(4, |world, state| {
+            let mut clamped = world
+                .query_filtered::<Entity, (With<ClampWindowBounds>, With<RefreshWindowSizes>)>();
+            assert!(clamped.single(world).is_ok());
+            state.fail_window_frame_updates(100, false);
+        })
+        .on_iteration(6, |world, _| {
+            for id in [101, 102] {
+                let floating = find_window_entity(id, world);
+                assert!(world.entity(floating).contains::<Unmanaged>());
+            }
+            assert_window_size!(
+                world,
+                100,
+                TEST_DISPLAY_WIDTH,
+                TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT
+            );
+            assert_window_size!(world, 101, TEST_DISPLAY_WIDTH, 400);
+            assert_window_size!(world, 102, 400, TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT);
         })
         .run(commands);
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -82,6 +82,7 @@ struct MockStateInner {
     windows: HashMap<WinID, MockWindowData>,
     displays: HashMap<u32, MockDisplayData>,
     fullscreen_spaces: HashSet<WorkspaceId>,
+    frame_update_failures: HashSet<WinID>,
     active_display_id: u32,
     cursor_position: Origin,
     event_queue: VecDeque<Event>,
@@ -100,6 +101,7 @@ impl MockState {
                 windows: HashMap::new(),
                 displays: HashMap::new(),
                 fullscreen_spaces: HashSet::new(),
+                frame_update_failures: HashSet::new(),
                 active_display_id: 0,
                 cursor_position: Origin::ZERO,
                 event_queue: VecDeque::new(),
@@ -169,6 +171,15 @@ impl MockState {
                     .event_queue
                     .push_back(Event::WindowFocused { window_id: id });
             }
+        }
+    }
+
+    pub(crate) fn fail_window_frame_updates(&self, id: WinID, fail: bool) {
+        let mut inner = self.inner.force_write();
+        if fail {
+            inner.frame_update_failures.insert(id);
+        } else {
+            inner.frame_update_failures.remove(&id);
         }
     }
 
@@ -411,8 +422,11 @@ impl MockState {
 
         let s = self.clone();
         mw.expect_update_frame().returning(move || {
-            s.inner
-                .force_read()
+            let state = s.inner.force_read();
+            if state.frame_update_failures.contains(&id) {
+                return Err(Error::InvalidWindow);
+            }
+            state
                 .windows
                 .get(&id)
                 .map(|w| w.frame)

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -83,6 +83,7 @@ struct MockStateInner {
     displays: HashMap<u32, MockDisplayData>,
     fullscreen_spaces: HashSet<WorkspaceId>,
     frame_update_failures: HashSet<WinID>,
+    workspace_query_failures: HashSet<WorkspaceId>,
     active_display_id: u32,
     cursor_position: Origin,
     event_queue: VecDeque<Event>,
@@ -102,6 +103,7 @@ impl MockState {
                 displays: HashMap::new(),
                 fullscreen_spaces: HashSet::new(),
                 frame_update_failures: HashSet::new(),
+                workspace_query_failures: HashSet::new(),
                 active_display_id: 0,
                 cursor_position: Origin::ZERO,
                 event_queue: VecDeque::new(),
@@ -180,6 +182,15 @@ impl MockState {
             inner.frame_update_failures.insert(id);
         } else {
             inner.frame_update_failures.remove(&id);
+        }
+    }
+
+    pub(crate) fn fail_workspace_queries(&self, id: WorkspaceId, fail: bool) {
+        let mut inner = self.inner.force_write();
+        if fail {
+            inner.workspace_query_failures.insert(id);
+        } else {
+            inner.workspace_query_failures.remove(&id);
         }
     }
 
@@ -645,9 +656,11 @@ impl MockState {
         let s = self.clone();
         wm.expect_windows_in_workspace()
             .returning(move |workspace_id| {
-                let mut windows = s
-                    .inner
-                    .force_read()
+                let state = s.inner.force_read();
+                if state.workspace_query_failures.contains(&workspace_id) {
+                    return Err(Error::InvalidWindow);
+                }
+                let mut windows = state
                     .windows
                     .values()
                     .filter_map(|w| (w.workspace_id == workspace_id).then_some(w.id))


### PR DESCRIPTION
## Related Issue
Closes #332 

## Changes
- Resize oversized windows after disconnecting a larger external display.
- Clamp managed-window widths to the replacement display’s usable width.
- Clamp floating-window width and height independently without enlarging dimensions that
  already fit.

- Move floating windows into the replacement display’s usable area.
- Retry clamping after transient workspace-enumeration or AX frame-read failures.
- Continue processing unrelated windows when one window fails.
- Add end-to-end coverage for display removal, floating geometry, and transient failures.
- Extend test mocks with controllable workspace-query and frame-read failures.
- Pass formatting, cargo check, all 174 tests, and strict Clippy.

## Test Result
```bash
cargo test test_unplug_clamps_windows_to_the_replacement_display_bounds -- --nocapture
```