### PR TITLE
chore: bump rust-version to 1.95.0 to match Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "paneru"
 version = "0.4.4"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.95.0"
 description = "A sliding, tiling window manager for MacOS."
 homepage = "https://github.com/karinushka/paneru"
 repository = "https://github.com/karinushka/paneru"


### PR DESCRIPTION
The Bevy 0.19 upgrade (5611baa) raised the effective MSRV: bevy_ecs 0.19 declares rust-version = "1.95.0". Cargo.toml still declared 1.89.0, so toolchains between 1.89 and 1.95 would attempt the build and fail at dependency resolution instead of getting a clean MSRV error up front.