### PR TITLE
fix: launchd plist log path swap and RUST_LOG passthrough

### DIFF
--- a/assets/launchd.plist
+++ b/assets/launchd.plist
@@ -21,14 +21,16 @@
     <dict>
       <key>NO_COLOR</key>
       <string>1</string>
+      <key>RUST_LOG</key>
+      <string>{rust_log}</string>
       <key>XDG_CONFIG_HOME</key>
       <string>{xdg_config_home}</string>
     </dict>
     <key>RunAtLoad</key>
     <true />
     <key>StandardErrorPath</key>
-    <string>{out_log_path}</string>
-    <key>StandardOutPath</key>
     <string>{error_log_path}</string>
+    <key>StandardOutPath</key>
+    <string>{out_log_path}</string>
   </dict>
 </plist>

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -197,6 +197,7 @@ impl Service {
     pub fn launchd_plist(&self) -> String {
         let xdg_config_home = env::var("XDG_CONFIG_HOME")
             .unwrap_or_else(|_| format!("{}/.config", self.home_dir.display()));
+        let rust_log = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
         format!(
             include_str!("../../assets/launchd.plist"),
             name = self.raw.name,
@@ -204,6 +205,7 @@ impl Service {
             out_log_path = self.raw.out_log_path,
             error_log_path = self.raw.error_log_path,
             xdg_config_home = xdg_config_home,
+            rust_log = rust_log,
         )
     }
 }


### PR DESCRIPTION
1. `StandardErrorPath` and `StandardOutPath` were crossed in the template:
   stderr (where `tracing` actually writes) was going to `*.out.log`, and
   stdout to `*.err.log`. Swapped them to match their names.
   
2. `RUST_LOG` is now passed through