### PR TITLE
feat: add installable app launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,22 @@ $ paneru install
 $ paneru start
 ```
 
+### Installing an app launcher
+
+To start Paneru from Spotlight, Alfred, Raycast, or another application launcher,
+install the lightweight app wrapper:
+
+```shell
+$ paneru install-app
+```
+
+This creates `$HOME/Applications/Paneru.app`. Opening the app starts the
+installed Paneru launch agent and exits immediately. Remove the wrapper with:
+
+```shell
+$ paneru uninstall-app
+```
+
 ### Running in the foreground
 
 ```shell

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,8 @@ pub struct Paneru {
 
 /// `SubCmd` enumerates the available command-line subcommands for `paneru`.
 /// These subcommands allow users to launch the daemon, install/uninstall it as a service,
-/// start/stop/restart the service, or send commands to a running daemon.
+/// install/uninstall its app launcher, start/stop/restart the service, or send commands to
+/// a running daemon.
 #[derive(Clone, Debug, Default, Subcommand)]
 pub enum SubCmd {
     /// Launches the `paneru` daemon directly in the console (default behavior).
@@ -68,6 +69,12 @@ pub enum SubCmd {
 
     /// Reinstalls the `paneru` background service.
     Reinstall,
+
+    /// Installs a Paneru app launcher to `~/Applications`.
+    InstallApp,
+
+    /// Uninstalls the Paneru app launcher from `~/Applications`.
+    UninstallApp,
 
     /// Starts the `paneru` background service.
     Start,
@@ -170,6 +177,8 @@ fn main() -> Result<()> {
         SubCmd::Install => service()?.install()?,
         SubCmd::Uninstall => service()?.uninstall()?,
         SubCmd::Reinstall => service()?.reinstall()?,
+        SubCmd::InstallApp => platform::app_launcher::AppLauncher::try_new()?.install()?,
+        SubCmd::UninstallApp => platform::app_launcher::AppLauncher::try_new()?.uninstall()?,
         SubCmd::Start => service()?.start()?,
         SubCmd::Stop => service()?.stop()?,
         SubCmd::Restart => service()?.restart()?,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -25,6 +25,7 @@ use process::ProcessHandler;
 pub use process::ProcessSerialNumber;
 pub use workspace::WorkspaceObserver;
 
+pub(crate) mod app_launcher;
 mod display;
 pub(crate) mod input;
 mod mission_control;

--- a/src/platform/app_launcher.rs
+++ b/src/platform/app_launcher.rs
@@ -1,0 +1,267 @@
+use std::{
+    env, fs,
+    io::{Error, ErrorKind, Result},
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use tracing::info;
+
+use crate::util::exe_path;
+
+const APP_BUNDLE_NAME: &str = "Paneru.app";
+const APP_EXECUTABLE_NAME: &str = "PaneruLauncher";
+const APP_BUNDLE_ID: &str = "com.github.karinushka.paneru.launcher";
+
+pub struct AppLauncher {
+    paneru_path: PathBuf,
+    app_path: PathBuf,
+}
+
+impl AppLauncher {
+    pub fn try_new() -> Result<Self> {
+        let home_dir = env::home_dir().ok_or(Error::new(
+            ErrorKind::NotFound,
+            "Cannot find home directory.",
+        ))?;
+        let paneru_path = exe_path().ok_or(Error::new(
+            ErrorKind::NotFound,
+            "Cannot find current executable path.",
+        ))?;
+        Ok(Self::new(
+            paneru_path,
+            home_dir.join("Applications").join(APP_BUNDLE_NAME),
+        ))
+    }
+
+    fn new(paneru_path: PathBuf, app_path: PathBuf) -> Self {
+        Self {
+            paneru_path,
+            app_path,
+        }
+    }
+
+    pub fn install(&self) -> Result<()> {
+        let parent = self.app_path.parent().ok_or(Error::new(
+            ErrorKind::InvalidInput,
+            "Application bundle path has no parent",
+        ))?;
+        fs::create_dir_all(parent)?;
+
+        let staging_path = parent.join(format!(".{APP_BUNDLE_NAME}.new"));
+        if staging_path.exists() {
+            fs::remove_dir_all(&staging_path)?;
+        }
+
+        self.write_bundle(&staging_path)?;
+        sign_bundle(&staging_path)?;
+
+        if self.app_path.exists() {
+            ensure_owned_bundle(&self.app_path)?;
+            fs::remove_dir_all(&self.app_path)?;
+        }
+        fs::rename(&staging_path, &self.app_path)?;
+        info!("installed app launcher to `{}`", self.app_path.display());
+        Ok(())
+    }
+
+    pub fn uninstall(&self) -> Result<()> {
+        if !self.app_path.exists() {
+            return Ok(());
+        }
+        ensure_owned_bundle(&self.app_path)?;
+        fs::remove_dir_all(&self.app_path)?;
+        info!("removed app launcher from `{}`", self.app_path.display());
+        Ok(())
+    }
+
+    fn write_bundle(&self, app_path: &Path) -> Result<()> {
+        let contents_path = app_path.join("Contents");
+        let executable_dir = contents_path.join("MacOS");
+        fs::create_dir_all(&executable_dir)?;
+        fs::write(contents_path.join("Info.plist"), info_plist())?;
+
+        let executable_path = executable_dir.join(APP_EXECUTABLE_NAME);
+        fs::write(
+            &executable_path,
+            launcher_script(self.paneru_path.as_path()),
+        )?;
+        let mut permissions = fs::metadata(&executable_path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(executable_path, permissions)
+    }
+}
+
+fn ensure_owned_bundle(app_path: &Path) -> Result<()> {
+    let plist = fs::read_to_string(app_path.join("Contents/Info.plist"))?;
+    if plist.contains(&format!("<string>{APP_BUNDLE_ID}</string>")) {
+        return Ok(());
+    }
+
+    Err(Error::new(
+        ErrorKind::AlreadyExists,
+        format!(
+            "refusing to replace application not owned by Paneru: {}",
+            app_path.display()
+        ),
+    ))
+}
+
+fn info_plist() -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Paneru</string>
+    <key>CFBundleExecutable</key>
+    <string>{APP_EXECUTABLE_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{APP_BUNDLE_ID}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Paneru</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{}</string>
+    <key>CFBundleVersion</key>
+    <string>{}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>12.0</string>
+    <key>LSUIElement</key>
+    <true/>
+  </dict>
+</plist>
+"#,
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_VERSION"),
+    )
+}
+
+fn launcher_script(paneru_path: &Path) -> String {
+    format!(
+        "#!/bin/sh\nexec {} start\n",
+        shell_quote(&paneru_path.to_string_lossy())
+    )
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn sign_bundle(app_path: &Path) -> Result<()> {
+    let output = Command::new("/usr/bin/codesign")
+        .args(["--force", "--deep", "--sign", "-"])
+        .arg(app_path)
+        .output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(Error::other(format!(
+        "codesign failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        os::unix::fs::PermissionsExt,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use super::{
+        APP_BUNDLE_ID, APP_EXECUTABLE_NAME, AppLauncher, ensure_owned_bundle, launcher_script,
+        shell_quote,
+    };
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn test_directory() -> PathBuf {
+        let test_id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "paneru-launcher-test-{}-{test_id}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn launcher_script_quotes_the_paneru_path() {
+        let script = launcher_script(PathBuf::from("/tmp/Paneru's bin").as_path());
+        assert_eq!(script, "#!/bin/sh\nexec '/tmp/Paneru'\"'\"'s bin' start\n");
+        assert_eq!(shell_quote("paneru"), "'paneru'");
+    }
+
+    #[test]
+    fn write_bundle_creates_a_launchable_application() {
+        let root = test_directory();
+        let app_path = root.join("Paneru.app");
+        let launcher =
+            AppLauncher::new(PathBuf::from("/opt/homebrew/bin/paneru"), app_path.clone());
+
+        launcher.write_bundle(&app_path).unwrap();
+
+        let plist = fs::read_to_string(app_path.join("Contents/Info.plist")).unwrap();
+        assert!(plist.contains(APP_BUNDLE_ID));
+        assert!(plist.contains("<string>APPL</string>"));
+        assert!(plist.contains("<key>LSUIElement</key>"));
+
+        let executable = app_path.join("Contents/MacOS").join(APP_EXECUTABLE_NAME);
+        assert_eq!(
+            fs::read_to_string(&executable).unwrap(),
+            "#!/bin/sh\nexec '/opt/homebrew/bin/paneru' start\n"
+        );
+        assert_ne!(
+            fs::metadata(executable).unwrap().permissions().mode() & 0o111,
+            0
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn owned_bundle_check_rejects_an_unrelated_application() {
+        let root = test_directory();
+        let app_path = root.join("Paneru.app");
+        fs::create_dir_all(app_path.join("Contents")).unwrap();
+        fs::write(
+            app_path.join("Contents/Info.plist"),
+            "<plist><string>com.example.unrelated</string></plist>",
+        )
+        .unwrap();
+
+        assert_eq!(
+            ensure_owned_bundle(&app_path).unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn install_replaces_owned_bundle_and_uninstall_removes_it() {
+        let root = test_directory();
+        let app_path = root.join("Applications/Paneru.app");
+        let launcher = AppLauncher::new(PathBuf::from("/usr/bin/true"), app_path.clone());
+
+        launcher.install().unwrap();
+        launcher.install().unwrap();
+
+        assert!(app_path.is_dir());
+        assert!(app_path.join("Contents/_CodeSignature").is_dir());
+
+        launcher.uninstall().unwrap();
+        assert!(!app_path.exists());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -2,7 +2,7 @@ use std::{
     env, fs,
     io::{Error, ErrorKind, Result, Write},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Command, Output, Stdio},
 };
 
 use tracing::{info, warn};
@@ -147,9 +147,44 @@ impl Service {
             self.install()?;
         }
         info!("starting service...");
-        self.raw.start()?;
+        self.create_log_files()?;
+        for args in start_commands(&self.raw, self.is_bootstrapped()?) {
+            Self::run_launchctl(&args)?;
+        }
         info!("service started");
         Ok(())
+    }
+
+    fn create_log_files(&self) -> Result<()> {
+        for path in [&self.raw.error_log_path, &self.raw.out_log_path] {
+            if !Path::new(path).exists() {
+                fs::File::create(path)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn is_bootstrapped(&self) -> Result<bool> {
+        let output = Self::launchctl(&["print", self.raw.service_target.as_str()])?;
+        Ok(output.status.success())
+    }
+
+    fn run_launchctl(args: &[&str]) -> Result<()> {
+        let output = Self::launchctl(args)?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        Err(Error::other(format!(
+            "launchctl {} failed with {}: {}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
+
+    fn launchctl(args: &[&str]) -> Result<Output> {
+        Command::new("/bin/launchctl").args(args).output()
     }
 
     /// Stops the service using `launchctl`.
@@ -207,5 +242,56 @@ impl Service {
             xdg_config_home = xdg_config_home,
             rust_log = rust_log,
         )
+    }
+}
+
+fn start_commands(service: &launchctl::Service, bootstrapped: bool) -> Vec<Vec<&str>> {
+    if bootstrapped {
+        vec![vec!["kickstart", service.service_target.as_str()]]
+    } else {
+        vec![
+            vec!["enable", service.service_target.as_str()],
+            vec![
+                "bootstrap",
+                service.domain_target.as_str(),
+                service.plist_path.as_str(),
+            ],
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::start_commands;
+
+    fn service() -> launchctl::Service {
+        launchctl::Service::builder()
+            .name("com.github.karinushka.paneru")
+            .uid("501")
+            .plist_path("/Users/test/Library/LaunchAgents/com.github.karinushka.paneru.plist")
+            .build()
+    }
+
+    #[test]
+    fn start_kickstarts_a_bootstrapped_service_by_service_target() {
+        assert_eq!(
+            start_commands(&service(), true),
+            vec![vec!["kickstart", "gui/501/com.github.karinushka.paneru"]]
+        );
+    }
+
+    #[test]
+    fn start_enables_and_bootstraps_an_unloaded_service() {
+        assert_eq!(
+            start_commands(&service(), false),
+            vec![
+                vec!["enable", "gui/501/com.github.karinushka.paneru"],
+                vec![
+                    "bootstrap",
+                    "gui/501",
+                    "/Users/test/Library/LaunchAgents/com.github.karinushka.paneru.plist"
+                ]
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Paneru is currently installed as a CLI/launchd service, so application launchers such as Spotlight, Alfred, and Raycast cannot discover it as an app. Users can wire up custom shell actions, but a small native app bundle provides a simpler and launcher-agnostic entry point.

While testing that flow, I also found that `paneru start` could report success without starting the daemon. The `launchctl` wrapper passed the plist path to `kickstart` and discarded non-zero exit statuses.

## Changes

- add `paneru install-app` and `paneru uninstall-app`
- generate an ad-hoc signed `$HOME/Applications/Paneru.app`
- keep the launcher UI-less with `LSUIElement` and have it invoke the installed Paneru binary with `start`
- stage the bundle next to its destination before replacing it
- refuse to replace or remove an existing app unless its bundle identifier belongs to Paneru
- start bootstrapped launchd services with their service target (`gui/<uid>/<label>`)
- propagate `launchctl` failures instead of logging a false success
- document the app-launcher workflow

## Validation

- `cargo test --locked` — 182 passed
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --release --locked`
- `plutil -lint` on the generated `Info.plist`
- `codesign --verify --deep --strict --verbose=2` on the generated app
- end-to-end macOS test: quit Paneru, open the generated `Paneru.app`, then confirm `paneru query active` and the launchd job return to a running state
