### PR TITLE
Skip process with PID 0 since it never finishes launching

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+rust = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-rust = "latest"

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -818,7 +818,12 @@ pub(crate) fn gather_initial_processes(
         match receiver.recv().expect("error reading initial processes") {
             Event::ProcessesLoaded | Event::Exit => break,
             Event::ApplicationLaunched { psn, observer } => {
-                initial_processes.push(Process::new(&psn, observer.clone()).into());
+                let process: BProcess = Process::new(&psn, observer.clone()).into();
+                if process.pid() != 0 {
+                    initial_processes.push(process);
+                } else {
+                    debug!("Skipping process with PID 0 (likely kernel_task).");
+                }
             }
             Event::InitialConfig(config) => {
                 // If there is a display menubar override, apply it to newly created displays.

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -412,6 +412,10 @@ pub(super) fn application_event_trigger(
         match event {
             Event::ApplicationLaunched { psn, observer } if find_process(*psn).is_none() => {
                 let process: BProcess = Process::new(psn, observer.clone()).into();
+                if process.pid() == 0 {
+                    debug!("Skipping process with PID 0 (likely kernel_task).");
+                    continue;
+                }
                 let timeout = Timeout::new(
                     Duration::from_secs(PROCESS_READY_TIMEOUT_SEC),
                     Some(format!(

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -875,10 +875,11 @@ pub(super) fn window_destroyed_trigger(
         // the app's AX window list is still warm for a moment after the close. Re-checking them
         // raced the window back to life, leaving the entity in the strip and a permanent gap where
         // the window had been.
-        if matches!(source, DestroySource::SpaceNotification)
-            && window.role().is_ok()
-        {
-            debug!("Window {} still present, this was SLS workspace change.", window.id());
+        if matches!(source, DestroySource::SpaceNotification) && window.role().is_ok() {
+            debug!(
+                "Window {} still present, this was SLS workspace change.",
+                window.id()
+            );
             continue;
         }
 


### PR DESCRIPTION
The debug logs are polluted with warnings about `2026-08-19T00:36:21.691910Z DEBUG paneru::manager::process: src/manager/process.rs:380:  (0) is not finished launching, subscribing to finishedLaunching changes`

This is due to paneru trying to handle the `kernel-task` process which never finishes launching as far as paneru is concerned so I added guards to skip it.