### PR TITLE
feat: make menubar configurable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -100,6 +100,37 @@ workspace_menu_status = false
 workspace_popup_status = true
 ```
 
+### `[decorations.menu]`
+
+Basic settings for the menubar display.
+
+| Option | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `orientation` | String | `'default'` | Which of the menubar elements appears first, the descriptor `'default'` or the indicator `'flipped'`. |
+| `colors` | [String] | `['#FFFFFF']` | An array of hex colors defining a linear gradient (left to right) coloring the menubar display. Set a solid color by including only one element. |
+| `angle` | Float | `90.0` | The angle (in degrees) of the gradient. |
+
+### `[decorations.menu.descriptor]`
+Settings for the descriptor component of the menubar display. The descriptor component is a visual marker for the Paneru menubar item.
+| Option | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `style` | String | `'symbol'` | Composition of the descriptor. Options are any SF Symbol `'symbol'`, any string of text `'text'`, both of those `'both'`, or nothing `'hidden'` |
+| `text` | String | `'VW'` | Text shown if `'text'` or `'both'` style is selected. |
+| `symbol` | String | `'fish.fill'` | SF Symbol shown if `'symbol'` or `'both'` style is selected. SF Symbol names can be found in the [SF Symbols App](https://developer.apple.com/sf-symbols/), in the Xcode library, or in a variety of places online. |
+
+### `[decorations.menu.indicator]`
+Settings for the indicator component of the menubar display. The indicator component shows your current (and optionally all active) virtual workspace(s).
+
+**Important Note: The `'unicode'` format can only differentiate between active and inactive workspaces, so it is incompatible with the `'mono'` style and will fall back to `'default'`.**
+
+| Option | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `style` | String | `'mono'` | Whether the indicator displays all virtual workspaces `'multi'`, or only your current workspace `'mono'`. |
+| `format` | String | `'default'` | The format of the character(s) which represent your virtual workspace(s).<br>Options are regular numbers `'default'`, Roman numerals `'roman'`, or any pair of Unicode characters `'unicode'`. |
+| `font_size` | Float (2.0 to 24.0) | `13.0` | Font size of the indicator in point. |
+| `active_character` | Char | `'☉'` | The Unicode character which represents an active workspace in the `'unicode'` format. |
+| `inactive_character` | Char | `'○'` | The Unicode character which represents an inactive workspace in the `'unicode'` format. |
+
 
 ### `[decorations.inactive.dim] (Native macOS Dimming)`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,11 @@ use std::{
 use stdext::function_name;
 use tracing::{error, info, warn};
 
-use self::decorations::BorderRadiusOption;
+use self::decorations::{
+    BorderRadiusOption, DescriptorStyle, IndicatorFormat, IndicatorStyle, MenubarOrientation,
+};
 use self::swipe::SwipeGestureDirection;
+
 #[cfg(test)]
 use crate::commands::{MoveFocus, Operation, ResizeDirection};
 use crate::{
@@ -852,6 +855,110 @@ impl Config {
         self.options()
             .create_virtual_workspace_automatically
             .is_some_and(|enabled| enabled)
+    }
+    pub fn menubar_orientation(&self) -> MenubarOrientation {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.orientation)
+            .unwrap_or(MenubarOrientation::Default)
+    }
+    pub fn menubar_gradient(&self) -> Vec<(f64, f64, f64)> {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.colors.as_ref())
+            .into_iter()
+            .flatten()
+            .map(|hex_string| parse_hex_color(hex_string))
+            .collect()
+    }
+    pub fn menubar_gradient_angle(&self) -> f64 {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.angle)
+            .unwrap_or(90.0)
+    }
+    pub fn menubar_descriptor_style(&self) -> DescriptorStyle {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.descriptor.as_ref())
+            .and_then(|descriptor_options| descriptor_options.style)
+            .unwrap_or(DescriptorStyle::Symbol)
+    }
+    pub fn menubar_descriptor_text(&self) -> String {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.descriptor.as_ref())
+            .and_then(|descriptor_options| descriptor_options.text.clone())
+            .unwrap_or(String::from("VW"))
+    }
+    pub fn menubar_descriptor_symbol(&self) -> String {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.descriptor.as_ref())
+            .and_then(|descriptor_options| descriptor_options.symbol.clone())
+            .unwrap_or(String::from("fish.fill"))
+    }
+    pub fn menubar_indicator_style(&self) -> IndicatorStyle {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.indicator.as_ref())
+            .and_then(|indicator| indicator.style)
+            .unwrap_or(IndicatorStyle::Mono)
+    }
+    pub fn menubar_indicator_format(&self) -> IndicatorFormat {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.indicator.as_ref())
+            .and_then(|indicator| indicator.format)
+            .unwrap_or(IndicatorFormat::Default)
+    }
+    pub fn menubar_indicator_font_size(&self) -> f64 {
+        const DEFAULT_FONT_SIZE: f64 = 13.0;
+        const MIN_FONT_SIZE: f64 = 1.0;
+        const MAX_FONT_SIZE: f64 = 24.0;
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.indicator.as_ref())
+            .and_then(|indicator| indicator.font_size)
+            .filter(|font_size| font_size.is_finite())
+            .unwrap_or(DEFAULT_FONT_SIZE)
+            .clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
+    }
+    pub fn menubar_indicator_active_character(&self) -> char {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.indicator.as_ref())
+            .and_then(|indicator| indicator.active_character)
+            .unwrap_or('☉')
+    }
+    pub fn menubar_indicator_inactive_character(&self) -> char {
+        self.inner()
+            .decorations
+            .as_ref()
+            .and_then(|decorations| decorations.menu.as_ref())
+            .and_then(|menubar| menubar.indicator.as_ref())
+            .and_then(|indicator| indicator.inactive_character)
+            .unwrap_or('○')
     }
 }
 

--- a/src/config/decorations.rs
+++ b/src/config/decorations.rs
@@ -5,6 +5,7 @@ pub struct DecorationsOptions {
     pub active: Option<GeneralDecorationsOptions>,
     pub inactive: Option<GeneralDecorationsOptions>,
     pub workspace_menu_status: Option<bool>,
+    pub menu: Option<MenubarOptions>,
     pub workspace_popup_status: Option<bool>,
 }
 
@@ -46,6 +47,78 @@ pub struct GeneralDimOptions {
     /// Default: "#000000" (black).
     pub color: Option<String>,
 }
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct MenubarOptions {
+    pub orientation: Option<MenubarOrientation>,
+    pub colors: Option<Vec<String>>,
+    pub angle: Option<f64>,
+    pub descriptor: Option<MenubarDescriptorOptions>,
+    pub indicator: Option<MenubarIndicatorOptions>,
+}
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct MenubarDescriptorOptions {
+    /// How the graphic/text descriptor to the left of the
+    /// VW #(s) is displayed. Options are symbol, text, both
+    /// or Hidden. Default is symbol.
+    pub style: Option<DescriptorStyle>,
+    /// Text string preceding VW #(s)
+    /// Defaults to "VW"
+    pub text: Option<String>,
+    /// Symbol System Name (SF Symbols)
+    /// Defaults to "fish.fill"
+    pub symbol: Option<String>,
+}
+#[derive(Deserialize, Debug, Clone, Copy, Default)]
+pub struct MenubarIndicatorOptions {
+    /// Format for virtual workspace indicator. Options are mono,
+    /// which shows just the current workspace, or multi, which
+    /// shows all active workspaces.
+    /// Defaults to mono.
+    pub style: Option<IndicatorStyle>,
+    /// Character style for virtual workspace indicator. Options
+    /// are default (1 or 1 2 3), roman (I or I II III), or
+    /// unicode (incompatible with mono or ○ ☉ ○). Roman
+    /// only properly formats numbers < 90.
+    pub format: Option<IndicatorFormat>,
+    /// Font size in pt.
+    /// Defaults to 13
+    pub font_size: Option<f64>,
+    /// Only relevant for multi style/Unicode format.
+    /// Defaults to ☉
+    pub active_character: Option<char>,
+    /// Only relevant for multi style/Unicode format.
+    /// Defaults to ○
+    pub inactive_character: Option<char>,
+}
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum IndicatorFormat {
+    Default,
+    Roman,
+    // If set must define active/inactive char. Only relevant for multi style
+    Unicode,
+}
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MenubarOrientation {
+    Default,
+    Flipped,
+}
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum IndicatorStyle {
+    Mono,
+    Multi,
+}
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DescriptorStyle {
+    Symbol,
+    Text,
+    Both,
+    Hidden,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum BorderRadiusOption {
     Auto,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -5,8 +5,10 @@ use bevy::MinimalPlugins;
 use bevy::app::App as BevyApp;
 use bevy::app::{First, Last, PostUpdate, PreUpdate, Startup};
 use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::lifecycle::RemovedComponents;
 use bevy::ecs::query::{Added, Changed, With};
 use bevy::ecs::resource::Resource;
+use bevy::ecs::schedule::SystemCondition;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
 use bevy::ecs::schedule::{ScheduleLabel as _, SingleThreadedExecutor};
 use bevy::ecs::system::{Commands, EntityCommands, Query, Res, SystemId};
@@ -93,6 +95,13 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 || !workspace_changed.is_empty()
                 || !focused_moved.is_empty()
         };
+    // The menu bar additionally shows how many virtual workspaces exist, so it
+    // has to redraw when one is created or reaped, neither of which touches the
+    // active strip.
+    let strip_count_changed =
+        |added: Query<(), Added<LayoutStrip>>, mut removed: RemovedComponents<LayoutStrip>| {
+            !added.is_empty() || removed.read().next().is_some()
+        };
     let native_tabs_enabled =
         |config: Option<Res<Config>>| config.is_none_or(|config| config.native_tabs_enabled());
 
@@ -177,7 +186,8 @@ pub fn register_systems(app: &mut bevy::app::App) {
                 systems::update_flash_messages,
             )
                 .chain(),
-            crate::menubar::update_menu_bar.run_if(vw_indicator_dirty),
+            crate::menubar::update_menu_bar
+                .run_if(vw_indicator_dirty.or_eager(strip_count_changed)),
         ),
     );
 }

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -1,17 +1,28 @@
 use bevy::ecs::query::{Has, With};
 use bevy::ecs::system::{NonSendMut, Query, Res};
 use objc2::rc::Retained;
-use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
-use objc2_app_kit::{
-    NSControlStateValueOff, NSControlStateValueOn, NSFont, NSImage, NSMenu, NSMenuItem,
-    NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
+use objc2::runtime::AnyObject;
+use objc2::{
+    AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
 };
-use objc2_foundation::{NSObject, NSString};
+use objc2_app_kit::{
+    NSBitmapImageRep, NSColor, NSControlStateValueOff, NSControlStateValueOn,
+    NSDeviceRGBColorSpace, NSFont, NSImage, NSImageScaling, NSImageView,
+    NSLayoutAttribute, NSMenu, NSMenuItem, NSScreen, NSStackView, NSStatusBar, NSStatusItem,
+    NSTextField, NSUserInterfaceLayoutOrientation, NSVariableStatusItemLength, NSView,
+};
+use objc2_core_foundation::{CGFloat, CGPoint, CGRect, CGSize};
+use objc2_foundation::{NSArray, NSInteger, NSObject, NSString};
+use objc2_quartz_core::{CAGradientLayer, CALayer};
 use tracing::warn;
 
 use crate::accessibility_prompt::{AccessibilitySetupAction, show_accessibility_setup};
 use crate::commands::{Command, Operation};
 use crate::config::Config;
+use crate::config::decorations::{
+    DescriptorStyle, IndicatorFormat, IndicatorStyle, MenubarOrientation,
+};
+use crate::ecs::layout::LayoutStrip;
 use crate::ecs::params::ActiveDisplay;
 use crate::ecs::{Bounds, FocusedMarker, Unmanaged};
 use crate::events::{Event, EventSender};
@@ -95,6 +106,8 @@ impl MenuActionTarget {
     }
 }
 
+const MENU_BAR_SPACING: CGFloat = 5.0;
+
 pub struct MenuBarManager {
     mtm: MainThreadMarker,
     status_bar: Retained<NSStatusBar>,
@@ -105,7 +118,13 @@ pub struct MenuBarManager {
     managed_window_items: Vec<Retained<NSMenuItem>>,
     manage_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
-    current_label: Option<String>,
+    current_content: Option<MenuBarContent>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum MenuBarContent {
+    Text(String),
+    Workspaces { current: Option<u32>, all: Vec<u32> },
 }
 
 #[derive(Debug, PartialEq)]
@@ -145,14 +164,14 @@ impl MenuBarManager {
             managed_window_items: Vec::new(),
             manage_item: None,
             configured_widths: Vec::new(),
-            current_label: None,
+            current_content: None,
         }
     }
 
     pub fn new_accessibility_required(mtm: MainThreadMarker, events: EventSender) -> Self {
         let mut manager = Self::new(mtm, events);
         manager.rebuild_accessibility_menu();
-        manager.show_label("!".to_owned());
+        manager.show_text("!");
         manager
     }
 
@@ -182,12 +201,13 @@ impl MenuBarManager {
     pub fn update(
         &mut self,
         virtual_index: u32,
-        show_virtual_workspace: bool,
-        preset_widths: &[f64],
+        virtual_indices: &[u32],
+        config: &Config,
         has_focused_window: bool,
         focused_width_ratio: Option<f64>,
     ) {
-        let widths = normalized_width_percentages(preset_widths);
+        let preset_widths = config.preset_column_widths();
+        let widths = normalized_width_percentages(&preset_widths);
         if self.configured_widths != widths {
             self.rebuild_menu(&widths);
         }
@@ -209,12 +229,13 @@ impl MenuBarManager {
             });
         }
 
-        let label = if show_virtual_workspace {
-            virtual_workspace_label(virtual_index)
+        let current = config.workspace_menu_status().then_some(virtual_index);
+        let all: &[u32] = if current.is_some() {
+            virtual_indices
         } else {
-            String::new()
+            &[]
         };
-        self.show_label(label);
+        self.show_workspaces(config, current, all);
     }
 
     fn rebuild_menu(&mut self, widths: &[i32]) {
@@ -261,32 +282,274 @@ impl MenuBarManager {
         item
     }
 
-    fn show_label(&mut self, label: String) {
-        if self.current_label.as_deref() == Some(label.as_str()) {
+    fn show_text(&mut self, label: &str) {
+        let content = MenuBarContent::Text(label.to_owned());
+        if self.current_content.as_ref() == Some(&content) {
             return;
         }
 
-        let tooltip = NSString::from_str("Paneru window manager");
-        let Some(button) = self.status_item.button(self.mtm) else {
-            warn!("unable to update menu bar: status item has no button");
+        let field = NSTextField::labelWithString(&NSString::from_str(label), self.mtm);
+        field.setFont(Some(&NSFont::menuBarFontOfSize(0.0)));
+        field.sizeToFit();
+        let size = field.frame().size;
+
+        if self.install(&field, size.width, size.height) {
+            self.current_content = Some(content);
+        }
+    }
+
+    fn show_workspaces(&mut self, config: &Config, current: Option<u32>, all: &[u32]) {
+        let content = MenuBarContent::Workspaces {
+            current,
+            all: all.to_vec(),
+        };
+        if self.current_content.as_ref() == Some(&content) {
             return;
+        }
+
+        let descriptor = self.build_descriptor(config);
+        let indicator = self.build_indicator(config, current, all);
+        let ordered = match config.menubar_orientation() {
+            MenubarOrientation::Default => [descriptor, indicator],
+            MenubarOrientation::Flipped => [indicator, descriptor],
         };
 
-        if button.image().is_none() {
-            let icon = NSImage::imageWithSystemSymbolName_accessibilityDescription(
-                &NSString::from_str("fish.fill"),
-                None,
-            );
-            if let Some(icon) = &icon {
-                icon.setTemplate(true);
-            }
-            button.setImage(icon.as_deref());
-            button.setFont(Some(&NSFont::menuBarFontOfSize(8.0)));
-            button.setImageHugsTitle(true);
+        let stack = NSStackView::new(self.mtm);
+        stack.setSpacing(MENU_BAR_SPACING);
+        stack.setOrientation(NSUserInterfaceLayoutOrientation::Horizontal);
+        for view in ordered.into_iter().flatten() {
+            stack.addArrangedSubview(&view);
         }
-        button.setTitle(&NSString::from_str(&label));
-        button.setToolTip(Some(&tooltip));
-        self.current_label = Some(label);
+
+        let fitting = stack.fittingSize();
+        let size = CGSize::new(
+            fitting.width,
+            fitting.height.min(self.status_bar.thickness()),
+        );
+
+        let installed = match self.gradient_view(config, &stack, size) {
+            Some(gradient) => self.install(&gradient, size.width, size.height),
+            None => self.install(&stack, size.width, size.height),
+        };
+        if installed {
+            self.current_content = Some(content);
+        }
+    }
+
+    /// Wraps `content` in a view hosting a [`CAGradientLayer`] masked by a
+    /// bitmap render of `content`, so the configured colours fill the glyphs
+    /// themselves rather than the box around them.
+    ///
+    /// Returns `None` when there is no gradient to draw or any step of the
+    /// render fails, leaving the caller to install `content` untouched.
+    fn gradient_view(
+        &self,
+        config: &Config,
+        content: &NSView,
+        size: CGSize,
+    ) -> Option<Retained<NSView>> {
+        let gradient = config.menubar_gradient();
+        if gradient.len() < 1 || size.width <= 0.0 || size.height <= 0.0 {
+            return None;
+        }
+        let bounds = CGRect::new(CGPoint::ZERO, size);
+        let scale = self.backing_scale_factor();
+
+        let rep = render_content_bitmap(content, bounds, scale)?;
+        let image = rep.CGImage()?;
+        let mask = CALayer::new();
+        mask.setFrame(bounds);
+        mask.setContentsScale(scale);
+        unsafe { mask.setContents(Some(AsRef::<AnyObject>::as_ref(&*image))) };
+
+        let colors = gradient
+            .into_iter()
+            .map(|(red, green, blue)| {
+                NSColor::colorWithSRGBRed_green_blue_alpha(red, green, blue, 1.0).CGColor()
+            })
+            .collect::<Vec<_>>();
+        let color_objects = colors
+            .iter()
+            .map(|color| AsRef::<AnyObject>::as_ref(&**color))
+            .collect::<Vec<_>>();
+
+        let angle = config.menubar_gradient_angle();
+        let layer = CAGradientLayer::new();
+        layer.setFrame(bounds);
+        layer.setContentsScale(scale);
+        layer.setStartPoint(unit_point_for_angle(size, angle + 180.0));
+        layer.setEndPoint(unit_point_for_angle(size, angle));
+        unsafe {
+            layer.setColors(Some(&NSArray::from_slice(&color_objects)));
+            layer.setMask(Some(&mask));
+        }
+
+        let view = NSView::new(self.mtm);
+        view.setLayer(Some(&layer));
+        view.setWantsLayer(true);
+        Some(view)
+    }
+
+    /// The scale the mask bitmap has to be rendered at. It cannot be read back
+    /// from the content view, which is still outside any window while it is
+    /// being rendered.
+    fn backing_scale_factor(&self) -> CGFloat {
+        self.status_item
+            .button(self.mtm)
+            .and_then(|button| button.window())
+            .map(|window| window.backingScaleFactor())
+            .or_else(|| NSScreen::mainScreen(self.mtm).map(|screen| screen.backingScaleFactor()))
+            .filter(|scale| *scale > 0.0)
+            .unwrap_or(1.0)
+    }
+
+    fn install(&self, view: &NSView, width: CGFloat, height: CGFloat) -> bool {
+        let Some(button) = self.status_item.button(self.mtm) else {
+            warn!("unable to update menu bar: status item has no button");
+            return false;
+        };
+
+        for subview in button.subviews() {
+            subview.removeFromSuperview();
+        }
+
+        if width <= 0.0 {
+            self.status_item.setLength(0.0);
+            return true;
+        }
+
+        let origin_y = ((self.status_bar.thickness() - height) / 2.0).max(0.0);
+        view.setTranslatesAutoresizingMaskIntoConstraints(true);
+        view.setFrame(CGRect::new(
+            CGPoint::new(MENU_BAR_SPACING, origin_y),
+            CGSize::new(width, height),
+        ));
+        button.addSubview(view);
+        button.setToolTip(Some(&NSString::from_str("Paneru window manager")));
+        self.status_item.setLength(width);
+        true
+    }
+
+    fn build_indicator(
+        &self,
+        config: &Config,
+        current: Option<u32>,
+        all: &[u32],
+    ) -> Option<Retained<NSStackView>> {
+        let current = current?;
+        let style = config.menubar_indicator_style();
+        let format = match (style, config.menubar_indicator_format()) {
+            (IndicatorStyle::Mono, IndicatorFormat::Unicode) => IndicatorFormat::Default,
+            (_, format) => format,
+        };
+
+        let stack = NSStackView::new(self.mtm);
+        stack.setSpacing(MENU_BAR_SPACING);
+        stack.setOrientation(NSUserInterfaceLayoutOrientation::Horizontal);
+        stack.setAlignment(NSLayoutAttribute::CenterY);
+        match style {
+            IndicatorStyle::Mono => {
+                stack.addArrangedSubview(&self.format_indicator(config, format, current, false));
+            }
+            IndicatorStyle::Multi => {
+                for &virtual_index in all {
+                    let field = self.format_indicator(
+                        config,
+                        format,
+                        virtual_index,
+                        virtual_index == current,
+                    );
+                    stack.addArrangedSubview(&field);
+                }
+            }
+        }
+        Some(stack)
+    }
+
+    fn format_indicator(
+        &self,
+        config: &Config,
+        format: IndicatorFormat,
+        virtual_index: u32,
+        is_active: bool,
+    ) -> Retained<NSTextField> {
+        let label = match format {
+            IndicatorFormat::Default => virtual_workspace_label(virtual_index),
+            IndicatorFormat::Roman => roman_numeral(virtual_index.saturating_add(1)),
+            IndicatorFormat::Unicode => if is_active {
+                config.menubar_indicator_active_character()
+            } else {
+                config.menubar_indicator_inactive_character()
+            }
+            .to_string(),
+        };
+        let font_size = config.menubar_indicator_font_size();
+        let font = if is_active && format != IndicatorFormat::Unicode {
+            NSFont::boldSystemFontOfSize(font_size)
+        } else {
+            NSFont::systemFontOfSize(font_size)
+        };
+        let field = NSTextField::labelWithString(&NSString::from_str(&label), self.mtm);
+        field.setFont(Some(&font));
+        field
+    }
+
+    fn build_descriptor(&self, config: &Config) -> Option<Retained<NSStackView>> {
+        let style = config.menubar_descriptor_style();
+        if style == DescriptorStyle::Hidden {
+            return None;
+        }
+        let stack = NSStackView::new(self.mtm);
+        stack.setSpacing(MENU_BAR_SPACING);
+        stack.setOrientation(NSUserInterfaceLayoutOrientation::Horizontal);
+        stack.setAlignment(NSLayoutAttribute::CenterY);
+        if matches!(style, DescriptorStyle::Symbol | DescriptorStyle::Both)
+            && let Some(image_view) = self.build_descriptor_symbol(config)
+        {
+            stack.addArrangedSubview(&image_view);
+        }
+        if matches!(style, DescriptorStyle::Text | DescriptorStyle::Both) {
+            stack.addArrangedSubview(&self.build_descriptor_text(config));
+        }
+        (!stack.arrangedSubviews().is_empty()).then_some(stack)
+    }
+
+    fn build_descriptor_symbol(&self, config: &Config) -> Option<Retained<NSImageView>> {
+        let symbol = config.menubar_descriptor_symbol();
+        let Some(image) = NSImage::imageWithSystemSymbolName_accessibilityDescription(
+            &NSString::from_str(&symbol),
+            None,
+        ) else {
+            warn!(%symbol, "unable to load menu bar descriptor symbol");
+            return None;
+        };
+        image.setTemplate(true);
+
+
+        let size = image.size();
+        let aspect_ratio = if size.height > 0.0 {
+            size.width / size.height
+        } else {
+            1.0
+        };
+        let scaled = CGSize::new(14.0 * aspect_ratio, 14.0);
+        image.setSize(scaled);
+
+        let image_view = NSImageView::new(self.mtm);
+        image_view.setImage(Some(&image));
+        image_view.setImageScaling(NSImageScaling::ScaleProportionallyUpOrDown);
+        image_view.setFrameSize(scaled);
+        image_view.setContentTintColor(Some(&*NSColor::whiteColor()));
+        Some(image_view)
+    }
+
+    fn build_descriptor_text(&self, config: &Config) -> Retained<NSTextField> {
+        let field = NSTextField::labelWithString(
+            &NSString::from_str(&config.menubar_descriptor_text()),
+            self.mtm,
+        );
+        field.setFont(Some(&NSFont::menuBarFontOfSize(0.0)));
+        field
     }
 }
 
@@ -298,6 +561,7 @@ impl Drop for MenuBarManager {
 
 pub fn update_menu_bar(
     active_display: ActiveDisplay,
+    workspaces: Query<&LayoutStrip>,
     focused: Query<(&Bounds, Has<Unmanaged>), With<FocusedMarker>>,
     config: Res<Config>,
     menu_bar: Option<NonSendMut<MenuBarManager>>,
@@ -306,6 +570,13 @@ pub fn update_menu_bar(
         return;
     };
     let strip = active_display.active_strip();
+    let mut virtual_indices = workspaces
+        .iter()
+        .filter(|workspace| workspace.id() == strip.id())
+        .map(|workspace| workspace.virtual_index)
+        .collect::<Vec<_>>();
+    virtual_indices.sort_unstable();
+    virtual_indices.dedup();
     let viewport = active_display.actual_bounds(&config);
 
     let focused_window = focused.iter().next();
@@ -315,8 +586,8 @@ pub fn update_menu_bar(
 
     menu_bar.update(
         strip.virtual_index,
-        config.workspace_menu_status(),
-        &config.preset_column_widths(),
+        &virtual_indices,
+        &config,
         focused_window.is_some(),
         focused_width_ratio,
     );
@@ -324,6 +595,88 @@ pub fn update_menu_bar(
 
 pub(crate) fn virtual_workspace_label(virtual_index: u32) -> String {
     (virtual_index + 1).to_string()
+}
+
+fn roman_numeral(value: u32) -> String {
+    const NUMERALS: [(u32, &str); 7] = [
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ];
+
+    let mut remaining = value;
+    let mut numeral = String::new();
+    while remaining > 0 {
+        let Some(&(weight, symbol)) = NUMERALS.iter().find(|(weight, _)| *weight <= remaining)
+        else {
+            break;
+        };
+        remaining -= weight;
+        numeral.push_str(symbol);
+    }
+    numeral
+}
+
+/// Renders `content` into a bitmap at `scale`, for use as a [`CALayer`] mask:
+/// only the alpha channel is read back, so the colors `AppKit` happens to draw
+/// the labels in do not matter.
+fn render_content_bitmap(
+    content: &NSView,
+    bounds: CGRect,
+    scale: CGFloat,
+) -> Option<Retained<NSBitmapImageRep>> {
+    let pixels_wide = NSInteger::try_from(round_px(bounds.size.width * scale)).ok()?;
+    let pixels_high = NSInteger::try_from(round_px(bounds.size.height * scale)).ok()?;
+
+    content.setFrame(bounds);
+    content.layoutSubtreeIfNeeded();
+
+    let rep = unsafe {
+        NSBitmapImageRep::initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel(
+            NSBitmapImageRep::alloc(),
+            std::ptr::null_mut(),
+            pixels_wide,
+            pixels_high,
+            8,
+            4,
+            true,
+            false,
+            NSDeviceRGBColorSpace,
+            0,
+            0,
+        )
+    }?;
+    rep.setSize(bounds.size);
+    content.cacheDisplayInRect_toBitmapImageRep(bounds, &rep);
+    Some(rep)
+}
+
+/// The point where a ray leaving the center of a `size`-sized rectangle at
+/// `degrees` crosses that rectangle's edge, in the unit coordinate space
+/// [`CAGradientLayer`] takes its start and end points in.
+///
+/// Angles run counter-clockwise from 0° pointing right, matching the layer's
+/// unflipped geometry: 90° is the top edge, 270° the bottom one.
+fn unit_point_for_angle(size: CGSize, degrees: f64) -> CGPoint {
+    let center = CGPoint::new(0.5, 0.5);
+    if size.width <= 0.0 || size.height <= 0.0 {
+        return center;
+    }
+
+    let (sin, cos) = degrees.to_radians().sin_cos();
+
+    let to_side = (size.width / 2.0) / cos.abs();
+    let to_cap = (size.height / 2.0) / sin.abs();
+    let distance = to_side.min(to_cap);
+
+    CGPoint::new(
+        center.x + distance * cos / size.width,
+        center.y + distance * sin / size.height,
+    )
 }
 
 fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
@@ -341,10 +694,23 @@ fn normalized_width_percentages(widths: &[f64]) -> Vec<i32> {
 
 #[cfg(test)]
 mod tests {
+    use objc2_core_foundation::{CGPoint, CGSize};
+
     use super::{
-        WindowMenuEnablement, normalized_width_percentages, virtual_workspace_label,
-        window_menu_enablement,
+        WindowMenuEnablement, normalized_width_percentages, roman_numeral, unit_point_for_angle,
+        virtual_workspace_label, window_menu_enablement,
     };
+
+    const EPSILON: f64 = 1e-9;
+
+    fn assert_unit_point(point: CGPoint, x: f64, y: f64) {
+        assert!(
+            (point.x - x).abs() < EPSILON && (point.y - y).abs() < EPSILON,
+            "expected ({x}, {y}), got ({}, {})",
+            point.x,
+            point.y
+        );
+    }
 
     #[test]
     fn virtual_workspace_label_is_one_based() {
@@ -353,10 +719,74 @@ mod tests {
     }
 
     #[test]
+    fn roman_numerals_terminate_and_subtract_correctly() {
+        assert_eq!(roman_numeral(0), "");
+        assert_eq!(roman_numeral(1), "I");
+        assert_eq!(roman_numeral(3), "III");
+        assert_eq!(roman_numeral(4), "IV");
+        assert_eq!(roman_numeral(5), "V");
+        assert_eq!(roman_numeral(9), "IX");
+        assert_eq!(roman_numeral(10), "X");
+        assert_eq!(roman_numeral(40), "XL");
+        assert_eq!(roman_numeral(49), "XLIX");
+        assert_eq!(roman_numeral(50), "L");
+        assert_eq!(roman_numeral(89), "LXXXIX");
+    }
+
+    #[test]
     fn menu_widths_are_sorted_deduplicated_and_valid() {
         assert_eq!(
             normalized_width_percentages(&[2.0, 0.5, 1.5, 0.5, 0.001, f64::NAN, -1.0]),
             vec![50, 150, 200]
+        );
+    }
+
+    #[test]
+    fn cardinal_gradient_angles_hit_edge_midpoints() {
+        let size = CGSize::new(100.0, 20.0);
+        assert_unit_point(unit_point_for_angle(size, 0.0), 1.0, 0.5);
+        assert_unit_point(unit_point_for_angle(size, 90.0), 0.5, 1.0);
+        assert_unit_point(unit_point_for_angle(size, 180.0), 0.0, 0.5);
+        assert_unit_point(unit_point_for_angle(size, 270.0), 0.5, 0.0);
+    }
+
+    #[test]
+    fn gradient_angles_leave_through_the_nearer_edge() {
+        // 45° out of a wide, short rect reaches the top long before the side,
+        // and out of a square it lands exactly on the corner.
+        assert_unit_point(
+            unit_point_for_angle(CGSize::new(100.0, 20.0), 45.0),
+            0.6,
+            1.0,
+        );
+        assert_unit_point(
+            unit_point_for_angle(CGSize::new(40.0, 40.0), 45.0),
+            1.0,
+            1.0,
+        );
+    }
+
+    #[test]
+    fn gradient_angles_wrap_and_stay_opposite() {
+        let size = CGSize::new(64.0, 22.0);
+        assert_unit_point(unit_point_for_angle(size, 450.0), 0.5, 1.0);
+        assert_unit_point(unit_point_for_angle(size, -90.0), 0.5, 0.0);
+
+        // What the caller relies on: the start and end of a gradient sit on
+        // opposite sides of the centre.
+        let start = unit_point_for_angle(size, 30.0 + 180.0);
+        let end = unit_point_for_angle(size, 30.0);
+        assert!((start.x + end.x - 1.0).abs() < EPSILON);
+        assert!((start.y + end.y - 1.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn gradient_angles_on_a_degenerate_rect_stay_centred() {
+        assert_unit_point(unit_point_for_angle(CGSize::new(0.0, 20.0), 45.0), 0.5, 0.5);
+        assert_unit_point(
+            unit_point_for_angle(CGSize::new(100.0, 0.0), 45.0),
+            0.5,
+            0.5,
         );
     }
 


### PR DESCRIPTION
# Notes
Added a bunch of config options for the menubar. See updates to CONFIGURATION.md as it's a lot to write again. Authored mostly by me with some Opus 5 revisions. I've reviewed everything and done a fair amount of testing.
## Example config
```toml
[decorations.menu]
orientation = "default"
colors = ["#FF0000","#00FF00"]
angle = 90

[decorations.menu.descriptor]
style = "symbol"
symbol = "fish"
text = "VW"

[decorations.menu.indicator]
style = "multi"
format = "unicode"
font_size = 13
active_character = "X"
inactive_character = "O"
```
## Demos
Example config:
<img width="275" height="35" alt="image" src="https://github.com/user-attachments/assets/bd85824e-4353-4c35-a616-6efb725aa432" />

Both/Default:
<img width="287" height="31" alt="image" src="https://github.com/user-attachments/assets/89b0d52c-826b-47bc-8837-3bf643303101" />

Hidden/Roman:
<img width="250" height="35" alt="image" src="https://github.com/user-attachments/assets/31603bda-3210-4310-a632-8980e42ef997" />

My config (that I think is cute because it looks like a fish and bubbles):
<img width="289" height="35" alt="image" src="https://github.com/user-attachments/assets/26c6dbad-2db8-4dc9-a70c-11c65bb44067" />
