### PR TITLE
fix: Restore focus when switching virtual workspaces without animations

### DIFF
--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -1200,6 +1200,11 @@ pub(crate) fn show_active_workspace(
                 entity: focus,
                 with_strip: true,
             });
+            // RaiseWindow only re-orders the windows; restore keyboard focus
+            // too, otherwise the focus marker stays on a window of the hidden
+            // workspace until the next explicit focus command. Focus after
+            // raising: raise_window_trigger must raise this window last.
+            commands.focus_entity(focus, false);
         }
     }
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -13,7 +13,7 @@ use crate::ecs::{
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
-use crate::platform::Modifiers;
+use crate::platform::{Modifiers, WinID};
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
@@ -1415,6 +1415,81 @@ fn test_virtual_workspace_switch_no_horizontal_slide_no_animations() {
         "strip x must equal the pre-switch scroll position after VW switch-back (no sideways slide). \
          Expected {strip_x_after_scroll}, got {strip_x_final}"
     );
+}
+
+/// Switching virtual workspaces with `virtual_workspace_animations = false` must
+/// restore keyboard focus to the workspace's remembered window. Regression test:
+/// the non-animation path of `show_active_workspace` only triggered
+/// `RaiseWindow` without calling `focus_entity`, so `FocusedMarker` stayed on a
+/// window of the hidden workspace and the first directional focus command after
+/// the switch was consumed by the re-enter-strip fallback instead of moving
+/// focus.
+#[test]
+fn test_virtual_workspace_switch_restores_focus_no_animations() {
+    let config: Config = (
+        MainOptions {
+            virtual_workspace_animations: Some(false),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let mut h = TestHarness::new()
+        .with_config(config)
+        .with_windows(4)
+        .with_focused_window(0);
+
+    let pump_event = |h: &mut TestHarness, ev: Event| {
+        h.app.world_mut().write_message::<Event>(ev);
+        for _ in 0..8 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+    let pump = |h: &mut TestHarness, c: Command| pump_event(h, Event::Command { command: c });
+    // Focus a window through the mock OS: updates the app's focused window and
+    // queues ApplicationFrontSwitched + WindowFocused events.
+    let focus = |h: &mut TestHarness, id: WinID| {
+        h.mock_state.focus_window(id);
+        for _ in 0..8 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    // Boot the strip and settle focus on window 0.
+    pump(&mut h, Command::PrintState);
+    assert_focused!(h.app.world_mut(), 0);
+
+    // Build VW1 out of windows 2 and 3, staying on VW0.
+    for id in [2, 3] {
+        focus(&mut h, id);
+        pump(
+            &mut h,
+            Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        );
+    }
+    focus(&mut h, 0);
+
+    // Visit VW1 and focus window 2 there, so VW0 is hidden with window 0 as
+    // its remembered focus and VW1 later records window 2.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    focus(&mut h, 2);
+    assert_focused!(h.app.world_mut(), 2);
+
+    // Switch back to VW0: focus must return to window 0 immediately, without
+    // any further focus command.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(0)));
+    assert_focused!(h.app.world_mut(), 0);
+
+    // Switch to VW1 again: focus must return to its remembered window 2.
+    pump(&mut h, Command::Window(Operation::VirtualNumber(1)));
+    assert_focused!(h.app.world_mut(), 2);
 }
 
 /// When a strip is mid-animation (has a `RepositionMarker`) at the moment the


### PR DESCRIPTION
Fixes #364.

## Problem

With `virtual_workspace_animations = false` (the default), switching virtual workspaces does not restore keyboard focus: `FocusedMarker` stays on a window of the hidden workspace, and the first directional `focus` command after the switch is consumed by the re-enter-strip fallback (`src/commands.rs:312`) instead of moving focus. Users observe this as "alt+2 then alt+l needs two presses".

Regression from `890c85b` ("fix: Raise windows when switching virtual workspaces."), which replaced `commands.focus_entity(...)` in the non-animation fallback of `show_active_workspace` with a raise-only `RaiseWindow` trigger. The animation path still calls `focus_entity`, so the bug only shows with animations disabled.

## Fix

In the non-animation fallback of `show_active_workspace`, keep the `RaiseWindow` trigger (it re-orders the strip's windows so the target ends up on top) and additionally restore `commands.focus_entity(focus, false)`. Focus is issued after the raise because `raise_window_trigger` must raise the target window last (raised windows get OS focus events).

## Test

Added `test_virtual_workspace_switch_restores_focus_no_animations` in `src/tests/interaction.rs`: builds a second virtual workspace, visits it, then asserts that switching back and forth with animations disabled immediately restores `FocusedMarker` to each workspace's remembered window. The test fails without the fix and passes with it.

Note: `config::test_config_defaults` fails locally both with and without this change (pre-existing, environment-dependent — it picks up the user config). All other 198 tests pass.
