### PR TITLE
fix: retain application observer after window discovery timeout

### DIFF
--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -358,7 +358,7 @@ pub(crate) fn finish_setup(
 /// observes the application for events, and adds its windows to the manager.
 /// This system processes `BProcess` entities marked with `FreshMarker`.
 /// If the process is not yet ready, it continues observing it. If ready, it attempts to create and observe an `Application`.
-/// A `Timeout` is added to the application if it takes too long to become observable.
+/// A `Timeout` stops initial window polling if the application does not expose a window in time.
 ///
 /// # Arguments
 ///
@@ -371,7 +371,7 @@ pub(super) fn add_launched_process(
     config: Res<Config>,
     mut commands: Commands,
 ) {
-    const APP_OBSERVABLE_TIMEOUT_SEC: u64 = 5;
+    const APP_WINDOW_DISCOVERY_TIMEOUT_SEC: u64 = 5;
     let mut already_seen = HashSet::new();
 
     for (entity, mut process, children) in fresh_processes {
@@ -408,9 +408,9 @@ pub(super) fn add_launched_process(
 
         if app.observe().is_ok_and(|good| good) {
             let timeout = Timeout::new(
-                Duration::from_secs(APP_OBSERVABLE_TIMEOUT_SEC),
+                Duration::from_secs(APP_WINDOW_DISCOVERY_TIMEOUT_SEC),
                 Some(format!(
-                    "{app} did not become observable in {APP_OBSERVABLE_TIMEOUT_SEC}s.",
+                    "{app} did not expose a window in {APP_WINDOW_DISCOVERY_TIMEOUT_SEC}s; stopping initial polling.",
                 )),
                 &mut commands,
             );
@@ -484,29 +484,35 @@ pub(super) fn fresh_marker_cleanup(cleanup: TimedOutSpawns, mut commands: Comman
     }
 }
 
-/// A Bevy system that ticks `Timeout` timers and despawns entities when their timers finish.
-/// This system is responsible for cleaning up entities that have exceeded their allotted time for an operation.
+/// Ticks `Timeout` timers and cleans up entities whose allotted time has elapsed.
+///
+/// A fresh application has already registered its accessibility observer, so its timeout only
+/// stops initial window polling. Other timed entities retain the usual despawn behavior.
 ///
 /// # Arguments
 ///
-/// * `timers` - A `Populated` query for `(Entity, &mut Timeout)` components.
+/// * `timers` - Timed entities and a marker identifying applications.
 /// * `clock` - The Bevy `Time` resource for getting the delta time.
-/// * `commands` - Bevy commands to despawn entities.
+/// * `commands` - Bevy commands used to clean up expired entities.
 pub(super) fn timeout_ticker(
-    timers: Populated<(Entity, &mut Timeout)>,
+    timers: Populated<(Entity, &mut Timeout, Has<Application>)>,
     clock: Res<Time>,
     mut commands: Commands,
 ) {
-    for (entity, mut timeout) in timers {
+    for (entity, mut timeout, application) in timers {
         if timeout.timer.is_finished() {
-            trace!("Despawning entity {entity} due to timeout.");
             if let Some(system_id) = timeout.system_id.take() {
                 commands.run_system(system_id);
                 commands.unregister_system(system_id);
             }
-            trace!("Removing timer {entity}");
             if let Ok(mut entity_commands) = commands.get_entity(entity) {
-                entity_commands.try_despawn();
+                if application {
+                    trace!("Stopping initial window polling for application {entity}");
+                    entity_commands.try_remove::<(FreshMarker, Timeout)>();
+                } else {
+                    trace!("Despawning entity {entity} due to timeout");
+                    entity_commands.try_despawn();
+                }
             }
         } else {
             timeout.timer.tick(clock.delta());
@@ -1357,6 +1363,74 @@ pub(crate) fn detect_tabbed_windows(
                 commands.focus_entity(entity, false);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod timeout_tests {
+    use std::time::Duration;
+
+    use bevy::prelude::*;
+
+    use super::timeout_ticker;
+    use crate::ecs::{FreshMarker, Timeout};
+    use crate::manager::{Application, app::MockApplicationApi};
+
+    fn expired_timeout() -> Timeout {
+        let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
+        timer.tick(Duration::from_secs(1));
+        Timeout {
+            timer,
+            system_id: None,
+        }
+    }
+
+    #[test]
+    fn application_timeout_stops_polling_without_despawning() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, timeout_ticker);
+
+        let process = app.world_mut().spawn_empty().id();
+        let application = app
+            .world_mut()
+            .spawn((
+                Application::new(Box::new(MockApplicationApi::new())),
+                FreshMarker,
+                expired_timeout(),
+                ChildOf(process),
+            ))
+            .id();
+        let application_pending_timeout_cleanup = app
+            .world_mut()
+            .spawn((
+                Application::new(Box::new(MockApplicationApi::new())),
+                expired_timeout(),
+                ChildOf(process),
+            ))
+            .id();
+        let ordinary_timeout = app.world_mut().spawn(expired_timeout()).id();
+
+        app.update();
+
+        for application in [application, application_pending_timeout_cleanup] {
+            let application = app
+                .world()
+                .get_entity(application)
+                .expect("application should retain its accessibility observer entity");
+            assert!(application.contains::<Application>());
+            assert!(!application.contains::<FreshMarker>());
+            assert!(!application.contains::<Timeout>());
+        }
+        assert!(app.world().get_entity(ordinary_timeout).is_err());
+
+        app.world_mut().entity_mut(process).despawn();
+        assert!(app.world().get_entity(application).is_err());
+        assert!(
+            app.world()
+                .get_entity(application_pending_timeout_cleanup)
+                .is_err()
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #362.

## Problem

When a newly observed application does not expose an accepted window before the discovery timeout, `timeout_ticker` currently despawns its `Application` entity.

Paneru has already installed the application's accessibility observer at that point. Despawning the entity drops the observer, so windows created later are invisible to Paneru until it is restarted.

## Change

Treat the application timeout as the end of initial window polling:

- remove `FreshMarker` and `Timeout`
- retain the `Application` and its accessibility observer
- preserve the existing despawn behavior for non-application timeouts

This also handles the deferred-command state where `FreshMarker` has already been removed but the expired `Timeout` remains until the next update. The existing five-second discovery deadline remains unchanged.

Polling stops when `FreshMarker` is removed. The retained application and observer are still removed with their parent process when the application terminates.

## Testing

Reproduced on macOS 27 using a regular AppKit application that became observable immediately but created its first standard window after 12 seconds. The unpatched installed Paneru did not discover the late window.

The regression test covers:

- an application timing out with `FreshMarker`
- an application with an expired timeout after marker cleanup
- unchanged despawning of ordinary timed entities
- removal of retained applications when their parent process terminates

Validation on macOS:

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test application_timeout_stops_polling_without_despawning`
- `cargo test -- --skip config::test_config_defaults` — 199 passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release --verbose`

`config::test_config_defaults` is skipped because its macOS-version expectation does not account for macOS 27; this is unrelated to the observer change.
