### PR TITLE
fix: stop Accessibility stalls from disabling the keyboard event tap

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -582,6 +582,8 @@ pub(crate) fn rewatch_configs(
 }
 
 pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<BevyApp> {
+    crate::manager::app::bound_ax_messaging_timeout()?;
+
     let window_manager: Box<dyn WindowManagerApi> = Box::new(WindowManagerOS::new(sender.clone()));
 
     // Discover (or create) the Lua init script first: whether it exists decides

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -11,8 +11,9 @@ use bevy::math::IRect;
 use bevy::tasks::AsyncComputeTaskPool;
 use bevy::tasks::futures_lite::future;
 use bevy::time::Time;
+use objc2_core_foundation::CFRetained;
 use objc2_foundation::NSPoint;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::pin::Pin;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, TryRecvError};
 use std::time::{Duration, Instant};
@@ -38,6 +39,7 @@ use crate::manager::{
 };
 use crate::overlay::{FlashMessageManager, OverlayManager};
 use crate::platform::{PlatformCallbacks, WinID};
+use crate::util::AXUIWrapper;
 
 /// Processes and applications still inside their spawn grace period, with the
 /// `FreshMarker` that says whether the spawn actually completed in time.
@@ -96,6 +98,17 @@ const LOOP_TIMEOUT_STEP: u32 = 1;
 /// leftover events stay in the channel for the next frame to pick up.
 const PUMP_BUDGET: Duration = Duration::from_millis(4);
 const PUMP_MAX_EVENTS: usize = 256;
+
+/// How long [`window_creation_event`] may spend building windows before it has
+/// to hand the frame back.
+///
+/// Building one reads Accessibility attributes, and each read blocks on a round
+/// trip into the owning app. The system runs on a worker the main thread parks
+/// on, and a parked main thread stops servicing the `CFRunLoop`, so a burst
+/// drained in one go starves the `CGEventTap` callback until macOS switches the
+/// tap off. Nothing is dropped when the budget is hit: the remainder waits in a
+/// queue for the next frame.
+const WINDOW_CREATION_BUDGET: Duration = Duration::from_millis(200);
 
 /// Gathers all present displays and spawns them as entities in the Bevy world.
 /// The currently active display (identified by `window_manager.active_display_id()`) is marked with `ActiveDisplayMarker`.
@@ -1247,19 +1260,29 @@ pub(crate) fn update_low_power_state(low_power_mode: Option<ResMut<LowPowerMode>
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
-pub(crate) fn window_creation_event(mut messages: MessageReader<Event>, mut commands: Commands) {
-    for event in messages.read() {
-        let Event::WindowCreated { element } = event else {
-            continue;
-        };
+pub(crate) fn window_creation_event(
+    mut messages: MessageReader<Event>,
+    mut commands: Commands,
+    mut pending: Local<VecDeque<CFRetained<AXUIWrapper>>>,
+) {
+    pending.extend(messages.read().filter_map(|event| match event {
+        Event::WindowCreated { element } => Some(element.clone()),
+        _ => None,
+    }));
 
-        if let Ok(window) = WindowOS::new(element)
+    let started = Instant::now();
+    while let Some(element) = pending.pop_front() {
+        if let Ok(window) = WindowOS::new(&element)
             .inspect_err(|err| {
                 trace!("not adding window {element:?}: {err}");
             })
             .map(|window| Window::new(Box::new(window)))
         {
             commands.trigger(SpawnWindowTrigger(vec![window]));
+        }
+
+        if started.elapsed() >= WINDOW_CREATION_BUDGET {
+            break;
         }
     }
 }

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -10,7 +10,9 @@ use objc2_core_foundation::{CFRetained, CFString, kCFRunLoopCommonModes};
 use std::ffi::c_void;
 use std::pin::Pin;
 use std::ptr::null_mut;
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::mpsc::{Sender, channel};
+use std::sync::{Arc, LazyLock, Mutex, PoisonError, RwLock};
+use std::thread;
 use stdext::sync::rw_lock::RwLockExt;
 
 use stdext::function_name;
@@ -376,6 +378,74 @@ enum ObserverType {
 
 /// `ObserverContext` holds the `EventSender` and the `ObserverType`,
 /// which are used within the `AXObserver` callback to dispatch accessibility events.
+/// An application notification whose window is not named yet.
+#[derive(Clone, Copy, Debug)]
+enum WindowNotification {
+    Focused,
+    Moved,
+    Resized,
+    MenuOpened,
+    MenuClosed,
+}
+
+impl WindowNotification {
+    fn from_name(notification: &str) -> Option<Self> {
+        match notification {
+            accessibility_sys::kAXFocusedWindowChangedNotification
+            | accessibility_sys::kAXFocusedUIElementChangedNotification => Some(Self::Focused),
+            accessibility_sys::kAXWindowMovedNotification => Some(Self::Moved),
+            accessibility_sys::kAXWindowResizedNotification => Some(Self::Resized),
+            accessibility_sys::kAXMenuOpenedNotification => Some(Self::MenuOpened),
+            accessibility_sys::kAXMenuClosedNotification => Some(Self::MenuClosed),
+            _ => None,
+        }
+    }
+
+    fn into_event(self, window_id: WinID) -> Event {
+        match self {
+            Self::Focused => Event::WindowFocused { window_id },
+            Self::Moved => Event::WindowMoved { window_id },
+            Self::Resized => Event::WindowResized { window_id },
+            Self::MenuOpened => Event::MenuOpened { window_id },
+            Self::MenuClosed => Event::MenuClosed { window_id },
+        }
+    }
+}
+
+struct PendingNotification {
+    kind: WindowNotification,
+    element: CFRetained<AXUIWrapper>,
+    events: EventSender,
+}
+
+/// Names the window behind each pending notification, off the run loop and in
+/// arrival order.
+///
+/// `_AXUIElementGetWindow` blocks on a round trip into the app that sent the
+/// notification. Called straight from the observer callback it holds the run
+/// loop, and the `CGEventTap` callback shares that run loop, so a slow app turns
+/// every lookup into keystroke latency.
+///
+/// One thread rather than a task pool: two focus notifications resolving out of
+/// order would leave paneru chasing the wrong window.
+static RESOLVER: LazyLock<Mutex<Sender<PendingNotification>>> = LazyLock::new(|| {
+    let (tx, rx) = channel::<PendingNotification>();
+    thread::Builder::new()
+        .name("ax-window-resolver".into())
+        .spawn(move || {
+            for pending in rx {
+                match ax_window_id(pending.element.as_ptr()) {
+                    Ok(window_id) => {
+                        _ = pending.events.send(pending.kind.into_event(window_id));
+                    }
+                    Err(err) => debug!("naming window for {:?}: {err}", pending.kind),
+                }
+            }
+        })
+        .expect("spawning the AX window resolver should succeed");
+    Mutex::new(tx)
+});
+
 struct ObserverContext {
     events: EventSender,
     which: ObserverType,
@@ -416,26 +486,24 @@ impl ObserverContext {
             return;
         }
 
-        let Ok(window_id) =
-            ax_window_id(element).inspect_err(|err| debug!("notification {notification}: {err}"))
-        else {
+        let Some(kind) = WindowNotification::from_name(notification) else {
+            error!("unhandled application notification: {notification:?}");
             return;
         };
-        let event = match notification {
-            accessibility_sys::kAXFocusedWindowChangedNotification
-            | accessibility_sys::kAXFocusedUIElementChangedNotification => {
-                Event::WindowFocused { window_id }
-            }
-            accessibility_sys::kAXWindowMovedNotification => Event::WindowMoved { window_id },
-            accessibility_sys::kAXWindowResizedNotification => Event::WindowResized { window_id },
-            accessibility_sys::kAXMenuOpenedNotification => Event::MenuOpened { window_id },
-            accessibility_sys::kAXMenuClosedNotification => Event::MenuClosed { window_id },
-            _ => {
-                error!("unhandled application notification: {notification:?}");
-                return;
-            }
+        let Ok(element) = AXUIWrapper::retain(element).inspect_err(|err| {
+            error!("invalid element {element:?}: {err}");
+        }) else {
+            return;
         };
-        _ = self.events.send(event);
+
+        _ = RESOLVER
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .send(PendingNotification {
+                kind,
+                element,
+                events: self.events.clone(),
+            });
     }
 
     /// Notifies the event sender about a window-level accessibility event.

--- a/src/manager/app.rs
+++ b/src/manager/app.rs
@@ -1,6 +1,6 @@
 use accessibility_sys::{
-    AXObserverRef, AXUIElementCreateApplication, AXUIElementRef, AXUIElementSetMessagingTimeout,
-    kAXErrorSuccess,
+    AXObserverRef, AXUIElementCreateApplication, AXUIElementCreateSystemWide, AXUIElementRef,
+    AXUIElementSetMessagingTimeout, kAXErrorSuccess,
 };
 use bevy::ecs::component::Component;
 use core::ptr::NonNull;
@@ -31,6 +31,21 @@ use crate::util::{AXUIAttributes, AXUIWrapper, MacResult, add_run_loop, remove_r
 /// element before giving up. See [`ApplicationOS::new`] for why this is set at
 /// all; the default is six seconds.
 const AX_MESSAGING_TIMEOUT_SEC: f32 = 0.25;
+
+/// Applies [`AX_MESSAGING_TIMEOUT_SEC`] to the process rather than to one
+/// element, and must run before any application is observed.
+///
+/// The call in [`ApplicationOS::new`] binds the element it is given. Per Apple's
+/// `AXUIElement.h` the system-wide element is the one that carries a
+/// process-global default, and an element left at zero "uses the current global
+/// timeout value". Window elements arrive from `AXUIElementCopyAttributeValue`
+/// and are never handed to `AXUIElementSetMessagingTimeout`, so without this
+/// they wait out the six second default instead.
+pub(crate) fn bound_ax_messaging_timeout() -> Result<()> {
+    let system_wide = AXUIWrapper::from_retained(unsafe { AXUIElementCreateSystemWide() })?;
+    unsafe { AXUIElementSetMessagingTimeout(system_wide.as_ptr(), AX_MESSAGING_TIMEOUT_SEC) }
+        .to_result(function_name!())
+}
 
 /// A static `LazyLock` that holds a list of `AXNotification` strings to be observed for application-level events.
 /// These notifications are general events related to an application's lifecycle and state changes,
@@ -192,10 +207,10 @@ impl ApplicationOS {
             let ptr = AXUIElementCreateApplication(process.pid());
             // Without this, a synchronous AX call to an app that stops servicing
             // its accessibility port (beachballing, paused in a debugger) blocks
-            // the main thread for the default six-second timeout, per call. Set
-            // on the application element so it covers every element obtained
-            // through it, windows included; a call that trips it fails with
-            // `kAXErrorCannotComplete`, treated like any other AX error.
+            // the main thread for the default six-second timeout, per call. This
+            // binds the application element; `bound_ax_messaging_timeout` covers
+            // the window elements copied out of it. A call that trips either one
+            // fails with `kAXErrorCannotComplete`, treated like any other AX error.
             AXUIElementSetMessagingTimeout(ptr, AX_MESSAGING_TIMEOUT_SEC);
             AXUIWrapper::retain(ptr)?
         };

--- a/src/manager/windows.rs
+++ b/src/manager/windows.rs
@@ -232,30 +232,27 @@ impl WindowOS {
 
         let forced = window.is_forced_manage(config, bundle_id);
 
-        if window.is_unknown() && !forced {
+        // Unlike the title above, role and subrole are not cached, so every read
+        // is another blocking round trip into an app that may already be wedged.
+        // Read each once and reach for the role only while it can still change
+        // the verdict.
+        let subrole = window.subrole().unwrap_or_default();
+        if subrole == kAXUnknownSubrole && !forced {
             return Err(Error::invalid_window(&format!(
-                "Ignoring AXUnknown window, id: {}, role {}, subrole {}",
-                window.id(),
-                window.role().unwrap_or_default(),
-                window.subrole().unwrap_or_default(),
+                "Ignoring AXUnknown window, id: {id}, subrole {subrole}"
             )));
         }
 
-        if !window.is_real() && !forced {
+        let role = window.role().unwrap_or_default();
+        if !Self::is_real(&role, &subrole) && !forced {
             return Err(Error::invalid_window(&format!(
-                "Ignoring non-real window, id: {}, role {}, subrole {}",
-                window.id(),
-                window.role().unwrap_or_default(),
-                window.subrole().unwrap_or_default(),
+                "Ignoring non-real window, id: {id}, role {role}, subrole {subrole}"
             )));
         }
 
         trace!(
-            "created {} title: {} role: {} subrole: {}",
-            window.id(),
+            "created {id} title: {} role: {role} subrole: {subrole}",
             window.title().unwrap_or_default(),
-            window.role().unwrap_or_default(),
-            window.subrole().unwrap_or_default(),
         );
         Ok(window)
     }
@@ -272,29 +269,15 @@ impl WindowOS {
             .any(|params| params.manage.is_some_and(|manage| manage))
     }
 
-    /// Checks if the window's subrole is "`AXUnknownSubrole`".
-    ///
-    /// # Returns
-    ///
-    /// `true` if the subrole is unknown, `false` otherwise.
-    fn is_unknown(&self) -> bool {
-        self.subrole()
-            .is_ok_and(|subrole| subrole.eq(kAXUnknownSubrole))
-    }
-
     /// Checks if the window is a "real" window based on its role and subrole.
     /// It considers standard and floating window subroles as real.
     ///
     /// # Returns
     ///
     /// `true` if the window is real, `false` otherwise.
-    fn is_real(&self) -> bool {
-        let role = self.role().ok();
-        let subrole = self.subrole().ok();
-
-        subrole.as_deref() == Some(kAXStandardWindowSubrole)
-            || (role.as_deref() == Some(kAXWindowRole)
-                && subrole.as_deref() == Some(kAXFloatingWindowSubrole))
+    fn is_real(role: &str, subrole: &str) -> bool {
+        subrole == kAXStandardWindowSubrole
+            || (role == kAXWindowRole && subrole == kAXFloatingWindowSubrole)
     }
 
     fn app_reference(&self) -> Option<CFRetained<AXUIWrapper>> {


### PR DESCRIPTION
## Summary

Hotkeys intermittently stop reaching paneru and land in the focused app instead, and typing feels laggy in between. It reads as a misbehaving keyboard rather than a window manager fault, which is what makes it hard to attribute.

Both symptoms come from the same place. Accessibility getters are synchronous Mach round trips into the target app. paneru makes them on the main run loop, and the `CGEventTap` callback runs on that same run loop. While a call is outstanding the tap cannot fire, so keystrokes are delayed. Hold the run loop long enough and macOS switches the tap off entirely, at which point hotkeys pass through to the focused app until paneru re-arms it.

Three commits, smallest to largest in effect.

## 1. Bound the timeout for window elements too

`ApplicationOS::new` already sets `AXUIElementSetMessagingTimeout` on the application element, with a comment saying that covers every element obtained through it.

`AXUIElement.h` does not document that inheritance. It describes the system-wide element as the object carrying a process-global default, and says an element left at zero "uses the current global timeout value". Window elements are copied out with `AXUIElementCopyAttributeValue` and are never passed to `AXUIElementSetMessagingTimeout`, so on that reading they wait out the six second default rather than the intended 0.25s. Every window attribute read is one of those: role, subrole, title, and the frame reads on the layout path.

This sets the same constant on the system-wide element once at startup. The per-application call is left alone; I did edit the comment beside it, since it now describes only half the picture.

**I have not proven the inheritance question empirically**, only that the documentation does not promise it. If you know the app-element timeout does propagate to copied children, this commit is unnecessary and the other two stand on their own.

## 2. Stop re-reading role and subrole

`is_unknown()` and `is_real()` each fetched both attributes, then the rejection messages fetched them again to build a string the caller only logs at `trace!`. `is_real` now takes the values it already has. A rejected window costs 4 round trips instead of 7.

`window_creation_event` also drained every pending `WindowCreated` in one frame. It now queues them and spends at most 200ms per frame, following the `PUMP_BUDGET` pattern already in that file. Queuing rather than leaving messages unread means nothing is lost if the buffer rotates, and one window always completes per frame so a slow app cannot stall progress.

## 3. Name windows off the run loop

This is the one that mattered most.

`notify_app` called `ax_window_id` to turn a notification's element into a window id. That is `_AXUIElementGetWindow`, a blocking round trip back into the app that just sent the notification, made from the observer callback on the main run loop.

It now retains the element and queues it for a resolver thread, which names the window and forwards the finished event. One thread rather than a task pool, because two focus notifications resolving out of order would leave paneru chasing the wrong window.

## Measurements

Taken on a downstream tree carrying these changes plus local stall instrumentation, on one machine.

Time the main thread spent blocked inside the AX notification callback, from a 60 second `sample`:

| | Blocked per 60s |
|---|---|
| Before | 2.32 s |
| After commit 3 | 0.00 s |

The second figure is structural rather than tuning: the callback no longer appears on the main thread at all.

Stalls over 750ms and tap disables, comparing an active working session before commits 2 and 3 against one after:

| | Before | After |
|---|---|---|
| Window | 33.5 min | 12 h 52 min |
| Stalls | 74 | 29 |
| Tap disables | 14 | 1 |
| Worst stall | 5039 ms | 979 ms |

All 29 remaining stalls fell in the first two hours of active use, and none since, including a morning that produced 18 `kAXErrorCannotComplete` timeouts with no stall and no tap disable. Timeouts without stalls is the intended shape: the cap fails a lookup fast instead of holding the loop.

The instrumentation that produced the stall counts is local and deliberately not part of this PR. It measures the gap between consecutive `pump_events` calls, and it is worth knowing that it cannot see blocking *inside* the pump, which is exactly where commit 3's problem lived.

## Not fixed here

The main thread still parks on Bevy workers doing Accessibility work in `update_passthrough`, `focused_window_id` and window creation. That is what the remaining sub-second stalls are. They sit under the roughly one second the tap tolerates, so they rarely disable it, but the right fix is the same move as commit 3 applied to the layout and focus paths. That is a larger change and belongs on its own.

Upstream `new_with_config` also calls `is_forced_manage` eagerly, which reads the title even for windows it is about to accept. Making that lazy would remove another round trip from the common path, but it reorders the rule lookup so I left it out.

## Test plan

`cargo clippy --all-targets` and `cargo fmt --check` are clean. `cargo test` gives 197 passed and 1 failure, `config::test_config_defaults`, which fails identically on `main` before these commits.
