### PR TITLE
fix: don't send window to next display after a vertical swap

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -606,7 +606,8 @@ fn command_swap_focus(
     // stays put and per-window animation slides the window into the slot.
     // Only when the slot would fall off the edge does the strip scroll —
     // and only by the shortfall.
-    if let Some(window) = handler() {
+    let swapped = handler();
+    if let Some(window) = swapped {
         commands.ensure_visible(window);
     } else {
         debug!(
@@ -616,11 +617,12 @@ fn command_swap_focus(
         );
     }
 
-    if windows
-        .focused()
-        .and_then(|(_, current)| get_window_in_direction(direction, current, active_strip))
-        .is_none()
-    {
+    // Only fall through to the neighbouring display when there was nothing to
+    // swap with in the first place. Re-querying the strip here would look at
+    // the layout *after* the swap, where the window has by definition no
+    // neighbour left in that direction - which sent every successful vertical
+    // swap straight on to the other display.
+    if swapped.is_none() {
         // Check if the movement can swap to another display.
         let bounds = active_display.bounds();
         let Some(other_display) = active_display.other().next() else {

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bevy::prelude::*;
 use bevy::time::TimeUpdateStrategy;
 
-use crate::commands::{Command, MouseMove, MoveFocus, Operation};
+use crate::commands::{Command, Direction, MouseMove, MoveFocus, Operation};
 use crate::config::Config;
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::{ActiveWorkspaceMarker, DockPosition, RefreshWindowSizes, Timeout};
@@ -473,6 +473,67 @@ fn test_wake_refreshes_active_workspace() {
             assert!(
                 refreshed,
                 "wake should mark the active workspace for a window-size refresh"
+            );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_vertical_swap_within_stack_stays_on_display() {
+    // Regression test: with a display arranged *below* the active one, a
+    // `Swap(South)` inside a stack used to swap the two windows and then
+    // immediately send the focused one to the display below, because the
+    // "is there anything left to swap with?" check ran against the layout
+    // after the swap had already happened.
+    let mut harness = TestHarness::new().with_windows(2);
+    harness.mock_state.add_display(
+        EXT_DISPLAY_ID,
+        IRect::new(
+            0,
+            TEST_DISPLAY_HEIGHT,
+            EXT_DISPLAY_WIDTH,
+            TEST_DISPLAY_HEIGHT + EXT_DISPLAY_HEIGHT,
+        ),
+        vec![EXT_WORKSPACE_ID],
+    );
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::Last)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Stack(true)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::North)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::Swap(Direction::South)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    harness
+        .on_iteration(4, |world, state| {
+            assert_on_workspace!(world, 0, TEST_WORKSPACE_ID);
+            assert_on_workspace!(world, 1, TEST_WORKSPACE_ID);
+            assert_eq!(state.active_display(), TEST_DISPLAY_ID);
+        })
+        .on_iteration(6, |world, state| {
+            assert_on_workspace!(world, 0, TEST_WORKSPACE_ID);
+            assert_on_workspace!(world, 1, TEST_WORKSPACE_ID);
+            assert_not_on_workspace!(world, 0, EXT_WORKSPACE_ID);
+            assert_not_on_workspace!(world, 1, EXT_WORKSPACE_ID);
+            assert_eq!(
+                state.active_display(),
+                TEST_DISPLAY_ID,
+                "swapping inside a stack must not move focus to another display"
             );
         })
         .run(commands);


### PR DESCRIPTION
Hi.

first of all, thanks for this great tool!

Found a bug when using it with 2 displays and got claude to debug and prepare a PR (since Rust is not my thing).
Here it is:



### The problem

With a second display arranged **above or below** the active one — the arrangement the README recommends for multi-display setups — `window swap north` / `window swap south` inside a stack swaps the two windows *and then immediately throws the focused window onto the other display*.

### Reproduce

1. Two displays stacked vertically.
2. On the active display, put two windows into a single column stack (`window stack`).
3. Focus the top window.
4. `paneru send-cmd window swap south` (or the bound hotkey).

### Behaviour

**Before:** the two windows swap correctly, then the focused window is moved to the display below and focus follows it. The stack you were trying to reorder is now split across two displays. Same thing happens with `swap north` when a display sits above.

**After:** the two windows swap and both stay put. The display fall-through still works when it should — i.e. when there genuinely was no window to swap with in that direction.

### Cause

`command_swap_focus` performs the swap and then re-queries the strip to decide whether to fall through to `ToNextDisplay`. That second lookup runs against the layout *after* the swap. Once the focused window has been swapped to the far end of the stack it has, by definition, no neighbour left in that direction — so the check reports "nothing to swap with" on exactly the swaps that just succeeded.

### Fix

Reuse the handler's own result rather than re-deriving it from the mutated layout. It already returns `None` precisely when there was nothing to swap with, which is the condition the fall-through wants. Horizontal swaps are unaffected.

### Tests

Adds a regression test covering a vertical swap inside a stack with a second display registered below the active one. It fails on `main` and passes with the fix.

`cargo test` — 200 passed, `cargo fmt --check` and `cargo clippy --all-targets` clean.
