### PR TITLE
feat: resize stacked windows vertically through preset heights

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -27,13 +27,14 @@ General behavior settings for the window manager.
 | `horizontal_mouse_warp` | Integer ``(-1, 1)`` | Off | If enabled, the mouse will warp to another screen above or below, when touching the left or right edge. The direction depends on the direction - a negative value will cause the left edge to warp to a screen above and the right edge to a screen below. This allows having horizontal positioning of displays while having them aligned in a virtual layout in macOS settings. The cursor lands at the *opposite* edge of the target display (preserving cursor flow), with the source's relative Y position. Carries pre-warp horizontal velocity to avoid a "standing start", and skips the warp when the equivalent Y has no position on the target — matching macOS's native side-by-side behavior for displays of unequal height. (inspired by https://github.com/mogenson/WarpMouse.spoon) |
 | `horizontal_mouse_warp_offset` | Integer (px) | `0` | Vertical pixel offset applied to the `horizontal_mouse_warp` landing position, signed by warp direction. Positive values shift the cursor lower when warping to a display *below* (in macOS arrangement) and higher when warping to one *above*. Use to compensate for physical desk arrangement differing from the macOS arrangement (e.g. portrait monitor sitting physically higher or lower than the laptop). |
 | `preset_column_widths` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75, 1.0, 1.5, 2.0]` | Ratios of the screen width used by the `window_resize` command and the menu bar width picker. Values above `1.0` create a horizontally scrollable oversized window. |
+| `preset_stack_heights` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75]` | Ratios of the viewport height used by the `window_vertical_resize` command. Only applies to windows inside a stack; every window in the column is kept at least 200px tall, so a ratio that would starve a neighbour is clamped. |
 | `animation_speed` | Float | *None* | Speed of window animations. Comfortable range is from 8 to 20. Unset or set to a very high value to effectively disable animations. |
 | `auto_center` | Boolean | `false` | Automatically center the focused window on the screen when switching focus. |
 | `sliver_height` | Float (0.1–1.0) | `1.0` | Vertical ratio of off-screen windows kept visible to prevent macOS from relocating them. |
 | `sliver_width` | Integer (px) | `5` | Horizontal width of off-screen windows kept visible. |
 | `menubar_height` | Integer (px) | *Auto* | Manually override the detected macOS menubar height. |
 | `window_hidden_ratio` | Float (0.0–1.0) | `0.0` | How much of a window can be hidden before it's forced into view on focus change. `0.0` = eager, `1.0` = lazy. |
-| `window_resize_cycle` | Boolean | `true` | If disabled, `window_resize` and `window_shrink` stop at the largest/smallest preset instead of cycling back. |
+| `window_resize_cycle` | Boolean | `true` | If disabled, `window_resize` and `window_shrink` (and their `window_vertical_*` counterparts) stop at the largest/smallest preset instead of cycling back. |
 | `mouse_resize_modifier` | String | *None* | If enabled allows window resizing using mouse movement. For example `cmd + shift` will allow resizing of the window when holding those keys. Proximity of the pointer to left or right window edge determines which side will be adjusted. |
 | `reap_empty_workspaces` | String | `false` | If enabled, a virtual workspace without any windows will be removed. |
 | `disable_native_tabs` | Boolean | `false` | If enabled, Paneru will not auto-merge a newly-spawned window into a tab group with an existing same-app sibling that shares its frame. Use this if you find unrelated windows being grouped together. |
@@ -152,6 +153,9 @@ https://github.com/karinushka/paneru/blob/3790b01f8d65df5d9000142db7cf25f9270dcc
 | `window_resize` | Cycle through preset widths (Grow). |
 | `window_grow` | Alias for `window_resize`. |
 | `window_shrink` | Cycle through preset widths (Shrink). |
+| `window_vertical_resize` | Cycle a stacked window through preset heights (Grow). No-op outside a stack. |
+| `window_vertical_grow` | Alias for `window_vertical_resize`. |
+| `window_vertical_shrink` | Cycle a stacked window through preset heights (Shrink). |
 | `window_fullwidth` | Toggle full-width mode. |
 | `window_manage` | Toggle between tiled and floating state. |
 | `window_stack` | Stack the current window into the column on the left. |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ $ paneru send-cmd <command> [args...]
 | `window resize`            | Cycle through `preset_column_widths`             |
 | `window grow`              | Grow to the next preset width                    |
 | `window shrink`            | Shrink to the previous preset width              |
+| `window vertical resize`   | Cycle a stacked window through `preset_stack_heights` |
+| `window vertical grow`     | Grow a stacked window to the next preset height  |
+| `window vertical shrink`   | Shrink a stacked window to the previous preset height |
 | `window fullwidth`         | Toggle full-width mode for the focused window    |
 | `window manage`            | Toggle managed/floating state                    |
 | `window equalize`          | Distribute equal heights in the focused stack    |
@@ -297,6 +300,9 @@ $ paneru send-cmd window balance
 
 # Cycle backward through preset widths.
 $ paneru send-cmd window shrink
+
+# Grow the focused window's height inside its stack.
+$ paneru send-cmd window vertical grow
 
 # Jump to the left-most window.
 $ paneru send-cmd window focus first

--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -41,6 +41,7 @@ paneru.setup {
     focus_follows_mouse = true,
     sliver_width = 5,
     animation_speed = 12.0,   -- write floats with a decimal point
+    preset_stack_heights = { 0.25, 0.5, 0.75 },
   },
   padding = { top = 10, bottom = 10, left = 8, right = 8 },
   swipe = { sensitivity = 0.4, scroll = { modifier = "alt" } },

--- a/crates/lua/src/lib.rs
+++ b/crates/lua/src/lib.rs
@@ -170,6 +170,7 @@ fn window_table(lua: &Lua, dispatch: &Dispatch) -> Result<Table> {
         directional(lua, dispatch, "window.swap", Operation::Swap)?,
     )?;
     window.set("resize", resize(lua, dispatch)?)?;
+    window.set("vertical_resize", vertical_resize(lua, dispatch)?)?;
     window.set(
         "next_display",
         follower(lua, dispatch, Operation::ToNextDisplay)?,
@@ -188,6 +189,14 @@ fn window_table(lua: &Lua, dispatch: &Dispatch) -> Result<Table> {
         ("full_width", Operation::FullWidth),
         ("grow", Operation::Resize(ResizeDirection::Grow)),
         ("shrink", Operation::Resize(ResizeDirection::Shrink)),
+        (
+            "vertical_grow",
+            Operation::ResizeVertical(ResizeDirection::Grow),
+        ),
+        (
+            "vertical_shrink",
+            Operation::ResizeVertical(ResizeDirection::Shrink),
+        ),
         ("raise_floating", Operation::RaiseFloating),
         ("toggle_float_layer", Operation::ToggleFloatingLayer),
     ] {
@@ -292,6 +301,16 @@ fn resize(lua: &Lua, dispatch: &Dispatch) -> Result<Function> {
     lua.create_function(move |lua, opts: Value| {
         let direction = ResizeOpts::read(lua, &opts)?;
         dispatch(lua, Command::Window(Operation::Resize(direction)))
+    })
+}
+
+/// `paneru.window.vertical_resize{ direction = "grow" }`, the height sibling of
+/// [`resize`], also defaulting to growing.
+fn vertical_resize(lua: &Lua, dispatch: &Dispatch) -> Result<Function> {
+    let dispatch = Rc::clone(dispatch);
+    lua.create_function(move |lua, opts: Value| {
+        let direction = ResizeOpts::read(lua, &opts)?;
+        dispatch(lua, Command::Window(Operation::ResizeVertical(direction)))
     })
 }
 
@@ -486,22 +505,27 @@ mod tests {
         assert!(run(r#"paneru.window.focus({ direction = "sideways" })"#).is_err());
         assert!(run("paneru.window.focus({})").is_err());
         assert!(run(r#"paneru.window.resize({ direction = "wider" })"#).is_err());
+        assert!(run(r#"paneru.window.vertical_resize({ direction = "taller" })"#).is_err());
         assert!(run(r#"paneru.run("not a command")"#).is_err());
     }
 
     #[test]
     fn defaults_match_the_documented_behaviour() {
-        let commands = run(r"
+        let commands = run(r#"
             paneru.window.resize()
+            paneru.window.vertical_resize()
+            paneru.window.vertical_resize("shrink")
             paneru.window.next_display()
             paneru.window.next_display({ follow = false })
-        ")
+        "#)
         .unwrap();
 
         assert_eq!(
             debug(&commands),
             debug(&[
                 Command::Window(Operation::Resize(ResizeDirection::Grow)),
+                Command::Window(Operation::ResizeVertical(ResizeDirection::Grow)),
+                Command::Window(Operation::ResizeVertical(ResizeDirection::Shrink)),
                 Command::Window(Operation::ToNextDisplay(MoveFocus::Follow)),
                 Command::Window(Operation::ToNextDisplay(MoveFocus::Stay)),
             ])

--- a/crates/shared_types/src/argv.rs
+++ b/crates/shared_types/src/argv.rs
@@ -79,6 +79,14 @@ fn parse_operation(argv: &[&str]) -> Result<Operation> {
         ),
         "grow" => Operation::Resize(ResizeDirection::Grow),
         "shrink" => Operation::Resize(ResizeDirection::Shrink),
+        // `window_vertical_resize` / `_grow` / `_shrink`, plus the explicit
+        // `window_vertical_resize_shrink` mirroring `window_resize_shrink`.
+        "vertical" => Operation::ResizeVertical(match argv.get(1).copied() {
+            None | Some("resize") => argv
+                .get(2)
+                .map_or(Ok(ResizeDirection::Grow), |arg| ResizeDirection::parse(arg))?,
+            Some(arg) => ResizeDirection::parse(arg)?,
+        }),
         "fullwidth" => Operation::FullWidth,
         "manage" => Operation::Manage,
         "equalize" => Operation::Equalize,
@@ -170,6 +178,9 @@ impl Operation {
             Operation::Swap(direction) => vec!["swap".to_string(), direction.token()],
             Operation::Center => owned(&["center"]),
             Operation::Resize(direction) => owned(&["resize", direction.token()]),
+            Operation::ResizeVertical(direction) => {
+                owned(&["vertical", "resize", direction.token()])
+            }
             // `SetWidth` comes from window rules, not from a command line; it has
             // no argv verb, so encode it as the equivalent full-width toggle.
             Operation::SetWidth(_) | Operation::FullWidth => owned(&["fullwidth"]),
@@ -224,6 +235,8 @@ mod tests {
             Operation::Swap(Direction::West),
             Operation::Center,
             Operation::Resize(ResizeDirection::Shrink),
+            Operation::ResizeVertical(ResizeDirection::Grow),
+            Operation::ResizeVertical(ResizeDirection::Shrink),
             Operation::FullWidth,
             Operation::ToNextDisplay(MoveFocus::Follow),
             Operation::ToNextDisplay(MoveFocus::Stay),

--- a/crates/shared_types/src/commands.rs
+++ b/crates/shared_types/src/commands.rs
@@ -149,7 +149,7 @@ impl<'de> Deserialize<'de> for Direction {
     }
 }
 
-/// Direction used when cycling preset resize widths.
+/// Direction used when cycling preset resize widths and heights.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResizeDirection {
@@ -225,6 +225,9 @@ pub enum Operation {
     Center,
     /// Resizes the focused window in the given direction.
     Resize(ResizeDirection),
+    /// Cycles the focused window's height through the preset stack heights.
+    /// Only applies to windows inside a stack.
+    ResizeVertical(ResizeDirection),
     /// Resizes the focused window to an exact display-width ratio.
     SetWidth(f64),
     /// Toggles the focused window to full width or a preset width.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,9 @@ mod query;
 use crate::config::Config;
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::{Column, LayoutStrip, StackItem, clamp_origin_to_viewport};
+use crate::ecs::layout::{
+    Column, LayoutStrip, MIN_WINDOW_HEIGHT, StackItem, clamp_origin_to_viewport,
+};
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker,
@@ -76,6 +78,7 @@ pub fn register_commands(app: &mut bevy::app::App) {
             print_internal_state_handler,
             mouse_to_next_display,
             resize_window,
+            resize_window_vertical,
             command_center_window,
             full_width_window,
             to_next_display,
@@ -772,6 +775,120 @@ fn resize_window(
 
     commands.resize_entity(entity, size);
     commands.reshuffle_around(entity);
+}
+
+/// Cycles the focused window's height through `preset_stack_heights`, letting
+/// the neighbour below (or above, when the window is last) absorb the
+/// difference.
+///
+/// Only stacks are eligible: `binpack_heights` stretches a column's lone member
+/// to the full strip height, so a height written anywhere else is overwritten on
+/// the next layout pass.
+fn resize_window_vertical(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    active_display: ActiveDisplay,
+    config: Res<Config>,
+    mut commands: Commands,
+) {
+    let Some(&Operation::ResizeVertical(direction)) =
+        filter_window_operations(&mut messages, |op| {
+            matches!(op, Operation::ResizeVertical(_))
+        })
+        .next()
+    else {
+        return;
+    };
+
+    let Some((_, entity)) = windows.focused() else {
+        return;
+    };
+
+    let strip = active_display.active_strip();
+    let Some(Column::Stack(items)) = strip
+        .index_of(entity)
+        .ok()
+        .and_then(|index| strip.get(index).ok())
+    else {
+        return;
+    };
+    let Some(position) = items.iter().position(|item| item.contains(entity)) else {
+        return;
+    };
+    let neighbour = if position + 1 < items.len() {
+        position + 1
+    } else if position > 0 {
+        position - 1
+    } else {
+        return;
+    };
+
+    // Pending resizes count: holding the key down must keep advancing through
+    // the presets instead of re-reading a mid-animation height.
+    let Some((frame, neighbour_frame)) = items[position]
+        .top()
+        .and_then(|entity| windows.moving_frame(entity))
+        .zip(
+            items[neighbour]
+                .top()
+                .and_then(|entity| windows.moving_frame(entity)),
+        )
+    else {
+        return;
+    };
+
+    let pair = frame.height() + neighbour_frame.height();
+    if pair < 2 * MIN_WINDOW_HEIGHT {
+        return;
+    }
+
+    let viewport = active_display.actual_bounds(&config);
+    let current_ratio = f64::from(frame.height()) / f64::from(viewport.height());
+    let heights = config.preset_stack_heights();
+    let fallback = *heights.first().unwrap_or(&0.5);
+    let cycle = config.window_resize_cycle();
+    // The presets are assumed sorted ascending, and the `0.05` dead-band keeps
+    // float noise from re-selecting the preset the window is already at.
+    let next_ratio = match direction {
+        ResizeDirection::Grow => heights
+            .iter()
+            .copied()
+            .find(|&r| r > current_ratio + 0.05)
+            .unwrap_or_else(|| {
+                if cycle {
+                    fallback
+                } else {
+                    *heights.last().unwrap_or(&fallback)
+                }
+            }),
+        ResizeDirection::Shrink => heights
+            .iter()
+            .rev()
+            .copied()
+            .find(|&r| r < current_ratio - 0.05)
+            .unwrap_or_else(|| {
+                if cycle {
+                    *heights.last().unwrap_or(&fallback)
+                } else {
+                    fallback
+                }
+            }),
+    };
+    let new_height = round_px(next_ratio * f64::from(viewport.height()))
+        .clamp(MIN_WINDOW_HEIGHT, pair - MIN_WINDOW_HEIGHT);
+
+    // Leaving the pair's total untouched is what makes the new height survive
+    // `binpack_heights`, which hands the column's last item the remainder.
+    for (item, height) in [
+        (&items[position], new_height),
+        (&items[neighbour], pair - new_height),
+    ] {
+        for entity in item.window_iter() {
+            if let Some(size) = windows.size(entity) {
+                commands.resize_entity(entity, size.with_y(height));
+            }
+        }
+    }
 }
 
 fn full_width_window(

--- a/src/config.rs
+++ b/src/config.rs
@@ -491,6 +491,10 @@ impl Config {
         self.options().preset_column_widths
     }
 
+    pub fn preset_stack_heights(&self) -> Vec<f64> {
+        self.options().preset_stack_heights
+    }
+
     pub fn swipe_gesture_direction(&self) -> SwipeGestureDirection {
         let config = self.inner();
         config
@@ -1056,6 +1060,10 @@ pub struct MainOptions {
     /// A list of preset column widths (as ratios) used for resizing windows.
     #[serde(default = "default_preset_column_widths")]
     pub preset_column_widths: Vec<f64>,
+    /// A list of preset heights (as ratios of the viewport) used when resizing
+    /// a window vertically inside a stack.
+    #[serde(default = "default_preset_stack_heights")]
+    pub preset_stack_heights: Vec<f64>,
     /// The animation speed for window movements in pixels per second.
     pub animation_speed: Option<f64>,
     /// Automatically center the window when switching focus with keyboard.
@@ -1104,7 +1112,8 @@ pub struct MainOptions {
     /// fully invisible. E.g. 0.5 = tolerate up to 50% hidden.
     pub window_hidden_ratio: Option<f64>,
 
-    /// Whether grow/shrink cycles back when reaching the end of presets.
+    /// Whether grow/shrink cycles back when reaching the end of presets. Applies
+    /// to both the horizontal and the vertical resize commands.
     /// Default: true (cycles). Set to false to stop at the limits.
     pub window_resize_cycle: Option<bool>,
 
@@ -1136,6 +1145,12 @@ pub struct MainOptions {
 /// Returns a default set of column widths.
 pub fn default_preset_column_widths() -> Vec<f64> {
     vec![0.25, 0.33333, 0.50, 0.66667, 0.75, 1.0, 1.5, 2.0]
+}
+
+/// Returns a default set of stacked window heights. Unlike widths there is no
+/// vertical scrolling, so ratios never exceed the viewport.
+pub fn default_preset_stack_heights() -> Vec<f64> {
+    vec![0.25, 0.33333, 0.50, 0.66667, 0.75]
 }
 
 /// `Keybinding` represents a keyboard shortcut and the command it triggers.
@@ -1939,6 +1954,31 @@ fn test_parse_resize_commands() {
 }
 
 #[test]
+fn test_parse_vertical_resize_commands() {
+    assert!(matches!(
+        parse_command(&["window", "vertical"]).unwrap(),
+        Command::Window(Operation::ResizeVertical(ResizeDirection::Grow))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "vertical", "resize"]).unwrap(),
+        Command::Window(Operation::ResizeVertical(ResizeDirection::Grow))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "vertical", "grow"]).unwrap(),
+        Command::Window(Operation::ResizeVertical(ResizeDirection::Grow))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "vertical", "shrink"]).unwrap(),
+        Command::Window(Operation::ResizeVertical(ResizeDirection::Shrink))
+    ));
+    assert!(matches!(
+        parse_command(&["window", "vertical", "resize", "shrink"]).unwrap(),
+        Command::Window(Operation::ResizeVertical(ResizeDirection::Shrink))
+    ));
+    assert!(parse_command(&["window", "vertical", "wider"]).is_err());
+}
+
+#[test]
 fn test_parse_restart_command() {
     assert!(matches!(
         parse_command(&["restart"]).unwrap(),
@@ -2252,13 +2292,18 @@ mod lua_setup_tests {
         let config = config_from_source(
             r"return {
                 default_workspaces = 3,
-                options = { sliver_width = 9, focus_follows_mouse = false },
+                options = {
+                    sliver_width = 9,
+                    focus_follows_mouse = false,
+                    preset_stack_heights = { 0.3, 0.7 },
+                },
                 padding = { top = 10, bottom = 4 },
             }",
         );
         assert_eq!(config.default_workspaces(), 3);
         assert_eq!(config.sliver_width(), 9);
         assert!(!config.focus_follows_mouse());
+        assert_eq!(config.preset_stack_heights(), vec![0.3, 0.7]);
         let (top, _right, bottom, _left) = config.edge_padding();
         assert_eq!((top, bottom), (10, 4));
     }

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -23,6 +23,10 @@ use crate::manager::{Display, Origin, Size, Window};
 use crate::platform::WorkspaceId;
 use crate::util::round_px;
 
+/// The floor every window in a column is packed against. Heights that would
+/// starve a sibling below it make [`binpack_heights`] fall back to averaging.
+pub(crate) const MIN_WINDOW_HEIGHT: i32 = 200;
+
 pub struct LayoutEventsPlugin;
 
 /// A strip, its entity, origin, display, and whether it's the active one.
@@ -727,8 +731,6 @@ impl LayoutStrip {
     where
         W: Fn(Entity) -> Option<IRect>,
     {
-        const MIN_WINDOW_HEIGHT: i32 = 200;
-
         self.column_positions(get_window_frame)
             .filter_map(move |(column, position)| {
                 let items: Vec<StackItem> = match column {

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -209,6 +209,152 @@ fn test_window_resize_grow_and_shrink_cycle() {
         .run(commands);
 }
 
+/// Stacks two windows, then cycles the focused one's height through the
+/// presets. The window above it — the only neighbour, since the focused one is
+/// last in the stack — absorbs the whole difference, and the column keeps
+/// filling the viewport.
+#[test]
+fn test_window_vertical_resize_grow_and_shrink_cycle() {
+    // The viewport is `TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT` tall and the
+    // two stacked windows split it evenly to start with.
+    const VIEWPORT_HEIGHT: i32 = TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT;
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 }, // 0
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::First)),
+        }, // 1
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        }, // 2
+        Event::Command {
+            command: Command::Window(Operation::Stack(true)),
+        }, // 3
+        Event::Command {
+            command: Command::Window(Operation::ResizeVertical(ResizeDirection::Grow)),
+        }, // 4
+        Event::Command {
+            command: Command::Window(Operation::ResizeVertical(ResizeDirection::Grow)),
+        }, // 5
+        Event::Command {
+            command: Command::Window(Operation::ResizeVertical(ResizeDirection::Shrink)),
+        }, // 6
+    ];
+
+    let config: Config = (
+        MainOptions {
+            preset_stack_heights: vec![0.3, 0.5, 0.7],
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(2)
+        .on_iteration(3, |world, _state| {
+            assert_window_size!(world, 0, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT / 2);
+            assert_window_size!(world, 1, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT / 2);
+        })
+        .on_iteration(4, |world, _state| {
+            // 0.7 of the viewport, with window 0 giving up exactly the delta.
+            assert_window_size!(world, 1, TEST_WINDOW_WIDTH, 524);
+            assert_window_size!(world, 0, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT - 524);
+        })
+        .on_iteration(5, |world, _state| {
+            // Past the last preset, so it cycles back to the smallest.
+            assert_window_size!(world, 1, TEST_WINDOW_WIDTH, 224);
+            assert_window_size!(world, 0, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT - 224);
+        })
+        .on_iteration(6, |world, _state| {
+            // Below the smallest preset, so shrinking cycles to the largest.
+            assert_window_size!(world, 1, TEST_WINDOW_WIDTH, 524);
+            assert_window_size!(world, 0, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT - 524);
+        })
+        .run(commands);
+}
+
+/// A preset that would starve the neighbour is clamped to leave it the minimum
+/// window height, rather than letting the binpacker average the column.
+#[test]
+fn test_window_vertical_resize_leaves_the_neighbour_its_minimum() {
+    const VIEWPORT_HEIGHT: i32 = TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT;
+    const MIN_WINDOW_HEIGHT: i32 = 200;
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::First)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Stack(true)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::ResizeVertical(ResizeDirection::Grow)),
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            // 0.9 of the viewport would leave the neighbour 75px.
+            preset_stack_heights: vec![0.5, 0.9],
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(2)
+        .on_iteration(4, |world, _state| {
+            assert_window_size!(
+                world,
+                1,
+                TEST_WINDOW_WIDTH,
+                VIEWPORT_HEIGHT - MIN_WINDOW_HEIGHT
+            );
+            assert_window_size!(world, 0, TEST_WINDOW_WIDTH, MIN_WINDOW_HEIGHT);
+        })
+        .run(commands);
+}
+
+/// Outside a stack the binpacker always stretches a column's lone member to the
+/// full viewport, so the command is a no-op there.
+#[test]
+fn test_window_vertical_resize_is_a_noop_outside_a_stack() {
+    const VIEWPORT_HEIGHT: i32 = TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT;
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::ResizeVertical(ResizeDirection::Shrink)),
+        },
+    ];
+
+    let config: Config = (
+        MainOptions {
+            preset_stack_heights: vec![0.3, 0.5, 0.7],
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(2)
+        .on_iteration(1, |world, _state| {
+            assert_window_size!(world, 0, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT);
+            assert_window_size!(world, 1, TEST_WINDOW_WIDTH, VIEWPORT_HEIGHT);
+        })
+        .run(commands);
+}
+
 #[test]
 fn test_window_can_resize_to_two_display_widths_and_scroll() {
     let commands = vec![


### PR DESCRIPTION
Hi.

I believe this feature was missing so hopefully this PR adds it with minimal impact.
Let me know if any adjustment is required.

FYI: Generated with Claude Code

## Resizing stacked windows vertically

Stacking two windows into one column is easy, but once they are there you are stuck with whatever heights they happen to have. The only way to change them is `window_equalize`, which resets *every* window in the column to an equal share. There is no way to say "make this one taller and that one shorter" the way `window_resize` does for column widths.

This adds the vertical counterpart: cycle the focused window's height through a list of presets, exactly like `window_resize` cycles widths.

### How it behaves

Press the grow binding and the focused window jumps to the next preset height. The window **directly below it** gives up (or takes) the difference — nothing else in the column moves, and the column still fills the screen. When the focused window is the last one in the stack, the window above it absorbs the change instead.

```
  before                grow                  grow
┌──────────┐         ┌──────────┐         ┌──────────┐
│    A     │         │    A     │         │    A     │
├──────────┤         ├──────────┤         ├──────────┤
│    B     │  ────►  │          │  ────►  │          │
├──────────┤         │    B     │         │    B     │
│    C     │         ├──────────┤         │          │
│          │         │    C     │         ├──────────┤
└──────────┘         └──────────┘         │    C     │
                                          └──────────┘
   A unchanged in both steps; only B and C trade space
```

A few details that fall out of this:

- **Only works inside a stack.** A window that is alone in its column always fills the full height, so the command does nothing there — it is silently ignored rather than fighting the layout.
- **Nobody gets squeezed out.** Every window keeps at least 200px of height, the same floor the layout engine already enforces. A preset that would starve the neighbour is capped so the neighbour keeps its minimum.
- **Apps with a minimum height still win.** If an app refuses to shrink past its own limit, the existing resize-verification logic corrects the layout, same as it does for widths.
- **Cycling follows `window_resize_cycle`.** With the default (`true`) the presets wrap around; set to `false` and it stops at the largest and smallest, matching how the width commands already behave for you.

### New configuration

One new option:

| Option | Type | Default | Description |
| --- | --- | --- | --- |
| `preset_stack_heights` | Array (Float) | `[0.25, 0.33, 0.5, 0.66, 0.75]` | Heights, as ratios of the screen height, that a stacked window cycles through. Unlike `preset_column_widths` there is no vertical scrolling, so values above `1.0` are not useful. |

Three new bindings:

| Binding | Description |
| --- | --- |
| `window_vertical_resize` | Cycle a stacked window through the preset heights (grow) |
| `window_vertical_grow` | Alias for `window_vertical_resize` |
| `window_vertical_shrink` | Cycle a stacked window through the preset heights (shrink) |

Example:

```toml
[options]
preset_stack_heights = [0.25, 0.33, 0.5, 0.66, 0.75]

[bindings]
window_vertical_grow = "cmd + alt - ~"
window_vertical_shrink = "cmd + alt - \\"
```

The existing `window_resize_cycle` option now applies to these as well as the width commands.

### Also available from the CLI and Lua

```shell
$ paneru send-cmd window vertical grow
$ paneru send-cmd window vertical shrink
```

```lua
paneru.window.vertical_grow()
paneru.window.vertical_shrink()
paneru.window.vertical_resize({ direction = "shrink" })
```

### Notes for review

The diff is additive: `resize_window` and the rest of the width path are untouched. The one shared change is promoting the layout engine's `MIN_WINDOW_HEIGHT` from a function-local constant to a module constant, so the new command clamps against the same value the layout packer uses.

Covered by three new tests (preset cycling, the minimum-height clamp, and the no-op outside a stack), plus parser and Lua round-trip tests. Docs updated in `CONFIGURATION.md`, `README.md` and `SCRIPTING.md`.

Tested live on macOS with a two-window stack across the full preset range.
