### PR TITLE
fix: keep hidden stacked windows off the display below

### DIFF
--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -25,6 +25,12 @@ use crate::util::round_px;
 
 pub struct LayoutEventsPlugin;
 
+/// How much of a hidden virtual workspace stays on its own display. Hiding a
+/// workspace parks its strip this many pixels inside the display's bottom-right
+/// corner, which keeps a small sliver on screen: macOS reassigns a window whose
+/// frame has left the display entirely to whichever display it landed on.
+pub(crate) const PARKED_STRIP_SLIVER: i32 = 10;
+
 /// A strip, its entity, origin, display, and whether it's the active one.
 /// Shared by [`reshuffle_layout_strip`] and [`ensure_visible_in_strip`].
 type StripPlacements<'w, 's> = Query<
@@ -1358,6 +1364,19 @@ fn position_layout_windows(
             }
         }
 
+        // Keep the window anchored to its own display. The parked strip origin
+        // only accounts for the first window: everything sitting below it in a
+        // stack picks up that offset on top of the corner and lands past the
+        // bottom edge, fully inside the display underneath. macOS then adopts
+        // the window onto that display, and showing the workspace again brings
+        // it back there instead of here. Park those at the corner as well.
+        let park_row = viewport.max.y - PARKED_STRIP_SLIVER;
+        if frame.min.y > park_row {
+            let height = frame.height();
+            frame.min.y = park_row;
+            frame.max.y = park_row + height;
+        }
+
         if bounds.0 != frame.size() {
             bounds.0 = frame.size();
         }
@@ -1373,7 +1392,14 @@ fn position_layout_windows(
             // strip's current position, so the two motions compose: e.g., on swap, the focused
             // window's target converges back to its old visual position as the strip settles, while
             // the other window slides past.
-            let offscreen_move = position.0.y.abs_diff(frame.min.y) > vertical_move_threshold;
+            // Parking and un-parking have to snap as one move. The clamp above
+            // leaves the lower stack members a short hop from their visible
+            // slot, which the distance threshold alone reads as an ordinary
+            // layout change - they would slide across the screen while the
+            // window above them teleports.
+            let parking = frame.min.y >= park_row || position.0.y >= park_row;
+            let offscreen_move =
+                parking || position.0.y.abs_diff(frame.min.y) > vertical_move_threshold;
             if context.swiping || offscreen_move && !config.virtual_workspace_animations() {
                 position.0 = frame.min;
                 if let Ok(mut entity_commands) = commands.get_entity(entity) {

--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -12,7 +12,7 @@ use objc2_core_graphics::CGDirectDisplayID;
 use tracing::{Level, info, instrument, warn};
 
 use crate::config::{Config, MissingWindowBehavior};
-use crate::ecs::layout::LayoutStrip;
+use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER};
 use crate::ecs::params::{WindowCtx, Windows};
 use crate::ecs::state::{
     PaneruState, SavedColumn, SavedStackItem, SavedStrip, SavedWindow, SavedWorkspace,
@@ -540,7 +540,7 @@ pub(super) fn restore_window_state(
         let origin = if is_global_active {
             display.bounds().min
         } else {
-            display.bounds().max - 10
+            display.bounds().max - PARKED_STRIP_SLIVER
         };
         let previous = PreviousStripPosition {
             origin: display.bounds().min,

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -19,7 +19,7 @@ use super::{ActiveDisplayMarker, SpawnWindowTrigger};
 use crate::commands::{Direction, MoveFocus, Operation, filter_window_operations};
 use crate::config::Config;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::LayoutStrip;
+use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER};
 use crate::ecs::params::{ActiveDisplay, WindowCtx, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker, Initializing,
@@ -729,7 +729,11 @@ fn handle_virtual_window_moves(
             let visible_origin = viewport.min;
             // mid-strip: keep the lone window at its current x.
             let shown = Origin::new(moved_left.unwrap_or(visible_origin.x), visible_origin.y);
-            let origin = if stay { viewport.max - 10 } else { shown };
+            let origin = if stay {
+                viewport.max - PARKED_STRIP_SLIVER
+            } else {
+                shown
+            };
             debug!(
                 "Creating new virtual row {target_idx} on workspace {}",
                 workspace_id
@@ -1153,9 +1157,9 @@ pub(crate) fn show_active_workspace(
         }
 
         if config.virtual_workspace_animations() {
-            commands.reposition_entity(entity, bounds.max - 10);
+            commands.reposition_entity(entity, bounds.max - PARKED_STRIP_SLIVER);
         } else {
-            position.0 = bounds.max - 10;
+            position.0 = bounds.max - PARKED_STRIP_SLIVER;
         }
     }
 

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -729,11 +729,8 @@ fn handle_virtual_window_moves(
             let visible_origin = viewport.min;
             // mid-strip: keep the lone window at its current x.
             let shown = Origin::new(moved_left.unwrap_or(visible_origin.x), visible_origin.y);
-            let origin = if stay {
-                viewport.max - PARKED_STRIP_SLIVER
-            } else {
-                shown
-            };
+            let parked = viewport.max - PARKED_STRIP_SLIVER;
+            let origin = if stay { parked } else { shown };
             debug!(
                 "Creating new virtual row {target_idx} on workspace {}",
                 workspace_id

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -5,7 +5,7 @@ use bevy::time::TimeUpdateStrategy;
 
 use crate::commands::{Command, Direction, MouseMove, MoveFocus, Operation};
 use crate::config::Config;
-use crate::ecs::layout::LayoutStrip;
+use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER};
 use crate::ecs::{ActiveWorkspaceMarker, DockPosition, RefreshWindowSizes, Timeout};
 use crate::events::Event;
 use crate::manager::{Display, Origin, Size};
@@ -535,6 +535,80 @@ fn test_vertical_swap_within_stack_stays_on_display() {
                 TEST_DISPLAY_ID,
                 "swapping inside a stack must not move focus to another display"
             );
+        })
+        .run(commands);
+}
+
+#[test]
+fn test_hidden_stack_stays_off_the_display_below() {
+    // Regression test: hiding a virtual workspace parks its strip at the
+    // display's bottom-right corner. Windows below the strip origin - the
+    // lower members of a stack - used to land past the bottom edge entirely,
+    // inside the display underneath, which macOS then adopts them onto. The
+    // window came back on the wrong display once the workspace was shown
+    // again.
+    let mut harness = TestHarness::new().with_windows(2);
+    harness.mock_state.add_display(
+        EXT_DISPLAY_ID,
+        IRect::new(
+            0,
+            TEST_DISPLAY_HEIGHT,
+            EXT_DISPLAY_WIDTH,
+            TEST_DISPLAY_HEIGHT + EXT_DISPLAY_HEIGHT,
+        ),
+        vec![EXT_WORKSPACE_ID],
+    );
+
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::Last)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::Stack(true)),
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(0)),
+        },
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    harness
+        .on_iteration(4, |world, _state| {
+            // Hidden, but still parked on their own display: every window keeps
+            // its origin above the top edge of the display below.
+            let mut query = world.query::<&crate::manager::Window>();
+            for window in query.iter(world) {
+                let frame = window.frame();
+                assert!(
+                    frame.min.y < TEST_DISPLAY_HEIGHT,
+                    "window {} parked at {:?}, inside the display below",
+                    window.id(),
+                    frame
+                );
+                assert_eq!(
+                    frame.min.y,
+                    TEST_DISPLAY_HEIGHT - PARKED_STRIP_SLIVER,
+                    "window {} should park on the corner sliver",
+                    window.id()
+                );
+            }
+        })
+        .on_iteration(6, |world, _state| {
+            assert_on_workspace!(world, 0, TEST_WORKSPACE_ID);
+            assert_on_workspace!(world, 1, TEST_WORKSPACE_ID);
+            assert_not_on_workspace!(world, 0, EXT_WORKSPACE_ID);
+            assert_not_on_workspace!(world, 1, EXT_WORKSPACE_ID);
+            assert_window_at!(world, 0, 400, TEST_MENUBAR_HEIGHT);
+            assert_window_at!(world, 1, 400, 394);
         })
         .run(commands);
 }


### PR DESCRIPTION
Follow-up to #369. Same symptom — a window ends up on the display below — but a
different cause, on a different code path. #369 fixed the *swap command*
re-querying a mutated layout. This one is in the *hide path* for virtual
workspaces, and #369 does not touch it.

### The problem

With a second display arranged **below** the active one, focus the bottom window
of a stack, switch to another virtual workspace and switch back: that window
returns on the display below instead of its own.

### Reproduce

1. Two displays stacked vertically.
2. On the upper display, put two windows into a single column stack (`window stack`).
3. Focus the **bottom** window of the stack.
4. `paneru send-cmd window virtualnum 2`, then `paneru send-cmd window virtualnum 1`.

### Cause

Hiding a virtual workspace parks its strip 10px inside the display's
bottom-right corner, leaving a sliver on screen so macOS does not reassign the
windows. That origin only accounts for the first window: every window below it
in a stack adds its own layout offset on top of the corner, so it lands past the
bottom edge entirely, fully inside the display underneath. macOS adopts the
window onto that display, and showing the workspace again brings it back there.

`position_layout_windows` clamped a parked window's `x` back to the sliver but
never bounded `y`, so the vertical case went unhandled.

Measured on a 1024x768 display with a second one at y 768..1968, two windows
stacked, workspace hidden:

```
window 0  min(1014,  758)   corner sliver, fine
window 1  min(1014, 1132)   fully inside the display below
```

### Fix

Clamp each window's parked row to the same corner sliver, so the strip offset
stops cascading past the bottom edge.

Parking and un-parking then have to snap as one move: after the clamp, the lower
stack members sit a short hop from their visible slot, which the existing
"moved more than 80% of the display height" test reads as an ordinary layout
change. They would slide across the screen while the window above them
teleports, so that test now also treats the park row itself as an off-screen
move.

The 10px park inset is named (`PARKED_STRIP_SLIVER`) and shared by the three
sites that park a strip, which previously hardcoded it.

### Notes for the reviewer

- **Where the clamp sits.** It has to be per window, in `position_layout_windows`
  — no single strip origin can park every member of a stack on the sliver, since
  each one adds its own offset to it.
- **`viewport` vs `bounds`.** The clamp uses `actual_display_bounds` (dock and
  menu bar excluded) while the parking sites use the raw `display.bounds()`. With
  a bottom dock the clamp therefore also pulls the *first* window up to the
  usable bottom edge, so the sliver stays above the dock rather than behind it.
  That looked like the better behaviour; say the word if you would rather the two
  used the same rectangle.
- **Visible windows are untouched.** The clamp only fires for `frame.min.y >
  viewport.max.y - 10`, which a tiled window cannot reach — it would need a height
  under 10px, well below `MIN_WINDOW_HEIGHT`.
- **`query on-screen` reporting.** Parked stack members now expose the same 10x10
  sliver the parked strip origin always did, so `window_visibility` counts them
  as visible where it previously did not. This makes them consistent with the
  first window of every hidden workspace, which already reported that way; it
  seemed right, but it is a behaviour change worth a look.
- **Verified live**, not just in the test: with displays arranged vertically, the
  parked frames stayed above the lower display's top edge and the focused bottom
  window came back on its own display, in its slot, still focused.

### Tests

Adds a regression test that stacks two windows with a second display registered
below the active one, hides the workspace and asserts every window parks on the
corner sliver rather than inside the display below. It fails on `main`
(`window 1 parked at IRect { min: IVec2(1014, 1132) }`) and passes with the fix.

`cargo test` — 201 passed, `cargo fmt` and `cargo clippy --all-targets` clean.

🤖 Generated with Claude Code
