### PR TITLE
fix: keep a manually centered window centered

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -16,12 +16,12 @@ use crate::config::Config;
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::{
-    Column, LayoutStrip, MIN_WINDOW_HEIGHT, StackItem, clamp_origin_to_viewport,
+    Column, LayoutStrip, MIN_WINDOW_HEIGHT, StackItem, clamp_origin_to_viewport, strip_signature,
 };
 use crate::ecs::params::{ActiveDisplay, ActiveDisplayMut, Windows};
 use crate::ecs::{
     ActiveDisplayMarker, ActiveWorkspaceMarker, Bounds, DockPosition, FocusedMarker,
-    FullWidthMarker, NativeFullscreenMarker, RaiseWindow, SelectedVirtualMarker,
+    FullWidthMarker, ManualStripOffset, NativeFullscreenMarker, RaiseWindow, SelectedVirtualMarker,
     SendMessageTrigger, SpawnCommandsExt, Timeout, Unmanaged,
 };
 use crate::events::Event;
@@ -649,6 +649,23 @@ fn command_swap_focus(
     }
 }
 
+/// Records that the user placed this strip's offset by hand, so
+/// `reshuffle_layout_strip` keeps it instead of re-deriving one from the
+/// focused window's frame. The mark is dropped again as soon as the strip's
+/// shape changes, the user swipes, or a window has to be scrolled into view.
+fn mark_manual_offset(
+    strip_entity: Entity,
+    strip: &LayoutStrip,
+    windows: &Windows,
+    commands: &mut Commands,
+) {
+    if let Ok(mut entity_commands) = commands.get_entity(strip_entity) {
+        entity_commands.try_insert(ManualStripOffset {
+            signature: strip_signature(strip, windows),
+        });
+    }
+}
+
 /// Centers the focused window on the active display.
 fn command_center_window(
     mut messages: MessageReader<Event>,
@@ -674,9 +691,19 @@ fn command_center_window(
         if active_display.active_strip().contains(entity)
             && let Some(layout_position) = windows.layout_position(entity)
         {
-            // Directly reposition the strip (bypasses hidden_ratio check).
+            // Directly reposition the strip (bypasses hidden_ratio check), and
+            // record the placement as deliberate so a later reshuffle — a
+            // repeated focus event, a return from another display — does not
+            // re-derive the offset and undo the centering.
             let strip_position = origin - layout_position.0;
-            commands.reposition_entity(active_display.active_strip_entity(), strip_position);
+            let strip_entity = active_display.active_strip_entity();
+            commands.reposition_entity(strip_entity, strip_position);
+            mark_manual_offset(
+                strip_entity,
+                active_display.active_strip(),
+                &windows,
+                &mut commands,
+            );
         } else {
             commands.reposition_entity(entity, origin);
         }
@@ -1312,7 +1339,14 @@ fn snap_window(
     frame.max = frame.min + size;
 
     let strip_position = frame.min - layout_position.0;
-    commands.reposition_entity(active_display.active_strip_entity(), strip_position);
+    let strip_entity = active_display.active_strip_entity();
+    commands.reposition_entity(strip_entity, strip_position);
+    mark_manual_offset(
+        strip_entity,
+        active_display.active_strip(),
+        &windows,
+        &mut commands,
+    );
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -267,6 +267,22 @@ pub struct ReshuffleAroundMarker;
 #[derive(Component)]
 pub struct EnsureVisibleMarker;
 
+/// Marks a [`LayoutStrip`](crate::ecs::layout::LayoutStrip) whose offset was
+/// placed deliberately by the user (`Operation::Center`, `Operation::Snap`)
+/// rather than derived from a window frame. While it is present and still
+/// current, `reshuffle_layout_strip` leaves the offset alone — edge invariant
+/// included — for any window that is already fully visible.
+///
+/// Currency is a value comparison, not change detection: the animator writes
+/// `Position` every frame and `layout_sizes_changed` turns that into a
+/// `LayoutStrip` change, so a tick would go stale immediately. `signature`
+/// holds the ordered column tops with their target widths, which survives
+/// scrolling and tab reordering but not an add, remove, reorder or resize.
+#[derive(Component, Debug)]
+pub struct ManualStripOffset {
+    pub signature: Vec<(Entity, i32)>,
+}
+
 #[derive(Component, Debug)]
 pub struct Scrolling {
     pub velocity: f64,

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -16,7 +16,8 @@ use crate::config::Config;
 use crate::ecs::params::Windows;
 use crate::ecs::{
     ActiveWorkspaceMarker, Bounds, DockPosition, EnsureVisibleMarker, Initializing, LayoutPosition,
-    Position, RepositionMarker, ReshuffleAroundMarker, Scrolling, SpawnCommandsExt,
+    ManualStripOffset, Position, RepositionMarker, ReshuffleAroundMarker, Scrolling,
+    SpawnCommandsExt,
 };
 use crate::errors::{Error, Result};
 use crate::manager::{Display, Origin, Size, Window};
@@ -35,7 +36,8 @@ pub struct LayoutEventsPlugin;
 /// frame has left the display entirely to whichever display it landed on.
 pub(crate) const PARKED_STRIP_SLIVER: i32 = 10;
 
-/// A strip, its entity, origin, display, and whether it's the active one.
+/// A strip, its entity, origin, display, whether it's the active one, and the
+/// offset it is animating toward if a move is already in flight.
 /// Shared by [`reshuffle_layout_strip`] and [`ensure_visible_in_strip`].
 type StripPlacements<'w, 's> = Query<
     'w,
@@ -46,6 +48,7 @@ type StripPlacements<'w, 's> = Query<
         &'static Position,
         &'static ChildOf,
         Option<Ref<'static, ActiveWorkspaceMarker>>,
+        Option<&'static RepositionMarker>,
     ),
 >;
 
@@ -101,6 +104,38 @@ pub(crate) fn clamp_origin_to_viewport(origin: Origin, size: Size, viewport: IRe
     let minimum = viewport.min.min(far_edge);
     let maximum = viewport.min.max(far_edge);
     origin.clamp(minimum, maximum)
+}
+
+/// How far a stored width may drift before a [`ManualStripOffset`] counts as
+/// stale. `window_resized_update_frame` writes back the OS geometry, which can
+/// land a pixel or two off the size the layout asked for.
+const SIGNATURE_WIDTH_TOLERANCE: i32 = 2;
+
+/// Fingerprints the shape of a strip for [`ManualStripOffset`]: the ordered
+/// column tops with the widths they are heading for.
+///
+/// Column tops only, so promoting a tab or a stacked window to the front of its
+/// column — which happens on every focus event — is not a layout change. Widths
+/// from `moving_frame`, so a resize counts once it is requested rather than
+/// once per animation frame. Neither depends on the strip's offset, which is
+/// the point: scrolling must not invalidate a deliberate placement.
+pub(crate) fn strip_signature(strip: &LayoutStrip, windows: &Windows) -> Vec<(Entity, i32)> {
+    strip
+        .all_columns()
+        .into_iter()
+        .filter_map(|entity| {
+            windows
+                .moving_frame(entity)
+                .map(|frame| (entity, frame.width()))
+        })
+        .collect()
+}
+
+fn signature_matches(current: &[(Entity, i32)], stored: &[(Entity, i32)]) -> bool {
+    current.len() == stored.len()
+        && current.iter().zip(stored).all(|(now, before)| {
+            now.0 == before.0 && (now.1 - before.1).abs() <= SIGNATURE_WIDTH_TOLERANCE
+        })
 }
 
 impl Plugin for LayoutEventsPlugin {
@@ -1023,6 +1058,7 @@ fn layout_strip_changed(
 fn reshuffle_layout_strip(
     markers: Query<(Entity, &LayoutPosition), With<ReshuffleAroundMarker>>,
     strips: StripPlacements,
+    manual_offsets: Query<&ManualStripOffset>,
     displays: DisplayViewports,
     windows: Windows,
     config: Res<Config>,
@@ -1032,7 +1068,7 @@ fn reshuffle_layout_strip(
         if let Ok(mut cmd) = commands.get_entity(entity) {
             cmd.try_remove::<ReshuffleAroundMarker>();
         }
-        let Some((strip, strip_entity, active_strip, child, active_marker)) =
+        let Some((strip, strip_entity, active_strip, child, active_marker, strip_reposition)) =
             strips.into_iter().find(|strip| strip.0.contains(entity))
         else {
             return;
@@ -1052,6 +1088,31 @@ fn reshuffle_layout_strip(
 
         let size = frame.size();
         let visible_width = display_bounds.intersect(frame).width();
+
+        // A deliberate offset (center, snap) outranks the derived one, but only
+        // while the window this reshuffle is about is still fully on screen: a
+        // focus event for a window scrolled past an edge has to bring it back,
+        // and at that point the placement is stale. Project against the strip's
+        // *target* offset — mid-animation the window's own frame is a tick
+        // behind a strip that is still moving.
+        if let Ok(manual) = manual_offsets.get(strip_entity) {
+            // The offset only ever meant "the user placed *this* layout here",
+            // so a strip that has since gained, lost, reordered or resized a
+            // column no longer has a placement to keep.
+            let current = strip_signature(strip, &windows);
+            let strip_target = strip_reposition.map_or(active_strip.0, |reposition| reposition.0);
+            let projected = layout_position.0 + strip_target;
+            if signature_matches(&current, &manual.signature)
+                && clamp_origin_to_viewport(projected, size, display_bounds) == projected
+            {
+                trace!("reshuffle_layout_strip: keeping manual offset on {strip_entity}");
+                return;
+            }
+            trace!("reshuffle_layout_strip: manual offset on {strip_entity} is stale");
+            if let Ok(mut cmd) = commands.get_entity(strip_entity) {
+                cmd.try_remove::<ManualStripOffset>();
+            }
+        }
 
         // Expose the window by clamping it into the viewport.
         frame.min = clamp_origin_to_viewport(frame.min, size, display_bounds);
@@ -1128,21 +1189,23 @@ fn ensure_visible_in_strip(
         if let Ok(mut cmd) = commands.get_entity(entity) {
             cmd.try_remove::<EnsureVisibleMarker>();
         }
-        let Some((_, strip_entity, strip_position, child, active_marker)) =
+        // Each marker is independent, and its own marker was already consumed
+        // above: bailing out of the loop would silently drop the rest.
+        let Some((_, strip_entity, strip_position, child, active_marker, _)) =
             strips.into_iter().find(|s| s.0.contains(entity))
         else {
-            return;
+            continue;
         };
 
         if active_marker.is_some_and(|m| m.is_added()) {
             trace!("ensure_visible_in_strip: skipping newly active workspace {strip_entity}");
-            return;
+            continue;
         }
         let Ok((display, dock)) = displays.get(child.parent()) else {
-            return;
+            continue;
         };
         let Some(size) = windows.size(entity) else {
-            return;
+            continue;
         };
         let viewport = display.actual_display_bounds(dock, &config);
 
@@ -1152,10 +1215,17 @@ fn ensure_visible_in_strip(
         // the strip target equals its current position — no movement.
         let clamped_min = clamp_origin_to_viewport(candidate_min, size, viewport);
         if clamped_min == candidate_min {
-            return;
+            continue;
         }
-        let strip_target = (clamped_min - layout_position.0).with_y(strip_position.0.y);
+        // Both axes come from the clamp: it is still the minimum shortfall, and
+        // keeping the strip's own y here would silently drop the vertical
+        // correction for a window sitting above the menu bar.
+        let strip_target = clamped_min - layout_position.0;
         trace!("ensure_visible_in_strip: entity {entity}, scroll strip to {strip_target}");
+        // Scrolling to expose a window overrides whatever the user placed here.
+        if let Ok(mut cmd) = commands.get_entity(strip_entity) {
+            cmd.try_remove::<ManualStripOffset>();
+        }
         commands.reposition_entity(strip_entity, strip_target);
     }
 }
@@ -1418,6 +1488,19 @@ fn position_layout_windows(
 mod tests {
     use super::*;
     use bevy::prelude::*;
+
+    #[test]
+    fn signature_tolerates_pixel_drift_but_not_a_reshape() {
+        let mut world = World::new();
+        let first = world.spawn_empty().id();
+        let second = world.spawn_empty().id();
+        let stored = vec![(first, 400), (second, 400)];
+
+        assert!(signature_matches(&[(first, 401), (second, 399)], &stored));
+        assert!(!signature_matches(&[(first, 420), (second, 400)], &stored));
+        assert!(!signature_matches(&[(second, 400), (first, 400)], &stored));
+        assert!(!signature_matches(&[(first, 400)], &stored));
+    }
 
     #[test]
     fn clamp_origin_supports_oversized_windows() {

--- a/src/ecs/scroll.rs
+++ b/src/ecs/scroll.rs
@@ -15,7 +15,8 @@ use crate::config::swipe::SwipeGestureDirection;
 use crate::ecs::layout::{Column, LayoutStrip};
 use crate::ecs::params::{ActiveDisplay, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, MissionControlActive, Position, Scrolling, SendMessageTrigger,
+    ActiveWorkspaceMarker, ManualStripOffset, MissionControlActive, Position, Scrolling,
+    SendMessageTrigger,
 };
 use crate::errors::Result;
 use bevy::ecs::schedule::common_conditions::on_message;
@@ -146,6 +147,12 @@ fn swipe_gesture(
     }
 
     let (entity, position, scrolling) = &mut *active_workspace;
+
+    // The user is driving the strip by hand now, so an earlier deliberate
+    // placement (center, snap) no longer describes where they want it.
+    if let Ok(mut entity_commands) = commands.get_entity(*entity) {
+        entity_commands.try_remove::<ManualStripOffset>();
+    }
 
     if touchpad_down && let Some(scrolling) = scrolling.as_mut() {
         scrolling.velocity = 0.0;

--- a/src/ecs/triggers.rs
+++ b/src/ecs/triggers.rs
@@ -332,8 +332,13 @@ pub(super) fn window_focused_trigger(
             if restored_focus {
                 continue;
             }
+            // A repeat focus event for the window that already holds focus (a
+            // new browser tab, an app re-activating) is not new layout
+            // information, so it must not re-derive the strip offset — that
+            // threw away a manual centering. Expose the window if it has been
+            // scrolled off an edge, and otherwise leave the strip alone.
             if !global_state.skip_reshuffle() && !global_state.initializing() {
-                ctx.commands.reshuffle_around(entity);
+                ctx.commands.ensure_visible(entity);
             }
             continue;
         }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -22,9 +22,9 @@ use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER};
 use crate::ecs::params::{ActiveDisplay, WindowCtx, Windows};
 use crate::ecs::{
-    ActiveWorkspaceMarker, DockPosition, FocusedMarker, Initializing, NativeFullscreenMarker,
-    Position, RaiseWindow, RefreshWindowSizes, RepositionMarker, Scrolling, SelectedVirtualMarker,
-    SpawnCommandsExt, Timeout, Unmanaged,
+    ActiveWorkspaceMarker, DockPosition, FocusedMarker, Initializing, ManualStripOffset,
+    NativeFullscreenMarker, Position, RaiseWindow, RefreshWindowSizes, RepositionMarker, Scrolling,
+    SelectedVirtualMarker, SpawnCommandsExt, Timeout, Unmanaged,
 };
 use crate::errors::Result;
 use crate::events::Event;
@@ -1151,7 +1151,8 @@ pub(crate) fn show_active_workspace(
 
         if let Ok(mut cmd) = commands.get_entity(entity) {
             cmd.try_remove::<Scrolling>()
-                .try_remove::<RepositionMarker>();
+                .try_remove::<RepositionMarker>()
+                .try_remove::<ManualStripOffset>();
         }
 
         if config.virtual_workspace_animations() {

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -4,11 +4,12 @@ use bevy::prelude::*;
 use bevy::time::TimeUpdateStrategy;
 
 use crate::commands::{Command, Direction, MouseMove, MoveFocus, Operation};
-use crate::config::Config;
+use crate::config::{Config, MainOptions};
 use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER};
 use crate::ecs::{ActiveWorkspaceMarker, DockPosition, RefreshWindowSizes, Timeout};
 use crate::events::Event;
-use crate::manager::{Display, Origin, Size};
+use crate::manager::{Display, Origin, Size, Window};
+use crate::platform::WinID;
 use crate::{assert_not_on_workspace, assert_on_workspace, assert_window_at, assert_window_size};
 
 use super::*;
@@ -609,6 +610,79 @@ fn test_hidden_stack_stays_off_the_display_below() {
             assert_not_on_workspace!(world, 1, EXT_WORKSPACE_ID);
             assert_window_at!(world, 0, 400, TEST_MENUBAR_HEIGHT);
             assert_window_at!(world, 1, 400, 394);
+        })
+        .run(commands);
+}
+
+/// Focusing a window on another display and coming back must not re-derive the
+/// strip offset on the display we left: the centering the user asked for there
+/// is still what they want to see when they return.
+#[test]
+fn test_center_survives_display_round_trip() {
+    let config: Config = (
+        MainOptions {
+            auto_center: Some(false),
+            continuous_swipe: Some(false),
+            animation_speed: Some(10000.0),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let centered = (TEST_DISPLAY_WIDTH - TEST_WINDOW_WIDTH) / 2;
+    let window_x = |world: &mut World, id: WinID| -> i32 {
+        let mut query = world.query::<&Window>();
+        query
+            .iter(world)
+            .find(|window| window.id() == id)
+            .expect("window not found")
+            .frame()
+            .min
+            .x
+    };
+
+    let commands = vec![
+        // 0: boot with focus on window 0.
+        Event::MenuOpened { window_id: 0 },
+        // 1: center it on the main display.
+        Event::Command {
+            command: Command::Window(Operation::Center),
+        },
+        // 2: focus moves to the window on the external display.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 3: and back to window 0.
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(config)
+        .with_display(
+            EXT_DISPLAY_ID,
+            IRect::new(0, -EXT_DISPLAY_HEIGHT, EXT_DISPLAY_WIDTH, 0),
+            vec![EXT_WORKSPACE_ID],
+        )
+        .with_windows(4)
+        .with_workspace_window(100, EXT_WORKSPACE_ID, |window| {
+            window.workspace_id = EXT_WORKSPACE_ID;
+        })
+        .on_iteration(1, move |world, state| {
+            assert_eq!(window_x(world, 0), centered, "window 0 must be centered");
+            state.focus_window(100);
+        })
+        .on_iteration(2, move |_world, state| {
+            state.focus_window(0);
+        })
+        .on_iteration(3, move |world, _state| {
+            assert_eq!(
+                window_x(world, 0),
+                centered,
+                "returning from another display must not undo the centering"
+            );
         })
         .run(commands);
 }

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -8,13 +8,13 @@ use crate::commands::{Command, Direction, MoveFocus, Operation};
 use crate::config::{Config, MainOptions, WindowParams, parse_command};
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::{
-    ActiveWorkspaceMarker, FocusedMarker, NativeFullscreenMarker, Position, Unmanaged,
-    layout::LayoutStrip,
+    ActiveWorkspaceMarker, FocusedMarker, ManualStripOffset, NativeFullscreenMarker, Position,
+    Unmanaged, layout::LayoutStrip,
 };
 use crate::ecs::{RepositionMarker, SpawnWindowTrigger};
 use crate::events::Event;
 use crate::manager::{Origin, Size, Window};
-use crate::platform::Modifiers;
+use crate::platform::{Modifiers, WinID};
 use crate::{assert_focused, assert_window_at, assert_window_size};
 
 use super::*;
@@ -2289,4 +2289,257 @@ fn test_auto_discover_unmanaged_focused_window() {
             );
         })
         .run(events);
+}
+
+/// The centering config the manual-offset tests share: `auto_center` off and
+/// `continuous_swipe` off is the combination that arms the edge invariant in
+/// `reshuffle_layout_strip`, which is what used to snap a centered strip back
+/// to the display's left edge.
+fn manual_offset_config() -> Config {
+    (
+        MainOptions {
+            auto_center: Some(false),
+            continuous_swipe: Some(false),
+            animation_speed: Some(10000.0),
+            swipe_gesture_fingers: Some(3),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into()
+}
+
+/// Where window 0 sits once `Operation::Center` has placed it.
+const CENTERED_X: i32 = (TEST_DISPLAY_WIDTH - TEST_WINDOW_WIDTH) / 2;
+
+fn active_strip_entity(world: &mut World) -> Entity {
+    let mut query =
+        world.query_filtered::<Entity, (With<LayoutStrip>, With<ActiveWorkspaceMarker>)>();
+    query.single(world).expect("exactly one active strip")
+}
+
+fn has_manual_offset(world: &mut World) -> bool {
+    let entity = active_strip_entity(world);
+    world.get::<ManualStripOffset>(entity).is_some()
+}
+
+fn window_x(world: &mut World, id: WinID) -> i32 {
+    let mut query = world.query::<&Window>();
+    query
+        .iter(world)
+        .find(|window| window.id() == id)
+        .expect("window not found")
+        .frame()
+        .min
+        .x
+}
+
+/// A repeated OS focus event for the window that already holds focus — what a
+/// browser emits when a new tab opens — is not new layout information. It used
+/// to run a full reshuffle, which re-derived the strip offset and threw away a
+/// manual centering.
+#[test]
+fn test_center_survives_repeated_focus_event() {
+    let commands = vec![
+        // 0: boot with focus on window 0.
+        Event::MenuOpened { window_id: 0 },
+        // 1: center it.
+        Event::Command {
+            command: Command::Window(Operation::Center),
+        },
+        // 2: the repeated focus event queued below plays out here.
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(manual_offset_config())
+        .with_windows(5)
+        .on_iteration(1, |world, state| {
+            assert_eq!(window_x(world, 0), CENTERED_X, "window 0 must be centered");
+            // The app re-announces the window that already holds focus.
+            state.focus_window(0);
+        })
+        .on_iteration(2, |world, _state| {
+            assert_eq!(
+                window_x(world, 0),
+                CENTERED_X,
+                "a repeated focus event must not undo the centering"
+            );
+            assert!(
+                has_manual_offset(world),
+                "the manual offset must survive a repeated focus event"
+            );
+        })
+        .run(commands);
+}
+
+/// The offset is only a claim about the layout it was taken on. Adding a window
+/// changes that layout, so the next reshuffle derives a fresh offset and the
+/// strip goes back to the edge invariant.
+#[test]
+fn test_center_dropped_when_window_added() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        // 1: center window 0.
+        Event::Command {
+            command: Command::Window(Operation::Center),
+        },
+        // 2: the sixth window spawned below joins the strip.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 3: a focus change asks for a reshuffle on the new layout.
+        Event::Command {
+            command: Command::Window(Operation::Focus(Direction::East)),
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(manual_offset_config())
+        .with_windows(5)
+        .on_iteration(1, |world, state| {
+            assert_eq!(window_x(world, 0), CENTERED_X, "window 0 must be centered");
+
+            let window = state.spawn_window(
+                TEST_PROCESS_ID,
+                TEST_WORKSPACE_ID,
+                5,
+                IRect::new(0, 0, TEST_WINDOW_WIDTH, TEST_WINDOW_HEIGHT),
+            );
+            world.trigger(SpawnWindowTrigger(vec![window]));
+        })
+        .on_iteration(3, |world, _state| {
+            assert_eq!(
+                window_x(world, 0),
+                0,
+                "a reshuffle on a changed layout must re-derive the offset"
+            );
+            assert!(
+                !has_manual_offset(world),
+                "adding a window must invalidate the manual offset"
+            );
+        })
+        .run(commands);
+}
+
+/// Skipping the reshuffle must not strand a window off-screen: if the strip has
+/// scrolled the focused window past an edge, a focus event still has to bring
+/// it back — and the manual placement it contradicts is dropped with it.
+#[test]
+fn test_partly_hidden_window_still_scrolled_into_view_after_center() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        // 1: center window 0.
+        Event::Command {
+            command: Command::Window(Operation::Center),
+        },
+        // 2: the strip is dragged left below, hiding half of window 0.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 3: the focus event queued below plays out here.
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(manual_offset_config())
+        .with_windows(5)
+        .on_iteration(1, |world, _state| {
+            assert_eq!(window_x(world, 0), CENTERED_X, "window 0 must be centered");
+
+            // Push the strip a full window width further left than the
+            // centering did, which drags window 0 off the left edge.
+            let strip_entity = active_strip_entity(world);
+            let displaced = {
+                let position = world.get::<Position>(strip_entity).expect("strip position");
+                Origin::new(position.0.x - TEST_WINDOW_WIDTH, position.0.y)
+            };
+            world.entity_mut(strip_entity).insert(Position(displaced));
+        })
+        .on_iteration(2, |_world, state| {
+            state.focus_window(0);
+        })
+        .on_iteration(3, |world, _state| {
+            assert!(
+                window_x(world, 0) >= 0,
+                "a window scrolled off the left edge must be brought back into view, got {}",
+                window_x(world, 0)
+            );
+            assert!(
+                !has_manual_offset(world),
+                "a manual offset that hides its own window is stale"
+            );
+        })
+        .run(commands);
+}
+
+/// Switching virtual workspaces re-places the strip from its saved origin, so
+/// the manual claim on the old offset goes away with the switch.
+#[test]
+fn test_center_dropped_on_virtual_workspace_switch() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        // 1: center window 0.
+        Event::Command {
+            command: Command::Window(Operation::Center),
+        },
+        // 2: move a window to VW1 and follow it there.
+        Event::Command {
+            command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+        },
+        // 3: back to VW0.
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(0)),
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(manual_offset_config())
+        .with_windows(5)
+        .on_iteration(1, |world, _state| {
+            assert!(has_manual_offset(world), "center must mark the strip");
+        })
+        .on_iteration(3, |world, _state| {
+            assert!(
+                !has_manual_offset(world),
+                "a workspace switch must invalidate the manual offset"
+            );
+        })
+        .run(commands);
+}
+
+/// Once the user drives the strip by hand, the earlier placement no longer
+/// describes where they want it.
+#[test]
+fn test_center_dropped_on_user_swipe() {
+    let commands = vec![
+        Event::MenuOpened { window_id: 0 },
+        // 1: center window 0.
+        Event::Command {
+            command: Command::Window(Operation::Center),
+        },
+        // 2: the user swipes the strip.
+        Event::Swipe {
+            delta: -0.2,
+            fingers: 3,
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(manual_offset_config())
+        .with_windows(5)
+        .on_iteration(1, |world, _state| {
+            assert!(has_manual_offset(world), "center must mark the strip");
+        })
+        .on_iteration(2, |world, _state| {
+            assert!(
+                !has_manual_offset(world),
+                "a user swipe must invalidate the manual offset"
+            );
+        })
+        .run(commands);
 }


### PR DESCRIPTION
Hi.

This is a bigger PR. The goal is to fix windows losing "centered" position all the time.
Since several files are modified, please have a thorough review of the changes.

### The problem

Center the focused window (`window center`, e.g. `cmd+alt+g`), then open a new
tab in the browser: the window jumps straight back to where it was. Same loss
when you focus a window on another display and come back to the centered one.

### Reproduce

1. `auto_center = false` (the default) and `[swipe] continuous = false`.
2. Several windows on one workspace, more than a display wide.
3. Focus a browser window, `paneru send-cmd window center`.
4. Open a new tab (`cmd+t`) — the window snaps back to the left edge.
5. Or: focus a window on another display, then focus the centered one again.

### Cause

`window center` centers by repositioning the *strip*, and nothing recorded that
the offset was deliberate. Any later `reshuffle_around` re-derives the offset
from the focused window's frame, and with `auto_center` off and
`continuous_swipe` off the edge invariant then pins the strip to the display's
left edge.

Two paths reach it without any layout having changed:

- A browser opening a tab re-emits an OS focus event for the window that
  already holds focus. `window_focused_trigger`'s `already_focused` branch
  reshuffled on every one of those.
- Returning from another display is a genuine focus change, so
  `autocenter_window_on_focus` runs — and it calls `reshuffle_around`
  unconditionally, even when `auto_center` is off.

### Fix

A repeat focus event now uses `ensure_visible` instead of `reshuffle_around`.
`ensure_visible_in_strip` is already the gentler primitive: a no-op while the
window is fully on screen, otherwise a scroll by exactly the off-screen
shortfall. A duplicate focus event carries no new layout information, so it
should not be able to re-derive the offset — but a window that *has* been
scrolled past an edge is still brought back.

For the paths that still reshuffle, `ManualStripOffset` marks a strip whose
offset the user placed by hand (`center`, `snap`). `reshuffle_layout_strip`
honours the mark for any window that is already fully visible, and drops it when
the window it is asked to expose is off-screen — a placement that hides its own
window is stale.

The mark carries a fingerprint of the strip's shape rather than a change tick:
the animator writes `Position` every frame and `layout_sizes_changed` turns that
into a `LayoutStrip` change, so change detection says "changed" on essentially
every frame. The fingerprint is the ordered column tops with their target
widths, which survives scrolling and tab promotion but not an add, remove,
reorder or resize. Swiping and workspace switches drop the mark too.

Also in here, both found on the way:

- `ensure_visible_in_strip` `return`ed out of its `for` loop in five places
  while consuming each `EnsureVisibleMarker` up front, so the first
  already-visible entity silently swallowed every other request that tick.
  Now `continue`.
- The same function clamped the entity into the viewport on both axes and then
  threw the vertical half away, keeping the strip's own `y`. It now uses the
  clamped `y` as well.

### Tests

New: center survives a repeated focus event; center survives a display
round-trip; center dropped on window add, on workspace switch, on user swipe; a
partly hidden window is still scrolled into view after a center; a unit test for
the fingerprint comparison.

Both halves were verified to carry weight by disabling each in turn — without
`ManualStripOffset` the display round-trip fails, without the `ensure_visible`
swap the repeat-focus case fails.

Full suite: 212 passing, clippy clean.

Generated with Claude Code
