### PR TITLE
feat: copy a window rule from the menu bar

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -297,6 +297,30 @@ horizontal_padding = 5
 bindings_passthrough = ["ctrl-h", "ctrl-l"]
 ```
 
+### Copying a rule from the menu bar
+
+Neither the bundle ID nor the exact window title is visible anywhere in the UI,
+so the Paneru menu bar has a **Copy Window Rule** entry. It puts a rule for the
+currently focused window on the clipboard, ready to paste:
+
+```toml
+[windows.ghostty]
+bundle_id = "com.mitchellh.ghostty"
+title = "^paneru — zsh$"
+# title = ".*"   # all windows of this app
+# app: Ghostty  role: AXWindow  subrole: AXStandardWindow
+# floating = true
+# manage = true
+# width = 0.5
+```
+
+The two matchers are live; everything else is a comment for you to uncomment.
+`title` is anchored and regex-escaped so it matches only this window — swap in
+the commented `.*` to cover every window of the app instead. The `app`, `role`
+and `subrole` line is there to tell one pasted rule from the next; none of those
+are matchable. When an `init.lua` is in charge, the snippet is written as a Lua
+table instead of TOML.
+
 ### Forcing management of LSUIElement or non-standard windows
 
 Some applications (e.g., BetterTouchTool, ProtonVPN) are flagged as background apps

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ https://github.com/user-attachments/assets/793e7eaa-7909-4086-8380-1fb7861f8780
   workspaces to stay organized within each context.
 - **Menu bar workspace indicator:** Shows the currently active virtual
   workspace in the macOS menu bar.
+- **Copy Window Rule:** A menu bar entry that puts a ready-to-paste
+  `[windows]` configuration rule for the focused window on the clipboard, so
+  you never have to guess an app's bundle id.
 - **Startup session restore:** Restores managed window layouts, virtual
   workspaces, and display assignments from the last saved state when Paneru
   starts.

--- a/crates/shared_types/src/argv.rs
+++ b/crates/shared_types/src/argv.rs
@@ -147,14 +147,14 @@ fn parse_mouse_move(argv: &[&str]) -> Result<MouseMove> {
 impl Command {
     /// The argv encoding of this command, as understood by [`parse_command`].
     ///
-    /// [`Command::Lua`] and [`Command::Layout`] have no encoding — they are
-    /// only ever issued in-process — and yield `None`.
+    /// [`Command::Lua`], [`Command::Layout`] and [`Operation::CopyRule`] have no
+    /// encoding — they are only ever issued in-process — and yield `None`.
     #[must_use]
     pub fn to_argv(&self) -> Option<Vec<String>> {
         let argv = match self {
             Command::Window(operation) => {
                 let mut argv = vec!["window".to_string()];
-                argv.extend(operation.to_argv());
+                argv.extend(operation.to_argv()?);
                 argv
             }
             Command::Mouse(MouseMove::ToNextDisplay) => {
@@ -170,10 +170,11 @@ impl Command {
 }
 
 impl Operation {
-    /// The argv tail following `window`, e.g. `["focus", "east"]`.
-    fn to_argv(&self) -> Vec<String> {
+    /// The argv tail following `window`, e.g. `["focus", "east"]`. `None` for
+    /// operations the command line cannot express.
+    fn to_argv(&self) -> Option<Vec<String>> {
         let owned = |args: &[&str]| args.iter().map(|arg| (*arg).to_string()).collect();
-        match self {
+        let argv = match self {
             Operation::Focus(direction) => vec!["focus".to_string(), direction.token()],
             Operation::Swap(direction) => vec!["swap".to_string(), direction.token()],
             Operation::Center => owned(&["center"]),
@@ -213,7 +214,10 @@ impl Operation {
             Operation::FocusManaged => owned(&["focus", "managed"]),
             Operation::RaiseFloating => owned(&["raise", "floating"]),
             Operation::ToggleFloatingLayer => owned(&["togglefloatlayer"]),
-        }
+            // Issued only by the menu bar; there is no verb to parse back.
+            Operation::CopyRule => return None,
+        };
+        Some(argv)
     }
 }
 

--- a/crates/shared_types/src/commands.rs
+++ b/crates/shared_types/src/commands.rs
@@ -267,6 +267,9 @@ pub enum Operation {
     /// Flips `FloatingLayer`, raises the other windows in the new top tier,
     /// and focuses the tier's last-focused window.
     ToggleFloatingLayer,
+    /// Copies a `[windows]` configuration rule for the focused window to the
+    /// clipboard. Never produced by parsing; the menu bar issues it directly.
+    CopyRule,
 }
 
 /// Defines operations that can be performed on the mouse.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,6 +13,7 @@ use tracing::{debug, error, info};
 mod query;
 
 use crate::config::Config;
+use crate::config::snippet::{RuleSubject, SnippetDialect, window_rule_snippet};
 use crate::ecs::display::FloatingLayer;
 use crate::ecs::focus::FocusHistory;
 use crate::ecs::layout::{
@@ -95,6 +96,13 @@ pub fn register_commands(app: &mut bevy::app::App) {
             snap_window,
         ),
     );
+    // A separate registration because the tuple above is already at Bevy's
+    // 20-system limit.
+    //
+    // A default dialect so the mock harness has one; the real app overwrites it
+    // once it knows whether a Lua script took over the configuration.
+    app.init_resource::<SnippetDialect>();
+    app.add_systems(PreUpdate, copy_window_rule);
 }
 
 pub fn filter_window_operations<'a, F: Fn(&Operation) -> bool>(
@@ -1000,6 +1008,55 @@ fn manage_window(
     {
         strip.append(entity);
         commands.reshuffle_around(entity);
+    }
+}
+
+/// Copies a `[windows]` configuration rule for the focused window to the
+/// clipboard, so the user can paste a working starting point instead of
+/// guessing the app's bundle id and transcribing the title into a regex.
+fn copy_window_rule(
+    mut messages: MessageReader<Event>,
+    windows: Windows,
+    apps: Query<&Application>,
+    dialect: Res<SnippetDialect>,
+    mut commands: Commands,
+) {
+    if filter_window_operations(&mut messages, |op| matches!(op, Operation::CopyRule))
+        .next()
+        .is_none()
+    {
+        return;
+    }
+
+    let Some((window, app)) = windows
+        .focused()
+        .and_then(|(window, _)| windows.find_parent(window.id()))
+        .and_then(|(window, _, app_entity)| Some((window, apps.get(app_entity).ok()?)))
+    else {
+        debug!("no focused window to copy a rule for");
+        return;
+    };
+
+    let bundle_id = app.bundle_id().unwrap_or_default();
+    let title = window.title().unwrap_or_default();
+    let role = window.role().unwrap_or_default();
+    let subrole = window.subrole().unwrap_or_default();
+    let snippet = window_rule_snippet(
+        *dialect,
+        &RuleSubject {
+            app_name: app.name(),
+            bundle_id: &bundle_id,
+            title: &title,
+            role: &role,
+            subrole: &subrole,
+        },
+    );
+
+    if crate::pasteboard::copy_to_clipboard(&snippet) {
+        info!("copied window rule for {}", app.name());
+        commands.flash_message("Window rule copied".to_owned(), 1.5);
+    } else {
+        error!("unable to copy the window rule to the clipboard");
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ use crate::{platform::CFStringRef, util::AXUIWrapper};
 
 pub mod decorations;
 pub mod padding;
+pub mod snippet;
 pub mod swipe;
 
 /// A `LazyLock` that determines the path to the application's configuration file.

--- a/src/config/snippet.rs
+++ b/src/config/snippet.rs
@@ -1,0 +1,266 @@
+//! Generates a ready-to-paste `[windows]` rule for a window.
+//!
+//! Only two fields in a window rule are matchers: `title` (a regex, matched
+//! unanchored) and `bundle_id` (exact string equality). See
+//! [`crate::config::Config::find_window_properties`]. Everything else a rule can
+//! carry is an effect, so the snippet emits the two matchers live and leaves the
+//! rest — plus the window's identity, which no matcher can use — as comments.
+
+use bevy::ecs::resource::Resource;
+
+/// Which configuration language the snippet is written in. A Lua `init.lua`
+/// disables the TOML file entirely (see [`crate::config::CONFIGURATION_FILE`]),
+/// so the snippet has to follow whichever one is in charge.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Resource)]
+pub enum SnippetDialect {
+    #[default]
+    Toml,
+    Lua,
+}
+
+/// The window a rule is being written for.
+#[derive(Clone, Copy, Debug)]
+pub struct RuleSubject<'a> {
+    pub app_name: &'a str,
+    pub bundle_id: &'a str,
+    pub title: &'a str,
+    pub role: &'a str,
+    pub subrole: &'a str,
+}
+
+/// Builds the snippet for `subject` in `dialect`.
+#[must_use]
+pub fn window_rule_snippet(dialect: SnippetDialect, subject: &RuleSubject<'_>) -> String {
+    let key = rule_key(subject.app_name);
+    let title = title_pattern(subject.title);
+    // An anchored empty title matches nothing useful, so the wildcard is already
+    // the live pattern and there is no alternative left to suggest.
+    let wildcard_alternative = !subject.title.is_empty();
+    let identity = identity_comment(subject);
+    let bundle_id = quote(subject.bundle_id);
+
+    let mut lines = Vec::new();
+    match dialect {
+        SnippetDialect::Toml => {
+            lines.push(format!("[windows.{key}]"));
+            if subject.bundle_id.is_empty() {
+                lines.push("# bundle_id = \"\"   # unknown; rule matches every app".to_owned());
+            } else {
+                lines.push(format!("bundle_id = \"{bundle_id}\""));
+            }
+            lines.push(format!("title = \"{title}\""));
+            if wildcard_alternative {
+                lines.push("# title = \".*\"   # all windows of this app".to_owned());
+            }
+            lines.push(format!("# {identity}"));
+            lines.push("# floating = true".to_owned());
+            lines.push("# manage = true".to_owned());
+            lines.push("# width = 0.5".to_owned());
+        }
+        SnippetDialect::Lua => {
+            lines.push("windows = {".to_owned());
+            lines.push(format!("  {key} = {{"));
+            if subject.bundle_id.is_empty() {
+                lines.push(
+                    "    -- bundle_id = \"\",   -- unknown; rule matches every app".to_owned(),
+                );
+            } else {
+                lines.push(format!("    bundle_id = \"{bundle_id}\","));
+            }
+            lines.push(format!("    title = \"{title}\","));
+            if wildcard_alternative {
+                lines.push("    -- title = \".*\",   -- all windows of this app".to_owned());
+            }
+            lines.push(format!("    -- {identity}"));
+            lines.push("    -- floating = true,".to_owned());
+            lines.push("    -- manage = true,".to_owned());
+            lines.push("    -- width = 0.5,".to_owned());
+            lines.push("  },".to_owned());
+            lines.push("}".to_owned());
+        }
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+/// Turns an application name into a table key: lowercased, with every run of
+/// non-alphanumerics collapsed into a single underscore.
+fn rule_key(app_name: &str) -> String {
+    let mut key = String::with_capacity(app_name.len());
+    for character in app_name.chars() {
+        if character.is_ascii_alphanumeric() {
+            key.push(character.to_ascii_lowercase());
+        } else if !key.ends_with('_') {
+            key.push('_');
+        }
+    }
+    let trimmed = key.trim_matches('_');
+    if trimmed.is_empty() {
+        "window".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+/// The regex a rule should carry to match exactly this title. Escaped so the
+/// title's own punctuation stays literal, then anchored so it does not also
+/// match longer titles — `is_match` is unanchored.
+fn title_pattern(title: &str) -> String {
+    if title.is_empty() {
+        return ".*".to_owned();
+    }
+    quote(&format!("^{}$", regex::escape(title)))
+}
+
+/// Escapes a string for a TOML basic string or a Lua double-quoted string. Runs
+/// after `regex::escape`, whose backslashes need escaping in turn.
+fn quote(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(character),
+        }
+    }
+    out
+}
+
+/// The comment identifying the window. None of these are matchable, so they are
+/// here only to tell the pasted rule apart from the next one.
+fn identity_comment(subject: &RuleSubject<'_>) -> String {
+    let name = if subject.app_name.is_empty() {
+        "?"
+    } else {
+        subject.app_name
+    };
+    let role = if subject.role.is_empty() {
+        "?"
+    } else {
+        subject.role
+    };
+    let subrole = if subject.subrole.is_empty() {
+        "?"
+    } else {
+        subject.subrole
+    };
+    format!("app: {name}  role: {role}  subrole: {subrole}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::InnerConfig;
+
+    fn subject<'a>(app_name: &'a str, bundle_id: &'a str, title: &'a str) -> RuleSubject<'a> {
+        RuleSubject {
+            app_name,
+            bundle_id,
+            title,
+            role: "AXWindow",
+            subrole: "AXStandardWindow",
+        }
+    }
+
+    #[test]
+    fn toml_snippet_has_both_matchers() {
+        let snippet = window_rule_snippet(
+            SnippetDialect::Toml,
+            &subject("Ghostty", "com.mitchellh.ghostty", "paneru"),
+        );
+        assert_eq!(
+            snippet,
+            concat!(
+                "[windows.ghostty]\n",
+                "bundle_id = \"com.mitchellh.ghostty\"\n",
+                "title = \"^paneru$\"\n",
+                "# title = \".*\"   # all windows of this app\n",
+                "# app: Ghostty  role: AXWindow  subrole: AXStandardWindow\n",
+                "# floating = true\n",
+                "# manage = true\n",
+                "# width = 0.5\n",
+            )
+        );
+    }
+
+    #[test]
+    fn lua_snippet_has_both_matchers() {
+        let snippet = window_rule_snippet(
+            SnippetDialect::Lua,
+            &subject("Ghostty", "com.mitchellh.ghostty", "paneru"),
+        );
+        assert_eq!(
+            snippet,
+            concat!(
+                "windows = {\n",
+                "  ghostty = {\n",
+                "    bundle_id = \"com.mitchellh.ghostty\",\n",
+                "    title = \"^paneru$\",\n",
+                "    -- title = \".*\",   -- all windows of this app\n",
+                "    -- app: Ghostty  role: AXWindow  subrole: AXStandardWindow\n",
+                "    -- floating = true,\n",
+                "    -- manage = true,\n",
+                "    -- width = 0.5,\n",
+                "  },\n",
+                "}\n",
+            )
+        );
+    }
+
+    /// The escaping order is the part that can silently go wrong: `regex::escape`
+    /// adds backslashes, which then need escaping again for the config string.
+    /// Parse the snippet back and match the very window it was made from.
+    #[test]
+    fn generated_toml_matches_the_window_it_came_from() {
+        let title = r#"Find "a.b" (2) \ [x]"#;
+        let bundle_id = "com.apple.Terminal";
+        let snippet = window_rule_snippet(SnippetDialect::Toml, &subject("Term", bundle_id, title));
+
+        let config = InnerConfig::new(&snippet).expect("snippet parses as TOML config");
+        let rules = config
+            .windows
+            .as_ref()
+            .expect("snippet defines a windows table");
+        let rule = rules.values().next().expect("exactly one rule");
+        assert!(rule.title.is_match(title));
+        assert_eq!(rule.bundle_id.as_deref(), Some(bundle_id));
+    }
+
+    #[test]
+    fn anchored_pattern_rejects_a_longer_title() {
+        let snippet = window_rule_snippet(SnippetDialect::Toml, &subject("Term", "com.x", "build"));
+        let config = InnerConfig::new(&snippet).expect("snippet parses as TOML config");
+        let rules = config.windows.as_ref().expect("windows table");
+        let rule = rules.values().next().expect("exactly one rule");
+        assert!(rule.title.is_match("build"));
+        assert!(!rule.title.is_match("rebuild all"));
+    }
+
+    #[test]
+    fn empty_title_falls_back_to_wildcard() {
+        let snippet = window_rule_snippet(SnippetDialect::Toml, &subject("Term", "com.x", ""));
+        assert!(snippet.contains("title = \".*\"\n"));
+        assert!(!snippet.contains("# title = \".*\""));
+    }
+
+    #[test]
+    fn empty_bundle_id_is_commented_out() {
+        let snippet = window_rule_snippet(SnippetDialect::Toml, &subject("Term", "", "hello"));
+        assert!(snippet.contains("# bundle_id = \"\"   # unknown; rule matches every app\n"));
+        let config = InnerConfig::new(&snippet).expect("snippet parses as TOML config");
+        let rules = config.windows.as_ref().expect("windows table");
+        assert!(rules.values().next().expect("one rule").bundle_id.is_none());
+    }
+
+    #[test]
+    fn rule_keys_are_sanitized() {
+        assert_eq!(rule_key("Ghostty"), "ghostty");
+        assert_eq!(rule_key("Visual Studio Code"), "visual_studio_code");
+        assert_eq!(rule_key("1Password 8"), "1password_8");
+        assert_eq!(rule_key("  —  "), "window");
+        assert_eq!(rule_key(""), "window");
+    }
+}

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -25,6 +25,7 @@ use derive_more::{Deref, DerefMut};
 use tracing::{Level, error, instrument, warn};
 
 use crate::commands::register_commands;
+use crate::config::snippet::SnippetDialect;
 use crate::config::{CONFIGURATION_FILE, Config, WindowParams};
 use crate::ecs::layout::LayoutStrip;
 use crate::ecs::state::PaneruState;
@@ -687,6 +688,14 @@ pub fn setup_bevy_app(sender: EventSender, receiver: Receiver<Event>) -> Result<
         .insert_non_send(flash_message_manager)
         .insert_non_send(menu_bar_manager)
         .insert_non_send(receiver);
+
+    // `CONFIGURATION_FILE` is `None` exactly when an `init.lua` took the TOML
+    // file out of play, so copied rules have to be written in Lua instead.
+    app.insert_resource(if CONFIGURATION_FILE.is_none() {
+        SnippetDialect::Lua
+    } else {
+        SnippetDialect::Toml
+    });
 
     if let Some(previous_state) =
         PaneruState::load_from_file(&PaneruState::default_state_file_path())

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod lua;
 mod manager;
 mod menubar;
 mod overlay;
+mod pasteboard;
 mod platform;
 mod reader;
 mod util;

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -62,6 +62,11 @@ define_class!(
             self.send_command(Command::Window(Operation::Manage));
         }
 
+        #[unsafe(method(copyWindowRule:))]
+        fn copy_window_rule(&self, _: &NSMenuItem) {
+            self.send_command(Command::Window(Operation::CopyRule));
+        }
+
         #[unsafe(method(openAccessibilitySettings:))]
         fn open_accessibility_settings(&self, _: &NSMenuItem) {
             if let Err(error) = std::process::Command::new("/usr/bin/open")
@@ -117,6 +122,7 @@ pub struct MenuBarManager {
     width_items: Vec<(i32, Retained<NSMenuItem>)>,
     managed_window_items: Vec<Retained<NSMenuItem>>,
     manage_item: Option<Retained<NSMenuItem>>,
+    copy_rule_item: Option<Retained<NSMenuItem>>,
     configured_widths: Vec<i32>,
     current_content: Option<MenuBarContent>,
 }
@@ -163,6 +169,7 @@ impl MenuBarManager {
             width_items: Vec::new(),
             managed_window_items: Vec::new(),
             manage_item: None,
+            copy_rule_item: None,
             configured_widths: Vec::new(),
             current_content: None,
         }
@@ -219,6 +226,9 @@ impl MenuBarManager {
         if let Some(manage_item) = &self.manage_item {
             manage_item.setEnabled(enablement.toggle_managed);
         }
+        if let Some(copy_rule_item) = &self.copy_rule_item {
+            copy_rule_item.setEnabled(enablement.toggle_managed);
+        }
         for (percentage, item) in &self.width_items {
             let selected = focused_width_ratio
                 .is_some_and(|ratio| (ratio.mul_add(100.0, -f64::from(*percentage))).abs() < 1.0);
@@ -243,6 +253,7 @@ impl MenuBarManager {
         self.width_items.clear();
         self.managed_window_items.clear();
         self.manage_item = None;
+        self.copy_rule_item = None;
 
         let status = self.add_item("Paneru — Running", None);
         status.setEnabled(false);
@@ -262,6 +273,9 @@ impl MenuBarManager {
         let manage = self.add_item("Toggle Managed", Some(sel!(toggleManaged:)));
         self.managed_window_items.push(center);
         self.manage_item = Some(manage);
+
+        self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
+        self.copy_rule_item = Some(self.add_item("Copy Window Rule", Some(sel!(copyWindowRule:))));
 
         self.menu.addItem(&NSMenuItem::separatorItem(self.mtm));
         self.add_item("Quit Paneru", Some(sel!(quitPaneru:)));

--- a/src/pasteboard.rs
+++ b/src/pasteboard.rs
@@ -1,0 +1,19 @@
+//! The general pasteboard, wrapped so ECS systems never touch `objc2` directly.
+
+use objc2_app_kit::{NSPasteboard, NSPasteboardTypeString};
+use objc2_foundation::NSString;
+use tracing::warn;
+
+/// Replaces the general pasteboard's contents with `text`. Returns `false` if
+/// `AppKit` refused the write, in which case nothing was copied.
+pub fn copy_to_clipboard(text: &str) -> bool {
+    let pasteboard = NSPasteboard::generalPasteboard();
+    pasteboard.clearContents();
+    // SAFETY: reading an AppKit constant that lives for the process lifetime.
+    let string_type = unsafe { NSPasteboardTypeString };
+    let copied = pasteboard.setString_forType(&NSString::from_str(text), string_type);
+    if !copied {
+        warn!("unable to write to the general pasteboard");
+    }
+    copied
+}


### PR DESCRIPTION
Writing a `[windows]` rule means knowing the app's bundle id and the window's
exact title. Neither is visible anywhere in Paneru's UI, and the only way to
read them today is `paneru send-cmd printstate` and squinting at the log.

Adds a **Copy Window Rule** entry to the menu bar. It puts a rule for the
currently focused window on the clipboard:

```toml
[windows.ghostty]
bundle_id = "com.mitchellh.ghostty"
title = "^paneru — zsh$"
# title = ".*"   # all windows of this app
# app: Ghostty  role: AXWindow  subrole: AXStandardWindow
# floating = true
# manage = true
# width = 0.5
```

Only `title` and `bundle_id` are matchers in `find_window_properties`, so those
are the two live lines; the rest is commented. `title` is `regex::escape`d and
anchored, since `is_match` is unanchored and an unescaped title with a `.` or
`(` in it would either fail to compile or match the wrong windows — the
commented `.*` covers the "every window of this app" case instead. The `app` /
`role` / `subrole` comment is only there to tell one pasted rule from the next;
none of it is matchable.

When an `init.lua` has taken the TOML file out of play (`CONFIGURATION_FILE`
is `None`), the snippet is emitted as a Lua table instead.

### Notes

- `Operation::CopyRule` is issued only by the menu bar, following the
  `Command::Lua` / `Command::Layout` precedent. `Operation::to_argv` now
  returns `Option<Vec<String>>` so it can say "no argv encoding" the same way
  `Command::to_argv` already does.
- `NSPasteboard` use is isolated in `src/pasteboard.rs`, per AGENTS.md §2
  (no `objc2` in ECS systems). No `Cargo.toml` change: `objc2-app-kit` is
  already pulled in with default features, which cover `NSPasteboard`.
- Snippet generation is a pure function in `src/config/snippet.rs`. The escaping
  order is the part that can silently go wrong — `regex::escape` adds
  backslashes that then need escaping again for the config string — so one test
  parses the generated TOML back through `InnerConfig` and asserts the rule
  matches the very title it was generated from.
- The new system is registered separately because the existing `PreUpdate` tuple
  was already at Bevy's 20-system limit.

### Testing

`cargo fmt`, `cargo clippy --all-targets` clean; `cargo test` (212) and
`cargo test --features lua,vendored,luajit` (285) pass. Verified by hand on a
release build: focused a window, clicked the entry, pasted the rule back into
`paneru.toml` and confirmed it takes effect.

🤖 Generated with Claude Code
