### PR TITLE
fix(lua): make ws:width() actually resize the focused window

### DIFF
--- a/src/ecs/layout_ops.rs
+++ b/src/ecs/layout_ops.rs
@@ -185,6 +185,19 @@ fn apply(
                     }
                 }
             }
+            // A stored ratio does not resize anything by itself: no system
+            // reacts to `WidthRatio` changes, and the next bounds sync
+            // recomputes it from the live frame, discarding the request. The
+            // interactive resize path (`resize_window`, used by the menubar
+            // width picker) does the real work — pixel size, viewport
+            // clamping, stacked siblings, reshuffle — but only for the
+            // focused window, so route through it when we can.
+            if windows.focused().is_some_and(|(_, focused)| focused == entity) {
+                commands.trigger(SendMessageTrigger(Event::Command {
+                    command: Command::Window(Operation::SetWidth(ratio)),
+                }));
+                return;
+            }
             commands.reshuffle_around(entity);
         }
 

--- a/src/tests/tiling.rs
+++ b/src/tests/tiling.rs
@@ -399,6 +399,31 @@ fn test_window_can_resize_to_two_display_widths_and_scroll() {
         .run(commands);
 }
 
+/// A `LayoutOp::SetWidth` handed back by a Lua handler must resize the focused
+/// window just like the interactive `Operation::SetWidth` path, instead of only
+/// storing a `WidthRatio` that nothing consumes and the next bounds sync
+/// overwrites from the live frame.
+#[test]
+fn test_lua_set_width_layout_op_resizes_the_focused_window() {
+    use paneru_shared_types::windowset::LayoutOp;
+
+    const VIEWPORT_HEIGHT: i32 = TEST_DISPLAY_HEIGHT - TEST_MENUBAR_HEIGHT;
+
+    let commands = vec![Event::Command {
+        command: Command::Layout(vec![LayoutOp::SetWidth {
+            window: 0,
+            ratio: 0.5,
+        }]),
+    }];
+
+    TestHarness::new()
+        .with_windows(1)
+        .on_iteration(2, |world, _state| {
+            assert_window_size!(world, 0, TEST_DISPLAY_WIDTH / 2, VIEWPORT_HEIGHT);
+        })
+        .run(commands);
+}
+
 fn assert_oversized_window_is_pannable(world: &mut World, id: i32) {
     let mut query = world.query::<&crate::manager::Window>();
     let window = query


### PR DESCRIPTION
## Problem

`ws:width(id, ratio)` from a Lua handler (via `paneru.windows` or a bind) is silently ignored — the window never resizes, with no error or log.

```lua
paneru.bind("ctrl + alt - t", function(ws)
  return ws:width(ws:focused(), 0.66)  -- accepted, nothing happens
end)
```

## Root cause

`apply_layout_ops` handles `LayoutOp::SetWidth` by inserting a `WidthRatio` component and reshuffling. Nothing consumes that insert:

- no system reacts to `Changed<WidthRatio>`, and
- the bounds sync recomputes `WidthRatio` **from the live frame** (`src/ecs/systems.rs` `Changed<Bounds>` query, `src/ecs/triggers.rs`), overwriting the injected ratio on the next pass.

So the request is dropped before any layout consumes it. (Verified end-to-end with a canary op: the Lua → outbox → `apply_layout_ops` pipeline delivers the op fine; the loss happens after the component insert.)

## Fix

Route the **focused** window's `SetWidth` through the interactive resize path — the same `Operation::SetWidth` command the menubar width picker uses — which already does the real work: pixel sizing against the viewport, clamping, stacked-sibling widths, reshuffle, animation. Non-focused targets keep the previous stored-ratio behavior (conservative: `resize_window` only acts on the focused window).

This mirrors the `VirtualNumber` re-emit pattern already used in the same match block.

## Why it matters

`ws:width` is a documented core primitive of the scripting API (SCRIPTING.md §6, the "pure window set" example uses it). With it working, scripts can express layouts static rules cannot — e.g. per-display spawn widths:

```lua
paneru.on("window_spawned", function(event)
  paneru.windows(function(ws)
    local d = ws:display_of(event.window_id)
    if not d then return end
    return ws:width(event.window_id, d.width > 1800 and 0.5 or 1.0)
  end)
end)
```

(full width on the laptop panel, half width on a large external — running as my daily driver on this patch)

## Testing

- New `TestHarness` regression test: `Command::Layout([SetWidth])` on the focused window must land the same size as the interactive path.
- Full suite: **279 passed / 0 failed** (`cargo test --features "lua,luajit,vendored"`, macOS 15 / M1 Max).
