### PR TITLE
fix: focus and expose the window a Cmd-Tab switched to

### DIFF
--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -138,6 +138,19 @@ fn signature_matches(current: &[(Entity, i32)], stored: &[(Entity, i32)]) -> boo
         })
 }
 
+/// The strip offset that shows all of a window sitting at `layout` within the
+/// strip, starting from `origin` and moving no further than the window's
+/// shortfall past a viewport edge. Returns `origin` unchanged when the window
+/// already fits.
+pub(crate) fn origin_exposing(
+    layout: Origin,
+    size: Size,
+    origin: Origin,
+    viewport: IRect,
+) -> Origin {
+    clamp_origin_to_viewport(layout + origin, size, viewport) - layout
+}
+
 impl Plugin for LayoutEventsPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
@@ -1504,6 +1517,31 @@ mod tests {
         assert!(!signature_matches(&[(first, 420), (second, 400)], &stored));
         assert!(!signature_matches(&[(second, 400), (first, 400)], &stored));
         assert!(!signature_matches(&[(first, 400)], &stored));
+    }
+
+    #[test]
+    fn origin_exposing_moves_only_by_the_shortfall() {
+        let viewport = IRect::new(0, 0, 1000, 800);
+        let size = Size::new(400, 700);
+
+        // Window at layout x 0 with the strip scrolled 600px to the left sits
+        // entirely off-screen; the strip has to come back to 0.
+        assert_eq!(
+            origin_exposing(Origin::new(0, 0), size, Origin::new(-600, 0), viewport),
+            Origin::new(0, 0)
+        );
+
+        // A window past the right edge only moves by what hangs over it.
+        assert_eq!(
+            origin_exposing(Origin::new(800, 0), size, Origin::ZERO, viewport),
+            Origin::new(-200, 0)
+        );
+
+        // Already fully visible: the offset is left alone.
+        assert_eq!(
+            origin_exposing(Origin::new(100, 0), size, Origin::new(50, 0), viewport),
+            Origin::new(50, 0)
+        );
     }
 
     #[test]

--- a/src/ecs/layout.rs
+++ b/src/ecs/layout.rs
@@ -1191,7 +1191,7 @@ fn ensure_visible_in_strip(
         }
         // Each marker is independent, and its own marker was already consumed
         // above: bailing out of the loop would silently drop the rest.
-        let Some((_, strip_entity, strip_position, child, active_marker, _)) =
+        let Some((_, strip_entity, strip_position, child, active_marker, strip_reposition)) =
             strips.into_iter().find(|s| s.0.contains(entity))
         else {
             continue;
@@ -1209,8 +1209,12 @@ fn ensure_visible_in_strip(
         };
         let viewport = display.actual_display_bounds(dock, &config);
 
-        // Where the entity would appear if the strip stays put.
-        let candidate_min = layout_position.0 + strip_position.0;
+        // Where the entity would appear once the strip settles. Mid-animation
+        // the strip's current position is on its way somewhere else, so the
+        // target offset is what the window's slot will actually be measured
+        // against - the same projection `reshuffle_layout_strip` makes.
+        let strip_target = strip_reposition.map_or(strip_position.0, |reposition| reposition.0);
+        let candidate_min = layout_position.0 + strip_target;
         // Clamp into the viewport. If already on-screen, this is a no-op and
         // the strip target equals its current position — no movement.
         let clamped_min = clamp_origin_to_viewport(candidate_min, size, viewport);
@@ -1220,13 +1224,13 @@ fn ensure_visible_in_strip(
         // Both axes come from the clamp: it is still the minimum shortfall, and
         // keeping the strip's own y here would silently drop the vertical
         // correction for a window sitting above the menu bar.
-        let strip_target = clamped_min - layout_position.0;
-        trace!("ensure_visible_in_strip: entity {entity}, scroll strip to {strip_target}");
+        let scroll_to = clamped_min - layout_position.0;
+        trace!("ensure_visible_in_strip: entity {entity}, scroll strip to {scroll_to}");
         // Scrolling to expose a window overrides whatever the user placed here.
         if let Ok(mut cmd) = commands.get_entity(strip_entity) {
             cmd.try_remove::<ManualStripOffset>();
         }
-        commands.reposition_entity(strip_entity, strip_target);
+        commands.reposition_entity(strip_entity, scroll_to);
     }
 }
 

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -1174,8 +1174,17 @@ pub(crate) fn show_active_workspace(
             entity_commands.try_remove::<PreviousStripPosition>();
         }
 
+        // A window of this strip already holding focus is what activated it in
+        // the first place - a Cmd-Tab straight into one of its windows. The
+        // remembered focus is a fallback for a plain workspace switch, so it
+        // must not pull focus away from that window.
+        let keeps_focus = windows
+            .focused()
+            .is_some_and(|(_, current_focus)| strip.contains(current_focus));
+
         if config.virtual_workspace_animations() {
-            if let Some(focus) = *focus
+            if !keeps_focus
+                && let Some(focus) = *focus
                 && strip.contains(focus)
             {
                 spawn_restore_focus_guard(focus, &mut commands);
@@ -1187,9 +1196,7 @@ pub(crate) fn show_active_workspace(
             position.0 = *origin;
         }
 
-        if let Some((_, current_focus)) = windows.focused()
-            && strip.contains(current_focus)
-        {
+        if keeps_focus {
             return;
         }
 

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -10,7 +10,6 @@ use bevy::ecs::query::{Added, Has, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
 use bevy::ecs::system::{Commands, Local, ParamSet, Populated, Query, Res, ResMut, Single};
-use bevy::math::IRect;
 use bevy::time::common_conditions::on_timer;
 use std::collections::HashSet;
 use std::time::Duration;
@@ -20,7 +19,7 @@ use super::{ActiveDisplayMarker, SpawnWindowTrigger};
 use crate::commands::{Direction, MoveFocus, Operation, filter_window_operations};
 use crate::config::Config;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER, clamp_origin_to_viewport};
+use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER, origin_exposing};
 use crate::ecs::params::{ActiveDisplay, WindowCtx, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, DockPosition, FocusedMarker, Initializing, ManualStripOffset,
@@ -1094,21 +1093,27 @@ fn move_virtual_workspace_bind(
     debug!("Moving {focused_entity} to new virtual space {target_virtual_index}");
 }
 
-/// The strip offset that shows all of `focus`, starting from `origin` and
-/// moving no further than the window's shortfall past a viewport edge.
-fn origin_exposing(
-    focus: Entity,
-    origin: Origin,
-    viewport: IRect,
+/// The column of `strip` whose window sits nearest the display's horizontal
+/// centre. Stands in for the focus a strip never had when it is parked, so
+/// that returning to it lands on whatever the user was looking at.
+fn column_closest_to_center(
+    strip: &LayoutStrip,
+    display: &Display,
     windows: &Windows,
-) -> Option<Origin> {
-    let layout = windows.layout_position(focus)?.0;
-    let size = windows.size(focus)?;
-    Some(clamp_origin_to_viewport(layout + origin, size, viewport) - layout)
+) -> Option<Entity> {
+    let display_center = display.bounds().center().x;
+    strip
+        .all_columns()
+        .into_iter()
+        .filter_map(|candidate| {
+            let center = windows.moving_frame(candidate)?.center().x;
+            Some((candidate, (center - display_center).abs()))
+        })
+        .min_by_key(|(_, distance)| *distance)
+        .map(|(candidate, _)| candidate)
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
-#[allow(clippy::too_many_lines)]
 pub(crate) fn show_active_workspace(
     activated: Single<Entity, Added<ActiveWorkspaceMarker>>,
     windows: Windows,
@@ -1139,18 +1144,7 @@ pub(crate) fn show_active_workspace(
             let mut focus =
                 current_focus.and_then(|(_, entity)| strip.contains(entity).then_some(entity));
             if focus.is_none() {
-                let display_center = active_display.bounds().center().x;
-                let closest = strip
-                    .all_columns()
-                    .into_iter()
-                    .filter_map(|candidate| {
-                        let center = windows.moving_frame(candidate)?.center().x;
-                        let distance = (center - display_center).abs();
-                        Some((candidate, distance))
-                    })
-                    .min_by_key(|(_, dist)| *dist)
-                    .map(|min| min.0);
-                focus = closest;
+                focus = column_closest_to_center(strip, active_display, &windows);
                 debug!("No previous focus, taking centered one {focus:?}.");
             }
 
@@ -1218,13 +1212,11 @@ pub(crate) fn show_active_workspace(
         // its `ActiveWorkspaceMarker` is added.
         let origin = arriving_focus
             .and_then(|focus_entity| {
+                let layout = windows.layout_position(focus_entity)?.0;
+                let size = windows.size(focus_entity)?;
                 let (display, dock) = displays.get(child.parent()).ok()?;
-                origin_exposing(
-                    focus_entity,
-                    *origin,
-                    display.actual_display_bounds(dock, &config),
-                    &windows,
-                )
+                let viewport = display.actual_display_bounds(dock, &config);
+                Some(origin_exposing(layout, size, *origin, viewport))
             })
             .unwrap_or(*origin);
 

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -1,5 +1,5 @@
 use bevy::app::{App, Plugin, PostUpdate, PreUpdate, Update};
-use bevy::ecs::change_detection::DetectChangesMut;
+use bevy::ecs::change_detection::{DetectChanges as _, DetectChangesMut, Ref};
 use bevy::ecs::component::Component;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
@@ -10,6 +10,7 @@ use bevy::ecs::query::{Added, Has, With, Without};
 use bevy::ecs::schedule::IntoScheduleConfigs as _;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists};
 use bevy::ecs::system::{Commands, Local, ParamSet, Populated, Query, Res, ResMut, Single};
+use bevy::math::IRect;
 use bevy::time::common_conditions::on_timer;
 use std::collections::HashSet;
 use std::time::Duration;
@@ -19,7 +20,7 @@ use super::{ActiveDisplayMarker, SpawnWindowTrigger};
 use crate::commands::{Direction, MoveFocus, Operation, filter_window_operations};
 use crate::config::Config;
 use crate::ecs::focus::FocusHistory;
-use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER};
+use crate::ecs::layout::{LayoutStrip, PARKED_STRIP_SLIVER, clamp_origin_to_viewport};
 use crate::ecs::params::{ActiveDisplay, WindowCtx, Windows};
 use crate::ecs::{
     ActiveWorkspaceMarker, DockPosition, FocusedMarker, Initializing, ManualStripOffset,
@@ -1093,12 +1094,27 @@ fn move_virtual_workspace_bind(
     debug!("Moving {focused_entity} to new virtual space {target_virtual_index}");
 }
 
+/// The strip offset that shows all of `focus`, starting from `origin` and
+/// moving no further than the window's shortfall past a viewport edge.
+fn origin_exposing(
+    focus: Entity,
+    origin: Origin,
+    viewport: IRect,
+    windows: &Windows,
+) -> Option<Origin> {
+    let layout = windows.layout_position(focus)?.0;
+    let size = windows.size(focus)?;
+    Some(clamp_origin_to_viewport(layout + origin, size, viewport) - layout)
+}
+
 #[instrument(level = Level::DEBUG, skip_all)]
+#[allow(clippy::too_many_lines)]
 pub(crate) fn show_active_workspace(
     activated: Single<Entity, Added<ActiveWorkspaceMarker>>,
     windows: Windows,
     mut workspaces: RestorableStrips,
-    displays: Query<&Display>,
+    displays: Query<(&Display, Option<&DockPosition>)>,
+    focus_markers: Query<Ref<FocusedMarker>>,
     config: Res<Config>,
     mut commands: Commands,
 ) {
@@ -1116,7 +1132,7 @@ pub(crate) fn show_active_workspace(
         .filter(|(entity, _, strip, _, _, _)| strip.id() == workspace_id && *entity != *activated);
 
     for (entity, mut position, strip, child, previous, moving) in current_workspace {
-        let Ok(active_display) = displays.get(child.parent()) else {
+        let Ok((active_display, _)) = displays.get(child.parent()) else {
             continue;
         };
         if previous.is_none() {
@@ -1162,7 +1178,7 @@ pub(crate) fn show_active_workspace(
         }
     }
 
-    let Ok((_, mut position, strip, _, previous_position, _)) = workspaces.get_mut(*activated)
+    let Ok((_, mut position, strip, child, previous_position, _)) = workspaces.get_mut(*activated)
     else {
         return;
     };
@@ -1178,9 +1194,39 @@ pub(crate) fn show_active_workspace(
         // the first place - a Cmd-Tab straight into one of its windows. The
         // remembered focus is a fallback for a plain workspace switch, so it
         // must not pull focus away from that window.
-        let keeps_focus = windows
+        let focused = windows
             .focused()
-            .is_some_and(|(_, current_focus)| strip.contains(current_focus));
+            .map(|(_, entity)| entity)
+            .filter(|entity| strip.contains(*entity));
+        let keeps_focus = focused.is_some();
+
+        // Only a focus that arrived with this activation gets the strip moved
+        // for it. A window that held focus all along - switching back from an
+        // empty workspace, say - keeps the offset the user left behind, even
+        // if they had scrolled it out of sight.
+        let arriving_focus = focused.filter(|entity| {
+            focus_markers
+                .get(*entity)
+                .is_ok_and(|marker| marker.is_added())
+        });
+
+        // The saved origin describes where the strip sat when it was parked,
+        // which says nothing about the window that just took focus: it can
+        // easily land mostly off-screen. Scroll the strip the minimum amount
+        // needed to expose it, the same correction `ensure_visible_in_strip`
+        // makes - it cannot do it here, because it skips a strip on the frame
+        // its `ActiveWorkspaceMarker` is added.
+        let origin = arriving_focus
+            .and_then(|focus_entity| {
+                let (display, dock) = displays.get(child.parent()).ok()?;
+                origin_exposing(
+                    focus_entity,
+                    *origin,
+                    display.actual_display_bounds(dock, &config),
+                    &windows,
+                )
+            })
+            .unwrap_or(*origin);
 
         if config.virtual_workspace_animations() {
             if !keeps_focus
@@ -1191,12 +1237,20 @@ pub(crate) fn show_active_workspace(
                 commands.focus_entity(focus, false);
             }
 
-            commands.reposition_entity(*activated, *origin);
+            commands.reposition_entity(*activated, origin);
         } else {
-            position.0 = *origin;
+            position.0 = origin;
         }
 
         if keeps_focus {
+            // The layout of a strip that has just been unparked can still
+            // settle over the next frames (widths recomputed, windows the
+            // workspace picked up while it was hidden). Re-check the arriving
+            // window then: `ensure_visible_in_strip` only scrolls if the slot
+            // it ends up in really falls off an edge.
+            if let Some(focus_entity) = arriving_focus {
+                commands.ensure_visible(focus_entity);
+            }
             return;
         }
 

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -2543,3 +2543,88 @@ fn test_center_dropped_on_user_swipe() {
         })
         .run(commands);
 }
+
+/// Cmd-Tab into an app parked on another virtual workspace must land focus on
+/// that app's window. Regression: with `virtual_workspace_animations = true`,
+/// the animated branch of `show_active_workspace` restored the strip's
+/// remembered focus unconditionally, so activating the strip through a focus
+/// event immediately yanked focus onto whatever was focused there last.
+#[test]
+fn test_focus_into_hidden_virtual_workspace_keeps_target_window() {
+    let config: Config = (
+        MainOptions {
+            animation_speed: Some(30.0),
+            virtual_workspace_animations: Some(true),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    let commands = vec![
+        // 0: boot.
+        Event::MenuOpened { window_id: 0 },
+        // 1: window 2 takes focus.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 2: park it on VW1.
+        Event::Command {
+            command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        },
+        // 3: window 3 takes focus.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 4: park it on VW1 too, leaving VW1 = [2, 3].
+        Event::Command {
+            command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        },
+        // 5: visit VW1.
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        // 6: focus window 3 there, so that is what VW1 remembers.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 7: back to VW0, parking VW1.
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(0)),
+        },
+        // 8: the Cmd-Tab into window 2 queued below plays out here.
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ];
+
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(4)
+        .on_iteration(0, |_world, state| {
+            state.focus_window(2);
+        })
+        .on_iteration(1, |world, _state| {
+            assert_focused!(world, 2);
+        })
+        .on_iteration(2, |_world, state| {
+            state.focus_window(3);
+        })
+        .on_iteration(3, |world, _state| {
+            assert_focused!(world, 3);
+        })
+        .on_iteration(5, |_world, state| {
+            state.focus_window(3);
+        })
+        .on_iteration(6, |world, _state| {
+            assert_focused!(world, 3);
+        })
+        .on_iteration(7, |_world, state| {
+            // Cmd-Tab straight into window 2, the other window on VW1.
+            state.focus_window(2);
+        })
+        .on_iteration(8, |world, _state| {
+            assert_focused!(world, 2);
+        })
+        .run(commands);
+}

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -2628,3 +2628,95 @@ fn test_focus_into_hidden_virtual_workspace_keeps_target_window() {
         })
         .run(commands);
 }
+
+/// Cmd-Tab into a window left hanging off the edge of a hidden virtual
+/// workspace must scroll that workspace's strip far enough to show all of it.
+/// Regression: `show_active_workspace` restored the strip to the offset it had
+/// when it was parked, which says nothing about the window that just took
+/// focus, and `window_hidden_ratio` lets the reshuffle leave a window that far
+/// over an edge alone - so nothing brought it back.
+#[test]
+fn test_focus_into_hidden_virtual_workspace_exposes_target_window() {
+    /// How far window 2 hangs off the left edge while VW1 is parked: a
+    /// quarter of it, which `window_hidden_ratio` below tolerates.
+    const OVERHANG: i32 = TEST_WINDOW_WIDTH / 4;
+
+    let config: Config = (
+        MainOptions {
+            animation_speed: Some(10000.0),
+            virtual_workspace_animations: Some(true),
+            auto_center: Some(false),
+            // A reshuffle may leave a window up to half hidden where it is,
+            // so exposing this one is down to the workspace restore itself.
+            window_hidden_ratio: Some(0.5),
+            ..Default::default()
+        },
+        vec![],
+    )
+        .into();
+
+    // Park windows 2 to 5 on VW1: four 400px columns on a 1024px display, so
+    // the strip is wider than the screen and has somewhere to scroll to.
+    let mut commands = vec![Event::MenuOpened { window_id: 0 }];
+    for _ in 0..4 {
+        commands.push(Event::Command {
+            command: Command::PrintState,
+        });
+        commands.push(Event::Command {
+            command: Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Stay)),
+        });
+    }
+    commands.extend([
+        // 9: visit VW1.
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(1)),
+        },
+        // 10: the strip is dragged left below, leaving window 2 hanging off.
+        Event::Command {
+            command: Command::PrintState,
+        },
+        // 11: park VW1 at that offset.
+        Event::Command {
+            command: Command::Window(Operation::VirtualNumber(0)),
+        },
+        // 12: the Cmd-Tab into window 2 queued below plays out here.
+        Event::Command {
+            command: Command::PrintState,
+        },
+    ]);
+
+    let focus_next = |id: WinID| move |_world: &mut World, state: MockState| state.focus_window(id);
+    TestHarness::new()
+        .with_config(config)
+        .with_windows(6)
+        .on_iteration(0, focus_next(2))
+        .on_iteration(2, focus_next(3))
+        .on_iteration(4, focus_next(4))
+        .on_iteration(6, focus_next(5))
+        .on_iteration(8, focus_next(5))
+        .on_iteration(9, move |world, _state| {
+            // Slide VW1 so window 2 hangs off the left edge by a quarter.
+            let strip_entity = active_strip_entity(world);
+            world
+                .entity_mut(strip_entity)
+                .insert(Position(Origin::new(-OVERHANG, TEST_MENUBAR_HEIGHT)));
+        })
+        .on_iteration(10, move |world, _state| {
+            assert_eq!(
+                window_x(world, 2),
+                -OVERHANG,
+                "test setup: window 2 must hang off the left edge before parking"
+            );
+        })
+        // Cmd-Tab straight into window 2, now that VW1 is parked.
+        .on_iteration(11, focus_next(2))
+        .on_iteration(12, |world, _state| {
+            assert_focused!(world, 2);
+            assert_eq!(
+                window_x(world, 2),
+                0,
+                "the workspace restore must show all of the window it was activated for"
+            );
+        })
+        .run(commands);
+}

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -159,6 +159,18 @@ impl MockState {
         self.create_window(id)
     }
 
+    /// Moves the app's focused window without emitting the notifications a
+    /// real focus change would produce.
+    pub fn set_focused_window(&self, id: WinID) {
+        let mut inner = self.inner.force_write();
+        let Some(pid) = inner.windows.get(&id).map(|window| window.pid) else {
+            return;
+        };
+        if let Some(app) = inner.apps.get_mut(&pid) {
+            app.focused_window_id = Some(id);
+        }
+    }
+
     pub fn focus_window(&self, id: WinID) {
         let mut inner = self.inner.force_write();
         if let Some(win) = inner.windows.get(&id) {
@@ -541,7 +553,19 @@ impl MockState {
         // Fill in remaining defaults
         mw.expect_element().return_const(None);
         mw.expect_raise_without_focus().return_const(());
-        mw.expect_focus_without_raise().return_const(());
+
+        // Focusing without raising still moves the OS focus, it just leaves the
+        // window order alone. Only the app's idea of its focused window changes
+        // here: the notification that follows in the real thing is what
+        // `focus_window` models, and callers of this already act on their own
+        // request. Dropping even this much left the app reporting the previous
+        // window, which made `window_focused_trigger` discard events for the
+        // window that had actually been focused.
+        let s = self.clone();
+        mw.expect_focus_without_raise()
+            .returning(move |_psn, _focused, _focused_psn| {
+                s.set_focused_window(id);
+            });
         mw.expect_set_padding().return_const(());
 
         Window::new(Box::new(mw))


### PR DESCRIPTION
Cmd-Tab to an app whose window sits on a hidden virtual workspace switches to that workspace, but the window you picked does not end up focused and visible.

**Focus.** The activation is caused by the focus event itself, so the window already holds `FocusedMarker` by the time `show_active_workspace` runs. Its animated branch then restored the strip's remembered focus unconditionally — the non-animated branch was guarded, the animated one was not — so focus jumped to whatever was focused on that workspace last. The guard now covers both.

**Visibility.** The strip was restored to the offset it had when it was parked, which says nothing about the window that just took focus: it could land almost entirely off-screen. The later reshuffle derives the offset from the window's own frame, which mid-restore is still parked, so the window often settled only partly visible. The restore now aims at an offset that shows the whole window, and marks it for a re-check on the next frame in case the layout is still settling. `ensure_visible_in_strip` projects against the strip's target offset rather than its current position, so that re-check is not read off a strip still in motion.

Only a focus that arrives with the activation moves the strip — a window that held focus all along (switching back from an empty workspace, say) keeps the offset it was left at.

Tests: two harness tests covering both halves, plus a unit test for the new `origin_exposing` helper.

Written with Claude Code.
