### PR TITLE
fix: keep virtual workspace row 0 instead of renumbering a space from "2"

### DIFF
--- a/src/ecs/restore.rs
+++ b/src/ecs/restore.rs
@@ -465,7 +465,11 @@ pub(super) fn restore_window_state(
             strip.remove(*entity);
         }
 
-        if had_consumed_window && strip.all_windows().is_empty() {
+        // Row 0 is the row every space is created with. Emptying it is normal
+        // (its windows move onto the restored rows), but despawning it leaves
+        // the space numbered from "2" with no row that any later switch or
+        // reap path recreates, so it is kept and reused instead.
+        if had_consumed_window && strip.all_windows().is_empty() && strip.virtual_index > 0 {
             emptied_existing_strips.insert(entity);
         }
     }

--- a/src/ecs/workspace.rs
+++ b/src/ecs/workspace.rs
@@ -484,7 +484,10 @@ fn find_orphaned_workspaces(
     let present = window_manager.present_displays();
 
     for (orphan, orphan_entity, timeout, child) in orphans {
-        if orphan.len() == 0 {
+        // Row 0 is the row every space is created with, so it is re-parented
+        // like a populated strip: despawning it leaves the space numbered from
+        // "2" with no row that any switch or reap path recreates.
+        if orphan.len() == 0 && orphan.virtual_index > 0 {
             if let Ok(mut cmd) = commands.get_entity(orphan_entity) {
                 cmd.try_despawn();
             }
@@ -939,9 +942,6 @@ fn switch_virtual_workspace_bind(
                 .iter()
                 .position(|(_, strip, _)| strip.virtual_index == *target_virtual_index)
             else {
-                if *target_virtual_index == 0 {
-                    return;
-                }
                 commands.spawn_layout_strip(
                     LayoutStrip::new(workspace_id, *target_virtual_index),
                     active_display.bounds().min,
@@ -1003,7 +1003,7 @@ fn switch_virtual_workspace_bind(
 /// Handles the keybinding to move windows between virtual workspaces.
 /// Missing destinations are created by `handle_virtual_window_moves`. South at
 /// the last row only proceeds when `create_workspace_automatically` is on;
-/// numbered targets always may create (except index 0).
+/// numbered targets always may create, row 0 included.
 #[instrument(level = Level::DEBUG, skip_all)]
 fn move_virtual_workspace_bind(
     mut messages: MessageReader<Event>,
@@ -1067,11 +1067,6 @@ fn move_virtual_workspace_bind(
         }
         Operation::VirtualMoveNumber(target_virtual_index, move_focus) => {
             if *target_virtual_index == current_virtual_index {
-                return;
-            }
-            if *target_virtual_index == 0
-                && !rows.iter().any(|(_, strip, _)| strip.virtual_index == 0)
-            {
                 return;
             }
             (*target_virtual_index, *move_focus)

--- a/src/tests/display.rs
+++ b/src/tests/display.rs
@@ -686,3 +686,58 @@ fn test_center_survives_display_round_trip() {
         })
         .run(commands);
 }
+
+/// An empty row 0 must survive its display going away. Despawning it left the
+/// space renumbered from "2" — the menu bar lists only the rows that exist —
+/// with no switch or reap path that recreates row 0.
+#[test]
+fn test_empty_baseline_row_survives_display_removal() {
+    let commands = vec![
+        Event::Command {
+            command: Command::PrintState,
+        },
+        Event::DisplayRemoved {
+            display_id: TEST_DISPLAY_ID,
+        },
+        Event::DisplayAdded {
+            display_id: TEST_DISPLAY_ID,
+        },
+    ];
+
+    TestHarness::new()
+        .on_iteration(0, |world, state| {
+            let strips = world
+                .query::<&LayoutStrip>()
+                .iter(world)
+                .map(|strip| strip.virtual_index)
+                .collect::<Vec<_>>();
+            assert_eq!(strips, vec![0], "the space starts with an empty row 0");
+            state.remove_display(TEST_DISPLAY_ID);
+        })
+        .on_iteration(1, |world, mut state| {
+            let entity = world
+                .query_filtered::<Entity, With<LayoutStrip>>()
+                .single(world)
+                .expect("empty row 0 should be orphaned, not despawned");
+            assert!(
+                world.entity(entity).get::<Timeout>().is_some(),
+                "orphaned row 0 should carry a timeout"
+            );
+            state.add_display(
+                TEST_DISPLAY_ID,
+                IRect::new(0, 0, TEST_DISPLAY_WIDTH, TEST_DISPLAY_HEIGHT),
+                vec![TEST_WORKSPACE_ID],
+            );
+        })
+        .on_iteration(2, |world, _state| {
+            let entity = world
+                .query_filtered::<Entity, With<LayoutStrip>>()
+                .single(world)
+                .expect("row 0 should still exist after the display returns");
+            assert!(
+                world.entity(entity).get::<ChildOf>().is_some(),
+                "row 0 should be re-parented to the returning display"
+            );
+        })
+        .run(commands);
+}

--- a/src/tests/interaction.rs
+++ b/src/tests/interaction.rs
@@ -2821,3 +2821,120 @@ fn test_copy_window_rule_command() {
         })
         .run(commands);
 }
+
+/// `virtualnum` on a missing row spawns it — row 0 included. Row 0 used to be
+/// the one index that bailed out instead, so a space that had lost its row 0
+/// could never switch back to workspace "1".
+#[test]
+fn test_virtual_number_recreates_missing_baseline_row() {
+    let mut h = TestHarness::new().with_windows(2);
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        for _ in 0..8 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    // Move both windows onto row 1 and switch there, then drop row 0 the way a
+    // display change does, leaving the space numbered from "2".
+    for _ in 0..2 {
+        pump(
+            &mut h,
+            Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+        );
+    }
+    let world = h.world();
+    let row_zero = world
+        .query::<(Entity, &LayoutStrip)>()
+        .iter(world)
+        .find(|(_, strip)| strip.virtual_index == 0)
+        .map(|(entity, _)| entity)
+        .expect("row 0 should still exist before it is dropped");
+    world.entity_mut(row_zero).despawn();
+
+    let world = h.world();
+    let indexes = world
+        .query::<&LayoutStrip>()
+        .iter(world)
+        .map(|strip| strip.virtual_index)
+        .collect::<Vec<_>>();
+    assert_eq!(indexes, vec![1], "only row 1 should be left");
+
+    pump(&mut h, Command::Window(Operation::VirtualNumber(0)));
+
+    let world = h.world();
+    let recreated = world
+        .query::<(&LayoutStrip, Has<ActiveWorkspaceMarker>)>()
+        .iter(world)
+        .filter(|(strip, _)| strip.virtual_index == 0)
+        .map(|(_, active)| active)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recreated,
+        vec![true],
+        "virtualnum 0 should recreate row 0 and make it active"
+    );
+}
+
+/// Moving a window to a missing row spawns it — row 0 included. Row 0 used to
+/// be refused here too, so a space that had lost its row 0 could not even send
+/// a window back to workspace "1".
+#[test]
+fn test_virtual_move_number_recreates_missing_baseline_row() {
+    let mut h = TestHarness::new().with_windows(2);
+    let pump = |h: &mut TestHarness, c: Command| {
+        h.app
+            .world_mut()
+            .write_message::<Event>(Event::Command { command: c });
+        for _ in 0..8 {
+            h.app.update();
+            for e in h.mock_state.drain_events() {
+                h.app.world_mut().write_message::<Event>(e);
+            }
+        }
+    };
+
+    // Park both windows on row 1 and drop the emptied row 0 the way a display
+    // change does, leaving the space numbered from "2".
+    for _ in 0..2 {
+        pump(
+            &mut h,
+            Command::Window(Operation::VirtualMoveNumber(1, MoveFocus::Follow)),
+        );
+    }
+    let world = h.world();
+    let row_zero = world
+        .query::<(Entity, &LayoutStrip)>()
+        .iter(world)
+        .find(|(_, strip)| strip.virtual_index == 0)
+        .map(|(entity, _)| entity)
+        .expect("row 0 should still exist before it is dropped");
+    world.entity_mut(row_zero).despawn();
+
+    pump(
+        &mut h,
+        Command::Window(Operation::VirtualMoveNumber(0, MoveFocus::Follow)),
+    );
+
+    let world = h.world();
+    let focused = world
+        .query_filtered::<Entity, With<FocusedMarker>>()
+        .single(world)
+        .expect("the followed window should be focused");
+    let recreated = world
+        .query::<&LayoutStrip>()
+        .iter(world)
+        .filter(|strip| strip.virtual_index == 0)
+        .map(|strip| strip.contains(focused))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recreated,
+        vec![true],
+        "the moved window should land on a single recreated row 0"
+    );
+}

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -654,6 +654,51 @@ fn test_startup_restore_keeps_one_selected_row_and_hides_inactive_rows() {
     );
 }
 
+/// Restore consumes row 0's windows onto the saved rows, which empties row 0.
+/// Despawning it there left the restored space numbered from "2", so the
+/// emptied baseline row is kept.
+#[test]
+fn test_startup_restore_keeps_emptied_baseline_row() {
+    let mut harness = TestHarness::new().with_windows(2);
+    harness.world().insert_resource(PaneruState {
+        version: 2,
+        timestamp: 123_456_789,
+        active_display_id: Some(TEST_DISPLAY_ID),
+        displays: vec![saved_display(TEST_DISPLAY_ID, true)],
+        workspaces: vec![SavedWorkspace {
+            workspace_id: TEST_WORKSPACE_ID,
+            display_id: Some(TEST_DISPLAY_ID),
+            active_virtual_index: Some(1),
+            strips: vec![SavedStrip {
+                virtual_index: 1,
+                columns: vec![
+                    SavedColumn::Single(saved_window(0)),
+                    SavedColumn::Single(saved_window(1)),
+                ],
+            }],
+        }],
+    });
+
+    for _ in 0..5 {
+        harness.app.update();
+    }
+
+    let world = harness.world();
+    let mut query = world.query::<(&LayoutStrip, Has<crate::ecs::ActiveWorkspaceMarker>)>();
+    let mut rows = query
+        .iter(world)
+        .filter(|(strip, _)| strip.id() == TEST_WORKSPACE_ID)
+        .map(|(strip, active)| (strip.virtual_index, strip.all_windows().len(), active))
+        .collect::<Vec<_>>();
+    rows.sort_unstable();
+
+    assert_eq!(
+        rows,
+        vec![(0, 0, false), (1, 2, true)],
+        "restore should keep the emptied row 0 alongside the restored row 1"
+    );
+}
+
 fn saved_display(display_id: u32, active: bool) -> SavedDisplay {
     SavedDisplay {
         display_id,


### PR DESCRIPTION
## The bug

A native space can end up holding virtual rows 1 and 2 with no row 0. Its
menu bar indicator then reads `2 3`, and nothing can get back to workspace
"1" — `virtualnum 1`, `virtualmovenum 1` and `virtualsendnum 1` are all
no-ops, and northward navigation walks the rows that exist, so it stops at
row 1.

Live example from a v0.5.0 daemon, on the space whose indicator read `2 3`:

```
$ paneru query state --json
vw {'native_workspace_id': 1, 'number': 1} nwin 0   <- padding, no strip behind it
vw {'native_workspace_id': 1, 'number': 2} nwin 3
vw {'native_workspace_id': 1, 'number': 3} nwin 1
```

## Where it came from

Two paths despawn an empty row 0:

- `find_orphaned_workspaces` despawns any empty orphaned strip when a display
  goes away — `09f5394` ("fix: Reparent workspaces both on add and move of a
  display", v0.3.7). `789e158` later moved the code into `ecs/workspace.rs`.
- `restore_window_state` despawns an existing strip whose windows were
  consumed onto the restored rows, which is exactly what happens to row 0 when
  the saved state keeps its windows on other rows — #223 ("feat: Restore window
  sessions on startup", v0.4.3).

Nothing renumbers the remainder: `renumber_virtual_indexes` only resolves
*duplicate* indexes among newly added strips, and
`reap_empty_virtual_workspaces` already refuses to reap row 0. So the hole is
permanent once it appears.

What makes it unrecoverable instead of self-healing came in #204 ("feat(api):
add JSON state and absolute workspaces", v0.4.2): the numbered switch and move
binds both special-case index 0 and `return` instead of spawning the missing
strip, making it the one index that does not auto-create. The same PR added the
`1..=max` padding in the query document, which hides the symptom — a bar built
on `paneru query` renders a slot for workspace 1 that no command can select,
while the menu bar lists only the rows that exist.

## The fix

Treat row 0 as the invariant it already is (`workspace_created_handler` creates
every space with it):

- `find_orphaned_workspaces`: re-parent an empty row 0 like a populated strip
  rather than despawning it.
- `restore_window_state`: keep and reuse row 0 when restore empties it.
- `switch_virtual_workspace_bind` / `move_virtual_workspace_bind`: drop the
  index-0 bail so a numbered target spawns row 0 like any other index.
  `Direction::First` already targeted index 0 unconditionally and let
  `handle_virtual_window_moves` spawn the destination, so no new machinery was
  needed.

Deliberately unchanged: the query document still pads missing numbers, since
middle-row gaps remain legitimate (reaping an empty row 1 of 0/1/2 leaves one)
and integrations rely on stable numbered slots.

## Tests

Four regression tests, one per path (312 pass, `cargo clippy --all-targets`
clean):

- `test_empty_baseline_row_survives_display_removal` — empty row 0 is orphaned
  and re-parented across a display removal/return instead of despawned.
- `test_startup_restore_keeps_emptied_baseline_row` — restore leaves row 0 in
  place next to the restored row 1.
- `test_virtual_number_recreates_missing_baseline_row` — `virtualnum 0`
  recreates row 0 and makes it active.
- `test_virtual_move_number_recreates_missing_baseline_row` — a numbered move
  lands the followed window on a recreated row 0.

`test_multi_workspace_orphaning` also becomes meaningful: its assertions used
to iterate an empty set, because both empty strips had been despawned.

Assisted by Claude Code.
